### PR TITLE
fix(tooltip): change media query for TooltipResponsive

### DIFF
--- a/packages/tooltip/src/component.responsive.tsx
+++ b/packages/tooltip/src/component.responsive.tsx
@@ -66,8 +66,8 @@ export const TooltipResponsive: FC<TooltipResponsiveProps> = ({
 }) => {
     const [view] = useMedia<View>(
         [
-            ['mobile', '(max-width: 767px)'],
-            ['desktop', '(min-width: 768px)'],
+            ['mobile', '(max-width: 1024px)'],
+            ['desktop', '(min-width: 1025px)'],
         ],
         defaultMatch,
     );


### PR DESCRIPTION
Изменяю медиа запрос, т.к. на планшетах с разрешением 1024 на 600 нужен мобильный компонент тултипа. Получено добро от дизайна(Татьяна Юдина)