### PR TITLE
fix(typography): removed default weight prop from Typography.Text

### DIFF
--- a/packages/list-header/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/list-header/src/__snapshots__/Component.test.tsx.snap
@@ -9,12 +9,12 @@ Object {
         class="component filled"
       >
         <span
-          class="secondary-large regular"
+          class="secondary-large"
         >
           Title
         </span>
         <span
-          class="description secondary-large regular"
+          class="description secondary-large"
         >
           , Description
         </span>
@@ -26,12 +26,12 @@ Object {
       class="component filled"
     >
       <span
-        class="secondary-large regular"
+        class="secondary-large"
       >
         Title
       </span>
       <span
-        class="description secondary-large regular"
+        class="description secondary-large"
       >
         , Description
       </span>
@@ -100,7 +100,7 @@ Object {
         class="component"
       >
         <span
-          class="secondary-large regular"
+          class="secondary-large"
         >
           Title
         </span>
@@ -112,7 +112,7 @@ Object {
       class="component"
     >
       <span
-        class="secondary-large regular"
+        class="secondary-large"
       >
         Title
       </span>

--- a/packages/typography/src/docs/Component.stories.mdx
+++ b/packages/typography/src/docs/Component.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta, Story, Props } from '@storybook/addon-docs';
-import { text, boolean, select, number } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { ComponentHeader, Tabs } from 'storybook/blocks';
 
 import { Typography } from '../component';
-import { name, version } from '../../package.json';
+import { version } from '../../package.json';
 import Description from './description.mdx';
 import Changelog from '../../CHANGELOG.md';
 import { colors } from '../colors';
@@ -108,7 +108,7 @@ import { colors } from '../colors';
         ];
         const color = select('color', colors, '');
         const tag = select('tag', ['div', 'p', 'span'], 'p');
-        const weight = select('weight', ['regular', 'medium', 'bold'], 'regular');
+        const weight = select('weight', ['regular', 'medium', 'bold', undefined], 'regular');
         const monospace = boolean('monospaceNumbers', false);
         return VIEW_TYPES.map(view => (
             <Typography.Text view={view} color={color} tag={tag} weight={weight} monospaceNumbers={monospace} key={view}>

--- a/packages/typography/src/text/component.test.tsx
+++ b/packages/typography/src/text/component.test.tsx
@@ -20,12 +20,6 @@ describe('Text', () => {
             expect(container.firstElementChild).toHaveClass('primary-medium');
         });
 
-        it('should set class `regular` as default weight', () => {
-            const { container } = render(<Text />);
-
-            expect(container.firstElementChild).toHaveClass('regular');
-        });
-
         it('should set `view` class', () => {
             const views: Array<TextProps['view']> = [
                 'primary-large',

--- a/packages/typography/src/text/component.tsx
+++ b/packages/typography/src/text/component.tsx
@@ -65,7 +65,7 @@ export const Text = forwardRef<TextElementType, TextProps>(
         {
             view = 'primary-medium',
             tag: Component = 'span',
-            weight = 'regular',
+            weight,
             monospaceNumbers = false,
             color,
             className,
@@ -81,7 +81,7 @@ export const Text = forwardRef<TextElementType, TextProps>(
                 className,
                 color && colors[color],
                 styles[view],
-                styles[weight],
+                weight && styles[weight],
             )}
             data-test-id={dataTestId}
             ref={ref as never}


### PR DESCRIPTION
В PR убран defaultProp weight , так как по-умолчанию для каждого варианта начертания в стилях уже проставлена толщина шрифта. 