### PR TITLE
fix(codemod): fix shade | alpha modificators bug

### DIFF
--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alfalab/core-components-codemod",
-    "version": "2.1.0",
+    "version": "2.1.2",
     "description": "Codemod tools for code transforms",
     "keywords": [],
     "license": "MIT",

--- a/packages/codemod/src/replace-color-vars/__test__/transform.spec.ts
+++ b/packages/codemod/src/replace-color-vars/__test__/transform.spec.ts
@@ -15,6 +15,9 @@ const inputCss = `
 
 .a {
   color: var(--color-light-border-secondary-inverted);
+  color: var(--color-light-border-secondary-inverted-tint-10);
+  color: var(--color-light-border-secondary-inverted-shade-20);
+  color: var(--color-light-border-secondary-inverted-alpha-30);
   background-color: var(--color-light-border-tertiary-inverted);
   border: 1px solid var(--color-light-graphic-neutral);
   background: var(--color-light-bg-neutral);
@@ -39,6 +42,9 @@ const expectedCss = `
 
 .a {
   color: var(--color-light-border-underline);
+  color: var(--color-light-border-underline-tint-10);
+  color: var(--color-light-border-underline-shade-20);
+  color: var(--color-light-border-underline-alpha-30);
   background-color: var(--color-light-border-underline-inverted);
   border: 1px solid var(--color-light-graphic-quaternary);
   background: var(--color-light-bg-quaternary);

--- a/packages/codemod/src/replace-color-vars/transform.ts
+++ b/packages/codemod/src/replace-color-vars/transform.ts
@@ -25,7 +25,7 @@ const plugin = (): Plugin => {
             if (decl.value.includes('--color-')) {
                 const fullVars = decl.value.match(/--color[\w-]+/g) || [];
                 const values = fullVars.map(
-                    color => color.match(/([\w-]+?)(?=-tint|alpha|shade|$)/g)[0],
+                    color => color.match(/([\w-]+?)(?=-tint|-alpha|-shade|$)/g)[0],
                 );
                 values.forEach(value => {
                     if (replacement[value]) {


### PR DESCRIPTION
Некорректно заменялись цвета с модификаторами `shade` | `alpha`
