### PR TITLE
fix(side-panel): fix ts

### DIFF
--- a/packages/side-panel/src/Component.desktop.tsx
+++ b/packages/side-panel/src/Component.desktop.tsx
@@ -1,7 +1,10 @@
 import React, { cloneElement, forwardRef, isValidElement, useRef } from 'react';
 import cn from 'classnames';
 
-import { Drawer, DrawerProps } from '@alfalab/core-components-drawer';
+import { Drawer } from '@alfalab/core-components-drawer';
+import { BaseModalProps } from '@alfalab/core-components-base-modal';
+import { TransitionProps } from 'react-transition-group/Transition';
+
 import mergeRefs from 'react-merge-refs';
 import { HeaderDesktop } from './components/header/Component.desktop';
 import { ContentDesktop } from './components/content/Component.desktop';
@@ -10,7 +13,12 @@ import { FooterDesktop } from './components/footer/Component.desktop';
 import styles from './desktop.module.css';
 import transitions from './transitions.desktop.module.css';
 
-export type SidePanelDesktopProps = DrawerProps & {
+export type SidePanelDesktopProps = BaseModalProps & {
+    /**
+     * Пропсы для анимации контента (CSSTransition)
+     */
+    contentTransitionProps?: Partial<TransitionProps>;
+
     /**
      * Ширина модального окна
      * @default "s"

--- a/packages/side-panel/src/Component.responsive.tsx
+++ b/packages/side-panel/src/Component.responsive.tsx
@@ -1,11 +1,30 @@
 import { useMedia } from '@alfalab/hooks';
 import React, { FC, forwardRef, useContext, useMemo } from 'react';
 
-import { SidePanelDesktop, SidePanelDesktopProps } from './Component.desktop';
-import { SidePanelMobile, SidePanelMobileProps } from './Component.mobile';
+import { TransitionProps } from 'react-transition-group/Transition';
+import { BaseModalProps } from '@alfalab/core-components-base-modal';
+import { SidePanelDesktop } from './Component.desktop';
+import { SidePanelMobile } from './Component.mobile';
 import { Closer } from './components/closer/Component';
 
-export type SidePanelResponsiveProps = SidePanelMobileProps & SidePanelDesktopProps;
+export type SidePanelResponsiveProps = BaseModalProps & {
+    /**
+     * Пропсы для анимации контента (CSSTransition)
+     */
+    contentTransitionProps?: Partial<TransitionProps>;
+
+    /**
+     * Ширина модального окна
+     * @default "s"
+     */
+    size?: 's';
+
+    /**
+     * Управление наличием закрывающего крестика
+     * @default false
+     */
+    hasCloser?: boolean;
+};
 
 type View = 'desktop' | 'mobile';
 

--- a/packages/side-panel/src/components/content/Component.desktop.tsx
+++ b/packages/side-panel/src/components/content/Component.desktop.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
 import { Content, ContentProps } from './Component';
-import { SidePanelDesktopProps } from '../../Component.desktop';
 
 import styles from './desktop.module.css';
 
@@ -9,7 +8,7 @@ export type ContentDesktopProps = ContentProps & {
     /**
      * Размер
      */
-    size?: SidePanelDesktopProps['size'];
+    size?: 's';
 };
 
 export const ContentDesktop: FC<ContentDesktopProps> = ({ size, className, ...restProps }) => (

--- a/packages/side-panel/src/components/content/Component.desktop.tsx
+++ b/packages/side-panel/src/components/content/Component.desktop.tsx
@@ -11,6 +11,8 @@ export type ContentDesktopProps = ContentProps & {
     size?: 's';
 };
 
-export const ContentDesktop: FC<ContentDesktopProps> = ({ size, className, ...restProps }) => (
-    <Content className={cn(className, size && styles[size])} {...restProps} />
-);
+export const ContentDesktop: FC<ContentDesktopProps> = ({
+    size = 's',
+    className,
+    ...restProps
+}) => <Content className={cn(className, size && styles[size])} {...restProps} />;

--- a/packages/side-panel/src/components/content/Component.tsx
+++ b/packages/side-panel/src/components/content/Component.tsx
@@ -15,15 +15,21 @@ export type ContentProps = {
      * Дополнительный класс
      */
     className?: string;
+
+    /**
+     * Идентификатор для систем автоматизированного тестирования
+     */
+    dataTestId?: string;
 };
 
-export const Content: FC<ContentProps> = ({ children, className }) => {
+export const Content: FC<ContentProps> = ({ children, className, dataTestId }) => {
     const { contentRef } = useContext(ModalContext);
 
     return (
         <div
             className={cn(styles.content, className, styles.flex)}
             ref={contentRef as Ref<HTMLDivElement>}
+            data-test-id={dataTestId}
         >
             {children}
         </div>

--- a/packages/side-panel/src/components/footer/Component.desktop.tsx
+++ b/packages/side-panel/src/components/footer/Component.desktop.tsx
@@ -12,7 +12,7 @@ export type FooterDesktopProps = FooterProps & {
 };
 
 export const FooterDesktop: FC<FooterDesktopProps> = ({
-    size,
+    size = 's',
     className,
     sticky,
     ...restProps

--- a/packages/side-panel/src/components/footer/Component.desktop.tsx
+++ b/packages/side-panel/src/components/footer/Component.desktop.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
 import { Footer, FooterProps } from './Component';
-import { SidePanelDesktopProps } from '../../Component.desktop';
 
 import styles from './desktop.module.css';
 
@@ -9,7 +8,7 @@ export type FooterDesktopProps = FooterProps & {
     /**
      * Размер
      */
-    size?: SidePanelDesktopProps['size'];
+    size?: 's';
 };
 
 export const FooterDesktop: FC<FooterDesktopProps> = ({

--- a/packages/side-panel/src/components/footer/Component.tsx
+++ b/packages/side-panel/src/components/footer/Component.tsx
@@ -31,9 +31,21 @@ export type FooterProps = {
      * Отступы между элементами футера
      */
     gap?: 16 | 24 | 32;
+
+    /**
+     * Идентификатор для систем автоматизированного тестирования
+     */
+    dataTestId?: string;
 };
 
-export const Footer: FC<FooterProps> = ({ children, className, sticky, layout = 'start', gap }) => {
+export const Footer: FC<FooterProps> = ({
+    children,
+    className,
+    sticky,
+    layout = 'start',
+    gap,
+    dataTestId,
+}) => {
     const { footerHighlighted, setHasFooter } = useContext(ModalContext);
 
     useEffect(() => {
@@ -52,6 +64,7 @@ export const Footer: FC<FooterProps> = ({ children, className, sticky, layout = 
                     [styles.sticky]: sticky,
                 },
             )}
+            data-test-id={dataTestId}
         >
             {children}
         </div>

--- a/packages/side-panel/src/components/header/Component.desktop.tsx
+++ b/packages/side-panel/src/components/header/Component.desktop.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import cn from 'classnames';
 import { Header, HeaderProps } from './Component';
 import { Closer } from '../closer/Component';
-import { SidePanelDesktopProps } from '../../Component.desktop';
 
 import styles from './desktop.module.css';
 
@@ -10,7 +9,7 @@ export type HeaderDesktopProps = Omit<HeaderProps, 'closer'> & {
     /**
      * Размер
      */
-    size?: SidePanelDesktopProps['size'];
+    size?: 's';
 
     /**
      * Наличие крестика

--- a/packages/side-panel/src/components/header/Component.desktop.tsx
+++ b/packages/side-panel/src/components/header/Component.desktop.tsx
@@ -18,7 +18,7 @@ export type HeaderDesktopProps = Omit<HeaderProps, 'closer'> & {
 };
 
 export const HeaderDesktop: FC<HeaderDesktopProps> = ({
-    size,
+    size = 's',
     className,
     contentClassName,
     hasCloser = true,

--- a/packages/side-panel/src/components/header/Component.tsx
+++ b/packages/side-panel/src/components/header/Component.tsx
@@ -55,6 +55,11 @@ export type HeaderProps = {
      * Фиксирует шапку
      */
     sticky?: boolean;
+
+    /**
+     * Идентификатор для систем автоматизированного тестирования
+     */
+    dataTestId?: string;
 };
 
 export const Header: FC<HeaderProps> = ({
@@ -68,6 +73,7 @@ export const Header: FC<HeaderProps> = ({
     title,
     closer,
     sticky,
+    dataTestId,
 }) => {
     const { headerHighlighted, setHasHeader } = useContext(ModalContext);
 
@@ -84,6 +90,7 @@ export const Header: FC<HeaderProps> = ({
                 [styles.sticky]: sticky,
                 [styles.hasContent]: hasContent,
             })}
+            data-test-id={dataTestId}
         >
             {leftAddons && <div className={cn(styles.addon, addonClassName)}>{leftAddons}</div>}
 


### PR DESCRIPTION
Изменила вложенность типизации у SidePanelDesktop и SidePanelResponsive с ( side-panel -> drawer -> base-modal ) и ( side-panel-responsive -> side-panel-desktop && side-panel-modal -> base-modal ) на side-panel -> base-modal 
добавила dataTestId в подкомпоненты Header, Content, Footer
 