### PR TITLE
feat(radio-group): make radio group value prop nullable

### DIFF
--- a/packages/radio-group/src/Component.tsx
+++ b/packages/radio-group/src/Component.tsx
@@ -81,7 +81,7 @@ export type RadioGroupProps = {
     /**
      * Value выбранного дочернего элемента
      */
-    value?: string;
+    value?: string | null;
 };
 
 export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
@@ -106,7 +106,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
 
         const renderRadio = (child: ReactElement) => {
             const { className: childClassName } = child.props;
-            const checked = (value || stateValue) === child.props.value;
+            const checked = value !== null && (value || stateValue) === child.props.value;
             const handleChange = (event: ChangeEvent) => {
                 setStateValue(child.props.value);
                 if (onChange) {
@@ -125,7 +125,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
         };
 
         const renderTag = (child: ReactElement) => {
-            const checked = (value || stateValue) === child.props.value;
+            const checked = value !== null && (value || stateValue) === child.props.value;
             const handleChange = (event: ChangeEvent | MouseEvent) => {
                 setStateValue(child.props.value);
                 if (onChange) {

--- a/packages/radio-group/src/docs/Component.stories.mdx
+++ b/packages/radio-group/src/docs/Component.stories.mdx
@@ -4,6 +4,7 @@ import { ComponentHeader, Tabs, CssVars } from 'storybook/blocks';
 
 import { Radio } from '@alfalab/core-components-radio';
 import { Tag } from '@alfalab/core-components-tag';
+import { Button } from '@alfalab/core-components-button';
 
 import { RadioGroup } from '../Component';
 import { name, version } from '../../package.json';

--- a/packages/radio-group/src/docs/description.mdx
+++ b/packages/radio-group/src/docs/description.mdx
@@ -28,25 +28,40 @@ render(() => {
 
 ```tsx live
 render(() => {
-    const [value, setValue] = React.useState('one');
+    const [value, setValue] = React.useState<string | null>('one');
 
     const onChange = (_, payload) => {
         setValue(payload.value);
     };
 
+    const onReset = () => {
+        setValue(null);
+    }
+
     return (
-        <RadioGroup
-            label='Заголовок группы'
-            onChange={onChange}
-            direction='horizontal'
-            type='tag'
-            name='tagRadioGroup'
-            value={value}
-        >
-            <Tag value='one'>Первый вариант</Tag>
-            <Tag value='two'>Второй вариант</Tag>
-            <Tag value='three'>Третий вариант</Tag>
-        </RadioGroup>
+        <React.Fragment>
+            <RadioGroup
+                label='Заголовок группы'
+                onChange={onChange}
+                direction='horizontal'
+                type='tag'
+                name='tagRadioGroup'
+                value={value}
+            >
+                <Tag value='one'>Первый вариант</Tag>
+                <Tag value='two'>Второй вариант</Tag>
+                <Tag value='three'>Третий вариант</Tag>
+            </RadioGroup>
+            <br />
+            <Button
+                onClick={ onReset }
+                size="s"
+                view="tertiary"
+                disabled={ value === null }
+            >
+                Сбросить выбор
+            </Button>
+        </React.Fragment>
     );
 });
 ```


### PR DESCRIPTION
# Опишите проблему
Нет возможности сбросить выделение дочернего контрола RadioGroup. Данный ПР позволит прокидывать null как value, чтобы компонент RadioGroup сверял value prop c null и checked флаг принимал нужное значение.

# Чек лист
- [x] Изменения в RadioGroup
- [x] Изменения в доках Storybook

Проверил свои изменения локально на последнем Safari.