### PR TITLE
chore: add missing type children

### DIFF
--- a/packages/calendar/src/components/header/Component.tsx
+++ b/packages/calendar/src/components/header/Component.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import cn from 'classnames';
 import { SelectorView } from '../../typings';
 
@@ -14,6 +14,11 @@ export type HeaderProps = {
      * Отображать тень? (нужна при прокрутке)
      */
     withShadow?: boolean;
+
+    /**
+     * Контент
+     */
+    children?: ReactNode;
 };
 
 export const Header: FC<HeaderProps> = ({ view = 'full', withShadow, children }) => {

--- a/packages/circular-progress-bar/src/Component.tsx
+++ b/packages/circular-progress-bar/src/Component.tsx
@@ -42,6 +42,11 @@ export type CircularProgressBarProps = {
     size?: 'l' | 'm' | 's';
 
     /**
+     * Контент
+     */
+    children?: ReactNode;
+
+    /**
      * Id компонента для тестов
      */
     dataTestId?: string;

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -21,7 +21,6 @@ export const Confirmation: FC<ConfirmationProps> = ({
     state,
     screen,
     alignContent = 'left',
-    children,
     requiredCharAmount = 5,
     countdownDuration = ONE_MINUTE,
     tempBlockDuration = ONE_DAY,

--- a/packages/dropzone/src/Component.tsx
+++ b/packages/dropzone/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, FC, useCallback, useRef, useState } from 'react';
+import React, { ComponentType, FC, ReactNode, useCallback, useRef, useState } from 'react';
 import cn from 'classnames';
 import { preventAndStopEvent } from './utils';
 import { Overlay as DefaultOverlay, OverlayProps } from './components';
@@ -36,6 +36,11 @@ export type DropzoneProps = {
      * Позволяет вручную управлять видимостью заглушки
      */
     overlayVisible?: boolean;
+
+    /**
+     * Контент
+     */
+    children?: ReactNode;
 
     /**
      * Компонент оверлея

--- a/packages/gallery/src/components/image-viewer/slide.tsx
+++ b/packages/gallery/src/components/image-viewer/slide.tsx
@@ -1,4 +1,4 @@
-import React, { FC, SyntheticEvent } from 'react';
+import React, { FC, ReactNode, SyntheticEvent } from 'react';
 import cn from 'classnames';
 
 import { Typography } from '@alfalab/core-components-typography';
@@ -70,6 +70,7 @@ type SlideInnerProps = {
     broken: boolean;
     withPlaceholder: boolean;
     loading: boolean;
+    children: ReactNode;
 };
 
 const SlideInner: FC<SlideInnerProps> = ({ children, broken, loading, withPlaceholder }) => {

--- a/packages/list/src/Component.tsx
+++ b/packages/list/src/Component.tsx
@@ -22,6 +22,11 @@ export type ListProps = {
     className?: string;
 
     /**
+     * Контент
+     */
+    children?: React.ReactNode;
+
+    /**
      * Id компонента для тестов
      */
     dataTestId?: string;

--- a/packages/mq/src/Component.tsx
+++ b/packages/mq/src/Component.tsx
@@ -7,6 +7,11 @@ const SUPPORTS_TOUCH = IS_BROWSER && (isPointerEventsSupported() || isTouchSuppo
 
 export type MqProps = {
     /**
+     * Контент
+     */
+    children?: React.ReactNode;
+
+    /**
      * Media выражение или кастомный запрос из `mq.json`, например `--mobile`.
      */
     query?: string;

--- a/packages/skeleton/src/Component.tsx
+++ b/packages/skeleton/src/Component.tsx
@@ -17,6 +17,10 @@ export type SkeletonProps = {
      */
     className?: string;
     /**
+     * Контент
+     */
+    children?: React.ReactNode;
+    /**
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;

--- a/packages/status/src/Component.tsx
+++ b/packages/status/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import cn from 'classnames';
 
 import styles from './index.module.css';
@@ -20,6 +20,11 @@ export type StatusProps = {
      * Цветовое оформление иконки
      */
     color?: typeof colors[number];
+
+    /**
+     * Контент
+     */
+    children?: ReactNode;
 
     /**
      * Идентификатор для систем автоматизированного тестирования


### PR DESCRIPTION
Явно указываю `children` в типах, т.к. с 18-й версии реакта [он отутствует](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46691) в `FC`.

#40 