### PR TITLE
feat(amount-input): added functionality to enter negative values

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "@alfalab/icons-glyph": "^2.16.0",
         "@alfalab/icons-logotype": "^1.28.0",
         "@alfalab/stylelint-core-vars": "^1.4.0",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "@popperjs/core": "2.3.3",
         "classnames": "2.2.6",
         "compute-scroll-into-view": "1.0.13",

--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -22,7 +22,7 @@
         "@alfalab/core-components-input": "^8.1.6",
         "@alfalab/core-components-with-suffix": "^3.2.6",
         "@alfalab/data": "^1.2.2",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6"
     }
 }

--- a/packages/amount-input/src/Component.test.tsx
+++ b/packages/amount-input/src/Component.test.tsx
@@ -94,6 +94,11 @@ describe('AmountInput', () => {
         expect(input.value).toBe(`12${THINSP}345,67`);
     });
 
+    it('should render passed negative amount', () => {
+        const input = renderAmountInput(-1234567);
+        expect(input.value).toBe(`-12${THINSP}345,67`);
+    });
+
     it('should render passed amount without zero minor part', () => {
         const input = renderAmountInput(1234500);
         expect(input.value).toBe(`12${THINSP}345`);
@@ -124,28 +129,47 @@ describe('AmountInput', () => {
         expect(input.value).toBe(`12${THINSP}345,67`);
     });
 
+    it("should replace entered '.' with ','", () => {
+        const input = renderAmountInput(null, null, { positiveOnly: false });
+
+        fireEvent.change(input, { target: { value: '-0.' } });
+        expect(input.value).toBe('-0,');
+
+        fireEvent.change(input, { target: { value: '0.' } });
+        expect(input.value).toBe('0,');
+
+        fireEvent.change(input, { target: { value: '-123.' } });
+        expect(input.value).toBe('-123,');
+
+        fireEvent.change(input, { target: { value: '123.4' } });
+        expect(input.value).toBe('123,4');
+
+        fireEvent.change(input, { target: { value: '-123.45' } });
+        expect(input.value).toBe('-123,45');
+
+        fireEvent.change(input, { target: { value: '123456789.12' } });
+        expect(input.value).toBe(`123${THINSP}456${THINSP}789,12`);
+    });
+
     it('should allow input correct amounts', () => {
         const input = renderAmountInput(0);
 
         fireEvent.change(input, { target: { value: '123456' } });
         expect(input.value).toBe(`123${THINSP}456`);
 
-        fireEvent.change(input, { target: { value: '123,' } });
-        expect(input.value).toBe('123,');
+        fireEvent.change(input, { target: { value: '0,' } });
+        expect(input.value).toBe('0,');
 
-        fireEvent.change(input, { target: { value: '123.' } });
+        fireEvent.change(input, { target: { value: '0,2' } });
+        expect(input.value).toBe('0,2');
+
+        fireEvent.change(input, { target: { value: '123,' } });
         expect(input.value).toBe('123,');
 
         fireEvent.change(input, { target: { value: '123,4' } });
         expect(input.value).toBe('123,4');
 
-        fireEvent.change(input, { target: { value: '123.4' } });
-        expect(input.value).toBe('123,4');
-
         fireEvent.change(input, { target: { value: '123,45' } });
-        expect(input.value).toBe('123,45');
-
-        fireEvent.change(input, { target: { value: '123.45' } });
         expect(input.value).toBe('123,45');
 
         fireEvent.change(input, { target: { value: '123456789' } });
@@ -153,12 +177,78 @@ describe('AmountInput', () => {
 
         fireEvent.change(input, { target: { value: '123456789,12' } });
         expect(input.value).toBe(`123${THINSP}456${THINSP}789,12`);
+    });
 
-        fireEvent.change(input, { target: { value: '123456789.12' } });
+    it('should allow input correct amounts when positiveOnly is false', () => {
+        const input = renderAmountInput(0, null, { positiveOnly: false });
+
+        fireEvent.change(input, { target: { value: '-' } });
+        expect(input.value).toBe('-');
+
+        fireEvent.change(input, { target: { value: '-0,' } });
+        expect(input.value).toBe('-0,');
+
+        fireEvent.change(input, { target: { value: '-0,2' } });
+        expect(input.value).toBe('-0,2');
+
+        fireEvent.change(input, { target: { value: '-123456' } });
+        expect(input.value).toBe(`-123${THINSP}456`);
+
+        fireEvent.change(input, { target: { value: '-123,' } });
+        expect(input.value).toBe('-123,');
+
+        fireEvent.change(input, { target: { value: '-123,4' } });
+        expect(input.value).toBe('-123,4');
+
+        fireEvent.change(input, { target: { value: '-123,45' } });
+        expect(input.value).toBe('-123,45');
+
+        fireEvent.change(input, { target: { value: '-123456789' } });
+        expect(input.value).toBe(`-123${THINSP}456${THINSP}789`);
+
+        fireEvent.change(input, { target: { value: '-123456789,12' } });
+        expect(input.value).toBe(`-123${THINSP}456${THINSP}789,12`);
+
+        fireEvent.change(input, { target: { value: '123456' } });
+        expect(input.value).toBe(`123${THINSP}456`);
+
+        fireEvent.change(input, { target: { value: '0,' } });
+        expect(input.value).toBe('0,');
+
+        fireEvent.change(input, { target: { value: '0,2' } });
+        expect(input.value).toBe('0,2');
+
+        fireEvent.change(input, { target: { value: '123,' } });
+        expect(input.value).toBe('123,');
+
+        fireEvent.change(input, { target: { value: '123,4' } });
+        expect(input.value).toBe('123,4');
+
+        fireEvent.change(input, { target: { value: '123,45' } });
+        expect(input.value).toBe('123,45');
+
+        fireEvent.change(input, { target: { value: '123456789' } });
+        expect(input.value).toBe(`123${THINSP}456${THINSP}789`);
+
+        fireEvent.change(input, { target: { value: '123456789,12' } });
         expect(input.value).toBe(`123${THINSP}456${THINSP}789,12`);
     });
 
-    it('should prevent input of incorrect amounts', () => {
+    it("should infer 0 if only ',' is entered", () => {
+        const input = renderAmountInput(null);
+
+        fireEvent.change(input, { target: { value: ',' } });
+        expect(input.value).toBe('0,');
+    });
+
+    it("should infer 0 if '-,' is entered", async () => {
+        const input = renderAmountInput(null, null, { positiveOnly: false });
+
+        fireEvent.change(input, { target: { value: '-,' } });
+        expect(input.value).toBe('-0,');
+    });
+
+    it('should prevent input of incorrect values', () => {
         const input = renderAmountInput(1234567);
 
         fireEvent.change(input, { target: { value: 'f' } });
@@ -166,6 +256,19 @@ describe('AmountInput', () => {
 
         fireEvent.change(input, { target: { value: '!' } });
         expect(input.value).toBe(`12${THINSP}345,67`);
+
+        fireEvent.change(input, { target: { value: 'e' } });
+        expect(input.value).toBe(`12${THINSP}345,67`);
+    });
+
+    it('should prevent input of negative values when onlyPositive is true', () => {
+        const input = renderAmountInput(null);
+
+        fireEvent.change(input, { target: { value: '-' } });
+        expect(input.value).toBe('');
+
+        fireEvent.change(input, { target: { value: '-17700' } });
+        expect(input.value).toBe('');
     });
 
     it('should allow enter only integer values when integersOnly is true', async () => {
@@ -216,7 +319,7 @@ describe('AmountInput', () => {
         expect(input.value).toBe(`12${THINSP}345,86`);
     });
 
-    it('should allow to past value with spaces', async () => {
+    it('should allow to paste value with spaces', async () => {
         const input = renderAmountInput(null);
 
         await userEvent.paste(input, '1 23');
@@ -233,7 +336,7 @@ describe('AmountInput', () => {
         expect(input.value).toBe('13,45');
     });
 
-    it('should allow set carret in the middle and enter decimal divider symbol', async () => {
+    it('should allow set caret in the middle and enter decimal divider symbol', async () => {
         const input = renderAmountInput(null);
 
         await userEvent.type(input, '123456');

--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -48,6 +48,12 @@ export type AmountInputProps = Omit<InputProps, 'value' | 'onChange' | 'type'> &
     integersOnly?: boolean;
 
     /**
+     * @default - true. Нельзя вводить отрицательные значения.
+     * Возможность вводить только положительные значения
+     */
+    positiveOnly?: boolean;
+
+    /**
      * Жир
      */
     bold?: boolean;
@@ -91,6 +97,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
                 suffix === currency ? getCurrencySymbol(currency) || '' : suffix
             }`,
             integersOnly = false,
+            positiveOnly = true,
             bold = true,
             colors = 'default',
             className,
@@ -104,13 +111,14 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
         ref,
     ) => {
         const getFormattedAmount = useCallback(() => {
-            if (value === '' || value === null) return '';
+            if (value === '' || value === null || value === '-') return '';
 
             return formatAmount({
                 value: +value,
                 currency,
                 minority,
                 view: 'default',
+                negativeSymbol: 'hyphen-minus',
             }).formatted;
         }, [currency, minority, value]);
 
@@ -135,9 +143,9 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
             if (integersOnly) {
                 [enteredValue] = enteredValue.split(',');
             }
-
+            // Сокращение минимальной длины мажорной части числа до 0 позволяет ввести "," => "0,"
             const isCorrectEnteredValue = RegExp(
-                `(^[0-9]{1,${integerLength}}(,([0-9]+)?)?$|^\\s*$)`,
+                `(^${positiveOnly ? '' : '-?'}[0-9]{0,${integerLength}}(,([0-9]+)?)?$|^\\s*$)`,
             ).test(enteredValue);
 
             if (isCorrectEnteredValue) {

--- a/packages/amount-input/src/docs/Component.stories.mdx
+++ b/packages/amount-input/src/docs/Component.stories.mdx
@@ -25,6 +25,7 @@ import styles from '!!raw-loader!../index.module.css';
         integerLength={number('integerLength', 9)}
         minority={number('minority', 100)}
         integersOnly={boolean('integersOnly', false)}
+        positiveOnly={boolean('positiveOnly', true)}
         bold={boolean('bold', true)}
         block={boolean('block', false)}
         size={select('size', ['s', 'm', 'l', 'xl'], 's')}

--- a/packages/amount-input/src/docs/description.mdx
+++ b/packages/amount-input/src/docs/description.mdx
@@ -33,31 +33,36 @@
 
 ```tsx live
 render(() => {
-    const [value, setValue] = React.useState(10000);
+  const [value, setValue] = React.useState(10000);
+  const [valueString, setValueString] = React.useState('10000');
+  const [suggests] = React.useState([
+    { currency: "RUR", minorUnits: 100, value: -1000, valueString: '-10' },
+    { currency: "RUR", minorUnits: 100, value: 0, valueString: '0' },
+    { currency: "RUR", minorUnits: 100, value: 500, valueString: '5' },
+    { currency: "RUR", minorUnits: 100, value: 156000, valueString: '1560' },
+    { currency: "RUR", minorUnits: 100, value: null, valueString: '' },
+  ]);
+  const handleChange = (event, payload) => {
+    setValue(payload.value);
+    setValueString(payload.valueString);
+  };
+  return (
+    <Space>
+      <AmountInput
+        value={value}
+        onChange={handleChange}
+        hint={`value: ${value} | valueString: ${valueString}`}
+        positiveOnly={false}
+      />
 
-    const [suggests] = React.useState([
-        { currency: 'RUR', minorUnits: 100, value: 15600 },
-        { currency: 'RUR', minorUnits: 100, value: 500 },
-        { currency: 'RUR', minorUnits: 100, value: null },
-        { currency: 'RUR', minorUnits: 100, value: 0 },
-    ]);
-
-    const handleChange = (event, payload) => {
-        setValue(payload.value);
-    };
-
-    return (
-        <Space>
-            <AmountInput value={value} onChange={handleChange} hint={`value: ${value}`} />
-
-            <Space direction="horizontal">
-                {suggests.map(s => (
-                    <Button size='xs' onClick={() => setValue(s.value)}>
-                        Установить {String(s.value)}
-                    </Button>
-                ))}
-            </Space>
-        </Space>
-    );
+      <Space direction="horizontal">
+        {suggests.map((s) => (
+          <Button size="xs" onClick={() => handleChange(null, {value: s.value, valueString: s.valueString})}>
+            Установить {String(s.value)}
+          </Button>
+        ))}
+      </Space>
+    </Space>
+  );
 });
 ```

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@alfalab/data": "^1.2.2",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6"
     },
     "peerDependencies": {

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -23,7 +23,7 @@
         "@alfalab/core-components-keyboard-focusable": "^3.0.3",
         "@alfalab/core-components-progress-bar": "^2.1.2",
         "@alfalab/icons-glyph": "^2.16.0",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6",
         "react-merge-refs": "1.1.0"
     }

--- a/packages/confirmation/package.json
+++ b/packages/confirmation/package.json
@@ -22,7 +22,7 @@
         "@alfalab/core-components-loader": "^2.0.4",
         "@alfalab/hooks": "^1.4.1",
         "@alfalab/icons-glyph": "^2.16.0",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6"
     },
     "peerDependencies": {

--- a/packages/filter-tag/package.json
+++ b/packages/filter-tag/package.json
@@ -23,7 +23,7 @@
         "@alfalab/core-components-icon-button": "^4.1.11",
         "@alfalab/core-components-tag": "^4.2.4",
         "@alfalab/hooks": "^1.4.1",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6"
     }
 }

--- a/packages/intl-phone-input/package.json
+++ b/packages/intl-phone-input/package.json
@@ -23,7 +23,7 @@
         "@alfalab/core-components-input-autocomplete": "7.0.4",
         "@alfalab/core-components-select": "^10.8.0",
         "@alfalab/hooks": "^1.4.1",
-        "@alfalab/utils": "^1.9.0",
+        "@alfalab/utils": "^1.11.0",
         "classnames": "2.2.6",
         "libphonenumber-js": "1.9.6",
         "react-merge-refs": "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,6 +129,11 @@
   resolved "https://registry.yarnpkg.com/@alfalab/data/-/data-1.2.2.tgz#3052b75f6e9857bbfa97a0b511b69167cbb9e89c"
   integrity sha512-Sj56c4bZBjm98PEaIiWyB0oDHNQIfPFYMxj1N0eh6WhPgmOz09Zm3oG5+9wZ2fkktVH8sElCHIUkjL2ztFPCbA==
 
+"@alfalab/data@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@alfalab/data/-/data-1.2.3.tgz#b4cc25542ecef657c6f0b64608eb6f9e37f35524"
+  integrity sha512-BWzAJkjxg/+ksajaTv2z35ElFh/jNZE3d+hlOWKfO9uxWITeKKEDs10yPWIlZRcY33q0QtgBlPfp5mQ6BdtnWg==
+
 "@alfalab/hooks@^1.0.0":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@alfalab/hooks/-/hooks-1.1.1.tgz"
@@ -199,6 +204,14 @@
   version "1.4.0"
   resolved "https://registry.npmjs.org/@alfalab/stylelint-core-vars/-/stylelint-core-vars-1.4.0.tgz"
   integrity sha512-6BOJJppFlPTsA/m53zjlBDTm49PF1O+wcrSDL7s3uOdMkChc0F/NXKTq+Oz/k4tI4yG5ZnyACcmD8g7vbjvVag==
+
+"@alfalab/utils@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@alfalab/utils/-/utils-1.11.0.tgz#2bfcb5d8f21864263fed4907c1d35b6108e5b3fe"
+  integrity sha512-X4WXuNHfHbmkgJNv1+c1ehCELwuirY3VSazveU46bnLo/KtizNVkM2BOl71gtqn9SvABoLdXe9Mi933Gp6crMw==
+  dependencies:
+    "@alfalab/data" "^1.2.3"
+    fast-redact "^3.1.1"
 
 "@alfalab/utils@^1.9.0":
   version "1.9.0"
@@ -12121,6 +12134,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-redact@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.1.1.tgz#790fcff8f808c2e12fabbfb2be5cb2deda448fa0"
+  integrity sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"


### PR DESCRIPTION
Для компонента AmountInput была добавлена возможность вводить отрицательные значения (с '-' перед значением). Данный функционал закрыт пропой-флагом `positiveOnly` (default - true, т.е. по дефолту нельзя вводить отрицательные значения). 

Также, в ходе разработки (во время изменения регулярки корректного значения инпута) появилась возможность вводить ',' в начало инпута, что затем конвертируется в '0,'. Не уверен, что это не было сделано ранее намеренно, поэтому, если такой функционал не нужен, то это довольно безболезненно можно тут поправить обратно.