### PR TITLE
fix(gallery): fixed height of swiper on ios 14 and lowest

### DIFF
--- a/packages/gallery/src/components/image-viewer/component.tsx
+++ b/packages/gallery/src/components/image-viewer/component.tsx
@@ -135,7 +135,7 @@ export const ImageViewer: FC = () => {
     const showControls = !singleSlide && !fullScreen;
 
     const swiperWidth = swiper?.width || 1;
-    const swiperHeight = swiper?.height || 1;
+    const swiperHeight = swiper?.height || swiper?.width;
 
     const swiperAspectRatio = swiperWidth / swiperHeight;
 

--- a/packages/gallery/src/components/image-viewer/component.tsx
+++ b/packages/gallery/src/components/image-viewer/component.tsx
@@ -135,7 +135,7 @@ export const ImageViewer: FC = () => {
     const showControls = !singleSlide && !fullScreen;
 
     const swiperWidth = swiper?.width || 1;
-    const swiperHeight = swiper?.height || swiper?.width;
+    const swiperHeight = swiper?.height || swiper?.width || 1;
 
     const swiperAspectRatio = swiperWidth / swiperHeight;
 

--- a/packages/gallery/src/index.module.css
+++ b/packages/gallery/src/index.module.css
@@ -11,5 +11,6 @@
 .modal {
     flex-grow: 1;
     width: 100%;
+    height: 100%;
     background: transparent;
 }


### PR DESCRIPTION
# Опишите проблему
Компонент галлереи отображает слайд высотой 1 пиксель и задний фон с нулевой высотой на ios14<

# Шаги для воспроизведения
1. Открыть галерею в сафари на ios14< с мобильного устройства

# Ожидаемое поведение
Картинки в одиночной галерее должны корректно отображаться на мобильных устройствах в safari на ios14<
