### PR TITLE
feat(*): change types for OptionList and add event for handlers to Tooltip

### DIFF
--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -493,7 +493,7 @@ export type OptionsListProps = {
     /**
      * Будет отображаться, если компонент пустой
      */
-    emptyPlaceholder?: string;
+    emptyPlaceholder?: ReactNode;
 
     /**
      * Количество видимых пунктов меню (5 = 5.5)

--- a/packages/tooltip/src/component.responsive.tsx
+++ b/packages/tooltip/src/component.responsive.tsx
@@ -26,12 +26,12 @@ type TooltipResponsiveProps = Omit<TooltipProps, 'open' | 'onClose' | 'onOpen'> 
     /**
      * Обработчик открытия
      */
-    onOpen?: () => void;
+    onOpen?: (event?: React.MouseEvent<HTMLElement>) => void;
 
     /**
      * Обработчик закрытия
      */
-    onClose?: () => void;
+    onClose?: (event?: React.MouseEvent<HTMLElement>) => void;
 
     /**
      * Заголовок кнопки в футере
@@ -67,17 +67,17 @@ export const TooltipResponsive: FC<TooltipResponsiveProps> = ({
 
     const [openValue, setOpenValueIfUncontrolled] = useControlled(open, false);
 
-    const handleOpen = () => {
+    const handleOpen = (event?: React.MouseEvent<HTMLElement>) => {
         if (onOpen) {
-            onOpen();
+            onOpen(event);
         } else {
             setOpenValueIfUncontrolled(true);
         }
     };
 
-    const handleClose = () => {
+    const handleClose = (event?: React.MouseEvent<HTMLElement>) => {
         if (onClose) {
-            onClose();
+            onClose(event);
         } else {
             setOpenValueIfUncontrolled(false);
         }


### PR DESCRIPTION
1)Расширил тип emptyPlaceholder компонента OptionList для передачи ReactNode.
2)Прокинул event в хендлеры для открытия и закрытия тултипа
