### PR TITLE
fix(link): replace component with a button in pseudo mode

### DIFF
--- a/packages/collapse/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/collapse/src/__snapshots__/Component.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Collapse Display tests should display radio group with one child correc
         </p>
       </div>
     </div>
-    <a
+    <button
       class="component primary pseudo withAddons"
     >
       <span>
@@ -52,7 +52,7 @@ exports[`Collapse Display tests should display radio group with one child correc
           </g>
         </svg>
       </span>
-    </a>
+    </button>
   </div>
 </div>
 `;

--- a/packages/confirmation/src/__image_snapshots__/confirmation-code-char-amount-align-sprite-snap.png
+++ b/packages/confirmation/src/__image_snapshots__/confirmation-code-char-amount-align-sprite-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14df82bb7c058b3b0b0a39c21d99f50573809d373155a6d8df10db2f667de85e
-size 52026
+oid sha256:9f50fd00cbf2f3ec842f8a62de21b0312f170bf54af41e23f1de4a182085fa24
+size 51104

--- a/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Confirmation Snapshot tests should match snapshot 1`] = `
           01:00
         </div>
       </div>
-      <a
+      <button
         class="component secondary pseudo smsComeLink"
       >
         <span
@@ -78,7 +78,7 @@ exports[`Confirmation Snapshot tests should match snapshot 1`] = `
         >
           Не приходит сообщение?
         </span>
-      </a>
+      </button>
     </div>
   </div>
 </div>
@@ -163,7 +163,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_CHECKING st
           class="loaderText"
         />
       </div>
-      <a
+      <button
         class="component secondary pseudo smsComeLink"
       >
         <span
@@ -171,7 +171,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_CHECKING st
         >
           Не приходит сообщение?
         </span>
-      </a>
+      </button>
     </div>
   </div>
 </div>
@@ -253,7 +253,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_ERROR state
           01:00
         </div>
       </div>
-      <a
+      <button
         class="component secondary pseudo smsComeLink"
       >
         <span
@@ -261,7 +261,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_ERROR state
         >
           Не приходит сообщение?
         </span>
-      </a>
+      </button>
     </div>
   </div>
 </div>
@@ -346,7 +346,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_SENDING sta
           class="loaderText"
         />
       </div>
-      <a
+      <button
         class="component secondary pseudo smsComeLink"
       >
         <span
@@ -354,7 +354,7 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_SENDING sta
         >
           Не приходит сообщение?
         </span>
-      </a>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/file-upload-item/src/__image_snapshots__/file-upload-item-ellipsis-name-0-upload-date-0-size-0-show-restore-0-snap.png
+++ b/packages/file-upload-item/src/__image_snapshots__/file-upload-item-ellipsis-name-0-upload-date-0-size-0-show-restore-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:052b0748efa216b30f525e8df1b9b4b65c79258ee54cc082fa7c589b73fe7864
-size 5204
+oid sha256:78a287f42becaf1cd82ab3f9d4db910be2fc74b52d5c066e2aa327eb6d3baba6
+size 4613

--- a/packages/file-upload-item/src/__image_snapshots__/file-upload-item-hide-meta-when-show-restore-true-name-0-upload-date-0-size-0-show-restore-0-snap.png
+++ b/packages/file-upload-item/src/__image_snapshots__/file-upload-item-hide-meta-when-show-restore-true-name-0-upload-date-0-size-0-show-restore-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ec50722240929ad604b3fa3e4720cf6aa5b8246f670682b20fa1065e2183dd5
-size 4504
+oid sha256:79af58811889e667d3d1af6c2f771d24f7515cfb60b60311f49d48497ad5a63a
+size 3922

--- a/packages/link/src/Component.tsx
+++ b/packages/link/src/Component.tsx
@@ -101,6 +101,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 
         const viewClassName = view === 'default' ? 'defaultView' : view;
 
+        const LinkComponent = pseudo ? 'button' : Component;
+
         const componentProps = {
             className: cn(
                 styles.component,
@@ -116,11 +118,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             'data-test-id': dataTestId,
             rel: restProps.target === '_blank' ? 'noreferrer noopener' : undefined,
             // Для совместимости с react-router-dom, меняем href на to
-            [typeof Component === 'string' ? 'href' : 'to']: href,
+            [typeof LinkComponent === 'string' ? 'href' : 'to']: href,
         };
 
         return (
-            <Component {...componentProps} {...restProps} ref={mergeRefs([linkRef, ref])}>
+            <LinkComponent {...componentProps} {...restProps} ref={mergeRefs([linkRef, ref])}>
                 {leftAddons || rightAddons ? (
                     <React.Fragment>
                         {leftAddons && <span className={styles.addons}>{leftAddons}</span>}
@@ -134,7 +136,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
                 ) : (
                     <span className={styles.text}>{children}</span>
                 )}
-            </Component>
+            </LinkComponent>
         );
     },
 );

--- a/packages/link/src/Component.tsx
+++ b/packages/link/src/Component.tsx
@@ -90,7 +90,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             children,
             colors = 'default',
             href,
-            Component = 'a',
+            Component = pseudo ? 'button' : 'a',
             ...restProps
         },
         ref,
@@ -100,8 +100,6 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         const [focused] = useFocus(linkRef, 'keyboard');
 
         const viewClassName = view === 'default' ? 'defaultView' : view;
-
-        const LinkComponent = pseudo ? 'button' : Component;
 
         const componentProps = {
             className: cn(
@@ -118,11 +116,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             'data-test-id': dataTestId,
             rel: restProps.target === '_blank' ? 'noreferrer noopener' : undefined,
             // Для совместимости с react-router-dom, меняем href на to
-            [typeof LinkComponent === 'string' ? 'href' : 'to']: href,
+            [typeof Component === 'string' ? 'href' : 'to']: href,
         };
 
         return (
-            <LinkComponent {...componentProps} {...restProps} ref={mergeRefs([linkRef, ref])}>
+            <Component {...componentProps} {...restProps} ref={mergeRefs([linkRef, ref])}>
                 {leftAddons || rightAddons ? (
                     <React.Fragment>
                         {leftAddons && <span className={styles.addons}>{leftAddons}</span>}
@@ -136,7 +134,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
                 ) : (
                     <span className={styles.text}>{children}</span>
                 )}
-            </LinkComponent>
+            </Component>
         );
     },
 );

--- a/packages/link/src/__image_snapshots__/link-pseudo-sprite-snap.png
+++ b/packages/link/src/__image_snapshots__/link-pseudo-sprite-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27b1d0146562a014bacf2b6b7ca170fa1eb3a26c5292c31701bfc0be4c1ac6bb
-size 48172
+oid sha256:ffa67b7073154642bc68ce83c460ec1586684b824eeeb15096b0dd6ace92ffbc
+size 53069

--- a/packages/link/src/__image_snapshots__/link-pseudo-underline-sprite-snap.png
+++ b/packages/link/src/__image_snapshots__/link-pseudo-underline-sprite-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99e9b28a7cbf8012adc2eb61bb2b7e1b6660b0deca079b5346decefcdd6bc3e7
-size 92204
+oid sha256:abc29ca940436867aadbd1b4ee4c3dcdc3076ce97e469340046c5df37021ef04
+size 96195

--- a/packages/link/src/__image_snapshots__/link-sprite-snap.png
+++ b/packages/link/src/__image_snapshots__/link-sprite-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27b1d0146562a014bacf2b6b7ca170fa1eb3a26c5292c31701bfc0be4c1ac6bb
-size 48172
+oid sha256:ffa67b7073154642bc68ce83c460ec1586684b824eeeb15096b0dd6ace92ffbc
+size 53069

--- a/packages/link/src/index.module.css
+++ b/packages/link/src/index.module.css
@@ -28,6 +28,15 @@
     @mixin focus-outline;
 }
 
+.pseudo {
+    margin: 0;
+    padding: 0;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    font: inherit;
+}
+
 .pseudo .text {
     border-bottom-style: dashed;
 }


### PR DESCRIPTION
См. issue https://github.com/core-ds/core-components/issues/148

В компоненте Link с пропсом pseudo по дефолту заменяется html-элемент "a" на "button"  с обнуленными стилями