### PR TITLE
feat(select-with-tags): add support useSelectWithApply hook

### DIFF
--- a/packages/select-with-tags/src/component.tsx
+++ b/packages/select-with-tags/src/component.tsx
@@ -30,7 +30,6 @@ export const SelectWithTags = forwardRef<HTMLInputElement, SelectWithTagsProps>(
             allowUnselect = true,
             collapseTagList = false,
             moveInputToNewLine = true,
-            emptyListPlaceholder = 'Ничего не найдено.',
             transformCollapsedTagText,
             transformTagText,
             Tag,
@@ -78,9 +77,9 @@ export const SelectWithTags = forwardRef<HTMLInputElement, SelectWithTagsProps>(
         );
 
         const handleChange = useCallback<Required<BaseSelectProps>['onChange']>(
-            ({ selectedMultiple, name }) => {
+            ({ selectedMultiple, name, initiator }) => {
                 if (onChange) {
-                    onChange({ selectedMultiple, name });
+                    onChange({ selectedMultiple, name, initiator });
                 }
 
                 if (!controlled) {
@@ -133,9 +132,6 @@ export const SelectWithTags = forwardRef<HTMLInputElement, SelectWithTagsProps>(
                     transformTagText,
                     handleUpdatePopover,
                     isPopoverOpen,
-                }}
-                optionsListProps={{
-                    emptyPlaceholder: emptyListPlaceholder,
                 }}
                 selected={selected || selectedTags}
                 autocomplete={isAutocomplete}

--- a/packages/select-with-tags/src/types.ts
+++ b/packages/select-with-tags/src/types.ts
@@ -33,7 +33,11 @@ export type SelectWithTagsProps = Omit<
     /**
      * Обработчик выбора
      */
-    onChange?: (payload: { selectedMultiple: Array<OptionShape | string>; name?: string }) => void;
+    onChange?: (payload: {
+        selectedMultiple: Array<OptionShape | string>;
+        initiator?: OptionShape | null;
+        name?: string;
+    }) => void;
 
     /**
      * Режим автокомплита
@@ -44,11 +48,6 @@ export type SelectWithTagsProps = Omit<
      * Функция сравнения при поиске
      */
     match?: OptionMatcher;
-
-    /**
-     * Будет отображаться, если компонент списка пустой
-     */
-    emptyListPlaceholder?: string;
 
     /**
      * Компонент Тэг


### PR DESCRIPTION
# Опишите проблему
Пресет [useSelectWithApply](https://github.com/core-ds/core-components/tree/master/packages/select/src/presets/useSelectWithApply) не работает с компонентом [SelectWithTags](https://core-ds.github.io/core-components/master/?path=/docs/%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D1%8B-selectwithtags--select-with-tags)
[Здесь](https://github.com/core-ds/core-components/blob/0befe76680b42a2c9657f0d0755a24c9f8a60f7c/packages/select-with-tags/src/component.tsx#L137) жёстко задается проп optionsListProps, без возможности прокинуть свои пропсы в компонент списка (пришлось удалить emptyListPlaceholder, теперь его нужно передавать в SelectWithTags как проп optionsListProps.emptyPlaceholder)
[Здесь](https://github.com/core-ds/core-components/blob/05b024d07502b3a013270ac15fcc5a3b44773aee/packages/select-with-tags/src/component.tsx#L83) не передается поле initiator, в следствии чего onChange из хука useSelectWithApply [отрабатывает сразу](https://github.com/core-ds/core-components/blob/05b024d07502b3a013270ac15fcc5a3b44773aee/packages/select/src/presets/useSelectWithApply/hook.tsx#L77), а не по кнопке "Применить"

# Шаги для воспроизведения
1. Добавить пресет useSelectWithApply к к компоненту SelectWithTags

# Ожидаемое поведение
В выпадающем списке должен появиться футер с кликабельными кнопками, при нажатии на кнопку "Применить" срабатывает onChange
![image](https://user-images.githubusercontent.com/30622012/172096508-5f085696-8eb3-4b99-94be-74da20e7c4e4.png)
