### PR TITLE
fix(calendar): increased button css class specificity

### DIFF
--- a/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="component calendar"
+        class="cc-calendar component calendar"
         tabindex="-1"
       >
         <div
@@ -700,7 +700,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
         
       </div>
       <div
-        class="component calendar sixWeeks"
+        class="cc-calendar component calendar sixWeeks"
         tabindex="-1"
       >
         <div

--- a/packages/calendar-with-skeleton/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-with-skeleton/src/__snapshots__/Component.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Calendar Render tests should render calendar when calendarVisible=\`tru
     class="component calendarVisible"
   >
     <div
-      class="component sixWeeks"
+      class="cc-calendar component sixWeeks"
       tabindex="-1"
     >
       <div

--- a/packages/calendar/src/Component.tsx
+++ b/packages/calendar/src/Component.tsx
@@ -260,7 +260,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
         return (
             <div
                 {...getRootProps({ ref })}
-                className={cn(styles.component, className, {
+                className={cn('cc-calendar', styles.component, className, {
                     [styles.sixWeeks]: weeks.length === 6,
                 })}
                 data-test-id={dataTestId}

--- a/packages/calendar/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar/src/__snapshots__/Component.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Calendar Display tests should match defaultView="days" snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div
@@ -664,7 +664,7 @@ exports[`Calendar Display tests should match defaultView="days" snapshot 1`] = `
 exports[`Calendar Display tests should match defaultView="months" snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div
@@ -906,7 +906,7 @@ exports[`Calendar Display tests should match defaultView="months" snapshot 1`] =
 exports[`Calendar Display tests should match defaultView="years" snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div
@@ -2283,7 +2283,7 @@ exports[`Calendar Display tests should match defaultView="years" snapshot 1`] = 
 exports[`Calendar Display tests should match selectorView="full" snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div
@@ -2944,7 +2944,7 @@ exports[`Calendar Display tests should match selectorView="full" snapshot 1`] = 
 exports[`Calendar Display tests should match selectorView="month-only" snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div
@@ -3606,7 +3606,7 @@ exports[`Calendar Display tests should match selectorView="month-only" snapshot 
 exports[`Calendar Display tests should match snapshot 1`] = `
 <div>
   <div
-    class="component sixWeeks"
+    class="cc-calendar component sixWeeks"
     tabindex="-1"
   >
     <div

--- a/packages/calendar/src/components/month-year-header/index.module.css
+++ b/packages/calendar/src/components/month-year-header/index.module.css
@@ -9,8 +9,10 @@
     justify-content: center;
 }
 
-.button {
-    border-radius: var(--border-radius-s);
+:global(.cc-calendar) {
+    & .button {
+        border-radius: var(--border-radius-s);
+    }
 }
 
 .month {

--- a/packages/calendar/src/components/months-table/index.module.css
+++ b/packages/calendar/src/components/months-table/index.module.css
@@ -12,26 +12,28 @@
     }
 }
 
-.button {
-    width: calc((var(--calendar-inner-width) / 3) - (var(--gap-xs) / 3));
-    margin-right: var(--gap-2xs);
-    margin-bottom: var(--gap-xs);
-
-    &:nth-child(3n) {
-        margin-right: 0;
-    }
-
-    @media (max-width: 374px) {
-        width: calc((var(--calendar-mobile-inner-width) / 2) - (var(--gap-2xs) / 2));
+:global(.cc-calendar) {
+    & .button {
+        width: calc((var(--calendar-inner-width) / 3) - (var(--gap-xs) / 3));
+        margin-right: var(--gap-2xs);
+        margin-bottom: var(--gap-xs);
 
         &:nth-child(3n) {
-            margin-right: var(--gap-2xs);
-        }
-
-        &:nth-child(2n) {
             margin-right: 0;
         }
 
-        height: 36px;
+        @media (max-width: 374px) {
+            width: calc((var(--calendar-mobile-inner-width) / 2) - (var(--gap-2xs) / 2));
+
+            &:nth-child(3n) {
+                margin-right: var(--gap-2xs);
+            }
+
+            &:nth-child(2n) {
+                margin-right: 0;
+            }
+
+            height: 36px;
+        }
     }
 }

--- a/packages/calendar/src/components/select-button/index.module.css
+++ b/packages/calendar/src/components/select-button/index.module.css
@@ -1,44 +1,46 @@
 @import '../../../../themes/src/default.css';
 @import '../../vars.css';
 
-.button {
-    @mixin paragraph_primary_medium;
+:global(.cc-calendar) {
+    & .button {
+        @mixin paragraph_primary_medium;
 
-    height: 40px;
-    position: relative;
-    padding: 0 var(--gap-xs);
-    background-color: transparent;
-    border-radius: var(--border-radius-l);
-
-    &:not(:disabled):hover {
-        background-color: var(--color-light-bg-tertiary);
-        color: var(--color-light-text-primary);
-    }
-
-    &.filled {
-        background-color: var(--color-light-bg-tertiary);
+        height: 40px;
+        position: relative;
+        padding: 0 var(--gap-xs);
+        background-color: transparent;
+        border-radius: var(--border-radius-l);
 
         &:not(:disabled):hover {
-            background-color: var(--color-light-bg-tertiary-shade-7);
+            background-color: var(--color-light-bg-tertiary);
+            color: var(--color-light-text-primary);
         }
-    }
 
-    &.outlined {
-        border: 1px solid var(--calendar-select-button-today-border-color);
-    }
+        &.filled {
+            background-color: var(--color-light-bg-tertiary);
 
-    &.selected,
-    &.selected:disabled {
-        background-color: var(--calendar-select-button-selected-background);
-        color: var(--color-light-text-primary-inverted);
+            &:not(:disabled):hover {
+                background-color: var(--color-light-bg-tertiary-shade-7);
+            }
+        }
 
-        &:not(:disabled):hover {
+        &.outlined {
+            border: 1px solid var(--calendar-select-button-today-border-color);
+        }
+
+        &.selected,
+        &.selected:disabled {
             background-color: var(--calendar-select-button-selected-background);
             color: var(--color-light-text-primary-inverted);
-        }
-    }
 
-    & > * {
-        flex-grow: 1;
+            &:not(:disabled):hover {
+                background-color: var(--calendar-select-button-selected-background);
+                color: var(--color-light-text-primary-inverted);
+            }
+        }
+
+        & > * {
+            flex-grow: 1;
+        }
     }
 }

--- a/packages/calendar/src/components/years-table/index.module.css
+++ b/packages/calendar/src/components/years-table/index.module.css
@@ -22,27 +22,29 @@
     }
 }
 
-.button {
-    /* 3 колонки с равными отступами */
-    width: calc((var(--calendar-inner-width) / 3) - (var(--gap-xs) / 3));
-    margin-right: var(--gap-2xs);
-    margin-bottom: var(--gap-xs);
-
-    &:nth-child(3n) {
-        margin-right: 0;
-    }
-
-    @media (max-width: 374px) {
-        width: calc((var(--calendar-mobile-inner-width) / 2) - (var(--gap-2xs) / 2));
+:global(.cc-calendar) {
+    & .button {
+        /* 3 колонки с равными отступами */
+        width: calc((var(--calendar-inner-width) / 3) - (var(--gap-xs) / 3));
+        margin-right: var(--gap-2xs);
+        margin-bottom: var(--gap-xs);
 
         &:nth-child(3n) {
-            margin-right: var(--gap-2xs);
-        }
-
-        &:nth-child(2n) {
             margin-right: 0;
         }
 
-        height: 36px;
+        @media (max-width: 374px) {
+            width: calc((var(--calendar-mobile-inner-width) / 2) - (var(--gap-2xs) / 2));
+
+            &:nth-child(3n) {
+                margin-right: var(--gap-2xs);
+            }
+
+            &:nth-child(2n) {
+                margin-right: 0;
+            }
+
+            height: 36px;
+        }
     }
 }


### PR DESCRIPTION
Поднял специфичность css классам кнопок внутри календаря, так как возникали ситуации, когда стили кнопок имели более высокий приоритет, чем стили, которыми внутри календаря их пытались переопределить.

Раньше полагались на последовательность css импортов. Как в итоге оказалось это не всегда и не везде работает.