### PR TITLE
feat(drawer): add footer node

### DIFF
--- a/packages/drawer/src/Component.tsx
+++ b/packages/drawer/src/Component.tsx
@@ -14,12 +14,16 @@ export type DrawerProps = Omit<BaseModalProps, 'container'> & {
      * Пропсы для анимации контента (CSSTransition)
      */
     contentTransitionProps?: Partial<TransitionProps>;
+    /**
+     * Можно прокинуть компонент, например для монтирования toast
+     */
+    footer?: React.ReactNode;
 };
 
 export const DrawerContext = BaseModalContext;
 
 export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
-    ({ open, className, children, contentTransitionProps, ...restProps }, ref) => {
+    ({ footer, open, className, children, contentTransitionProps, ...restProps }, ref) => {
         const transitionProps = useMemo(
             () => ({
                 classNames: {
@@ -82,7 +86,10 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
                 backdropProps={backdropProps}
             >
                 <CSSTransition appear={true} {...contentProps} in={open}>
-                    <div className={styles.content}>{children}</div>
+                    <React.Fragment>
+                        <div className={styles.content}>{children}</div>
+                        {footer}
+                    </React.Fragment>
                 </CSSTransition>
             </BaseModal>
         );


### PR DESCRIPTION
# Опишите проблему
Надо реализовать дизайн
<img width="370" alt="изображение" src="https://user-images.githubusercontent.com/30253042/167255766-780f46d1-22a3-40f7-bf45-64d27aeec572.png">

пробовал реализовать в контенте самого drawer показ тоаста, но там что-то у меня не получилось, так как идет загрузка с лоадером и потом вставка элементов и элемент улетает вниз, в который будет монтироваться нотификация, и только после ручной прокрутки он показывается, попробовал в данном варианте - заработало

с доработкой

https://user-images.githubusercontent.com/30253042/167256008-0e5e4583-6a49-4d12-9a09-7040487749ea.mov

было до этого

https://user-images.githubusercontent.com/30253042/167256026-8bafa8c6-e2ca-405d-bf40-dac65b91a506.mov



