### PR TITLE
feat(vars): export CSS custom properties as JS vars

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -23,11 +23,13 @@ lerna exec \
 # собираю пакет themes
 lerna exec --scope @alfalab/core-components-themes -- node $(pwd)/bin/build-themes.js
 
+# экспорт CSS-переменных в JS-переменные
+lerna exec --scope @alfalab/core-components-vars -- node $(pwd)/bin/export-css-custom-properties-as-js-vars.js
+
 # собираю все подпакеты с компонентами
 lerna exec --concurrency $CONCURRENCY \
     --ignore @alfalab/core-components-codemod \
     -- $(pwd)/bin/rollup.sh
-
 
 # копирую собранные css пакеты в корневой пакет
 copy_to_root="cp -rp dist/ ../../dist/\${PWD##*/}"

--- a/bin/export-css-custom-properties-as-js-vars.js
+++ b/bin/export-css-custom-properties-as-js-vars.js
@@ -1,0 +1,31 @@
+const exportCustomVariables = require('postcss-export-custom-variables');
+const path = require('path');
+const postcssImport = require('postcss-import');
+const postcss = require('postcss');
+const fs = require('fs');
+const shell = require('shelljs');
+
+const distPath = '../dist/vars/';
+const jsPath = path.resolve(__dirname, distPath, 'index.js');
+const cssPath = path.resolve(__dirname, '../packages/vars/src/index.css');
+const css = fs.readFileSync(cssPath, 'utf-8');
+
+fs.mkdirSync(path.resolve(__dirname, distPath), { recursive: true });
+
+postcss()
+    .use(postcssImport({}))
+    .use(
+        exportCustomVariables({
+            exporter: 'js',
+            destination: jsPath,
+        }),
+    )
+    .process(css, { from: cssPath, to: jsPath })
+    .then(() => {
+        shell.exec(`tsc --typeRoots [] --declaration --emitDeclarationOnly --allowJs ${jsPath}`);
+        process.exit(0);
+    })
+    .catch(reason => {
+        console.log(reason);
+        process.exit(1);
+    });

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
         "postcss-custom-media": "^7.0.8",
         "postcss-custom-properties": "^10.0.0",
         "postcss-each": "^0.10.0",
+        "postcss-export-custom-variables": "^1.0.0",
         "postcss-for": "^2.1.1",
         "postcss-import": "^12.0.1",
         "postcss-mixins": "^6.2.3",

--- a/packages/vars/src/Component.stories.mdx
+++ b/packages/vars/src/Component.stories.mdx
@@ -31,6 +31,10 @@ import shadowsIndigo from '!!raw-loader!./shadows-indigo.css';
 ```css
 @import '@alfalab/core-components/vars';
 ```
+Для удобства использования все CSS-переменные экспортируются в виде JS-переменных:
+```typescript
+import * as vars from '@alfalab/core-components/vars';
+```
 
 ## Отступы
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18392,6 +18392,13 @@ postcss-env-function@^2.0.2:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
+postcss-export-custom-variables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-export-custom-variables/-/postcss-export-custom-variables-1.0.0.tgz#8cee371f2b21769ed7f1a01cf89cfebd23d7a131"
+  integrity sha1-jO43Hyshdp7X8aAc+Jz+vSPXoTE=
+  dependencies:
+    postcss "^6.0.1"
+
 postcss-flexbugs-fixes@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz"


### PR DESCRIPTION
Есть необходимость получать доступ к CSS-переменным из JS. Теоретически из JS можно достучаться до кастомных CSS-свойств, но во время сборки переменные заменяются на конечные значения.

Возникла идея сгенерировать файл `index.js`, который будет экспортировать аналоги CSS-переменных из `@alfalab/core-components/vars/index.css`.

Добавлен скрипт `bin/export-css-custom-properties-as-js-vars.js`, который запускается во время сборки и сохраняет файл с JS-переменными в `dist/vars/index.js`.

Не уверен, что все сделано корректно с точки зрения текущей архитектуры сборки. В итоговой директории `dist/vars` создаются поддиректории `modern`, `cssm`, `esm`, которые содержат все то же самое, что и корневая директория (`dist/vars`). Файл с JS-переменными кладется только в `dist/vars`. Вообще насколько необходимы разные сборки (`modern`, `cssm`, `esm`) для пакета `vars`?
