### PR TITLE
fix(tooltip): passing onClose parameter to tooltip component

### DIFF
--- a/packages/tooltip/src/component.responsive.tsx
+++ b/packages/tooltip/src/component.responsive.tsx
@@ -117,6 +117,7 @@ export const TooltipResponsive: FC<TooltipResponsiveProps> = ({
             open={open}
             content={content}
             onOpen={handleOpen}
+            onClose={handleClose}
             targetClassName={targetClassName}
             targetRef={targetRef}
         >


### PR DESCRIPTION
# Опишите проблему
TooltipResponsive не закрывается

# Шаги для воспроизведения
1. Перейти на страницу c TooltipResponsive и открыть его
2. Кликнуть на серый фон

# Ожидаемое поведение
Тултип закроется