### PR TITLE
refactor(file-upload-item): change file size positioning

### DIFF
--- a/packages/file-upload-item/src/index.module.css
+++ b/packages/file-upload-item/src/index.module.css
@@ -61,10 +61,10 @@
 
 .meta {
     display: flex;
-    align-items: center;
     white-space: nowrap;
     margin-right: var(--gap-2xs);
     margin-left: var(--gap-xl);
+    padding: var(--gap-2xs) 0;
 
     & > * {
         margin-right: var(--gap-s);


### PR DESCRIPTION
В [реквесте](https://github.com/core-ds/core-components/pull/30/) были изменены условия отображения текста ошибки / предупреждения для успешного статуса загрузки файла. В связи с этим пришлось поправить позиционирование размера файла (уезжало вниз к дополнительному тексту).

Было: 
![image](https://user-images.githubusercontent.com/36763742/170496426-2c8fd73d-4067-4a3e-9379-87572b7f9406.png)

Стало: 
![image](https://user-images.githubusercontent.com/36763742/170496461-72e5a065-7607-4cfd-b517-f4765de01626.png)
