### PR TITLE
fix(tooltip): passing open parameter to tooltip component

### DIFF
--- a/packages/tooltip/src/component.responsive.tsx
+++ b/packages/tooltip/src/component.responsive.tsx
@@ -114,6 +114,7 @@ export const TooltipResponsive: FC<TooltipResponsiveProps> = ({
     ) : (
         <Tooltip
             {...restProps}
+            open={open}
             content={content}
             onOpen={handleOpen}
             targetClassName={targetClassName}


### PR DESCRIPTION
# Опишите проблему
При открытии TooltipResponsive не открывается сам Tooltip, только серая подложка

# Шаги для воспроизведения
1. Перейти на страницу НИБа, где используется TooltipResponsive из core-components: 26.10+
2. Открыть тултип

# Ожидаемое поведение
При нажатии на кнопку должен появиться тултип
<img width="1792" alt="Снимок экрана 2022-06-16 в 11 50 15" src="https://user-images.githubusercontent.com/22305147/174032304-7ef83627-c167-47a3-bfd4-e5228ed3ea77.png">

# Текущее поведение
<img width="1788" alt="Снимок экрана 2022-06-16 в 11 52 36" src="https://user-images.githubusercontent.com/22305147/174032608-2c725d4b-81ab-4099-870e-d721a0321594.png">

