### PR TITLE
feat(cdn-icon): edited icon size fit svg

### DIFF
--- a/packages/cdn-icon/src/index.module.css
+++ b/packages/cdn-icon/src/index.module.css
@@ -1,5 +1,8 @@
 @import '../../themes/src/default.css';
 
+.component {
+    display: inline-flex;
+}
 .component svg {
     fill: currentColor;
 }


### PR DESCRIPTION
Компонент CDNIcon выполнен в виде span с инлайонвым отображением (по умолчанию), в связи с чем, он имеет размеры, отличные от содержимого (самой иконки). Это приводит к смещению иконки при использовании. Изменил тип отображения (1 строчка в CSS), чтобы решить проблему.
![image](https://user-images.githubusercontent.com/109101415/178338563-c0fad862-b482-43bf-831c-be768e71d5ee.png)
