### PR TITLE
feat(codemod): codemode to remove dist from imports

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -26,22 +26,23 @@ $ npx @alfalab/core-components-codemod --transformers=button-xs,button-views src
 
 ### Список доступных трансформеров
 
-| Название     | Описание                                                                                    |
-| ------------ | ------------------------------------------------------------------------------------------- |
-| paragraph    | Меняет компонент `Paragraph` из `arui-feather` на актульный компонент из `core-components` |
-| label        | Меняет компонент `Label` из `arui-feather` на актульный компонент из `core-components`     |
-| heading      | Меняет компонент `Heading` из `arui-feather` на актульный компонент из `core-components`   |
-| button-xs    | Изменяет размер кнопки с `xs` на `xxs`                                                     |
-| button-views | Меняет вид кнопки с `filled` \| `transparent` на `secondary`, `outlined` на `tertiary`     |
-| replace-color-vars | Заменяет цветовые токены при преходе на core-components v27 и выше: |
-|              | `--color-light-border-secondary-inverted`: `--color-light-border-underline` |
-|              | `--color-light-border-tertiary-inverted`: `--color-light-border-underline-inverted` |
-|              | `--color-light-graphic-neutral`: `--color-light-graphic-quaternary` |
-|              | `--color-light-bg-neutral`: `--color-light-bg-quaternary` |
-|              | `--color-dark-graphic-neutral`: `--color-dark-graphic-quaternary` |
-|              | `--color-dark-bg-neutral`: `--color-dark-bg-quaternary` |
-|              | `--color-static-bg-neutral-light`: `--color-static-bg-quaternary-light` |
-|              | `--color-static-bg-neutral-dark`: `--color-static-bg-quaternary-dark` |
+| Название           | Описание                                                                                                                                                                                                                            |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paragraph          | Меняет компонент `Paragraph` из `arui-feather` на актульный компонент из `core-components`                                                                                                                                          |
+| label              | Меняет компонент `Label` из `arui-feather` на актульный компонент из `core-components`                                                                                                                                              |
+| heading            | Меняет компонент `Heading` из `arui-feather` на актульный компонент из `core-components`                                                                                                                                            |
+| button-xs          | Изменяет размер кнопки с `xs` на `xxs`                                                                                                                                                                                              |
+| button-views       | Меняет вид кнопки с `filled` \                                                                                                                                                                                                      | `transparent` на `secondary`, `outlined` на `tertiary`     |
+| replace-color-vars | Заменяет цветовые токены при преходе на core-components v27 и выше:                                                                                                                                                                 |
+|                    | `--color-light-border-secondary-inverted`: `--color-light-border-underline`                                                                                                                                                         |
+|                    | `--color-light-border-tertiary-inverted`: `--color-light-border-underline-inverted`                                                                                                                                                 |
+|                    | `--color-light-graphic-neutral`: `--color-light-graphic-quaternary`                                                                                                                                                                 |
+|                    | `--color-light-bg-neutral`: `--color-light-bg-quaternary`                                                                                                                                                                           |
+|                    | `--color-dark-graphic-neutral`: `--color-dark-graphic-quaternary`                                                                                                                                                                   |
+|                    | `--color-dark-bg-neutral`: `--color-dark-bg-quaternary`                                                                                                                                                                             |
+|                    | `--color-static-bg-neutral-light`: `--color-static-bg-quaternary-light`                                                                                                                                                             |
+|                    | `--color-static-bg-neutral-dark`: `--color-static-bg-quaternary-dark`                                                                                                                                                               |
+| delete-dist        | Удаляет '/dist' в импортах отдельных пакетов. Может принимать дополнительный аргумент командной строки --packages, в котором указывается список компонентов, импорты которых нужно обработать, например (--packages="modal,button") |
 
 ## Разработка
 

--- a/packages/codemod/bin/index.js
+++ b/packages/codemod/bin/index.js
@@ -46,7 +46,11 @@ function main() {
 
         try {
             console.log(chalk.green(`Запускаем ${transformerName}:`));
-            shell.exec(`jscodeshift --parser=tsx --transform=${transformer} ${argv._.join(' ')}`);
+            shell.exec(
+                `jscodeshift --parser=tsx --transform=${transformer} ${argv._.join(' ')} ${
+                    argv.packages ? `--packages=${argv.packages.replace(/\s/g, '')}` : ''
+                }`,
+            );
         } catch (error) {
             console.log(chalk.red(error));
         }

--- a/packages/codemod/src/delete-dist/__testfixtures__/transform-with-packages.input.tsx
+++ b/packages/codemod/src/delete-dist/__testfixtures__/transform-with-packages.input.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal } from '@alfalab/core-components-modal/dist/esm';
+import { Button } from '@alfalab/core-components-button/dist/cssm';
+import { Calendar, CalendarMobile } from '@alfalab/core-components-calendar/dist/modern';
+import { Alert as CoreAlert } from '@alfalab/core-components-alert/dist/esm';
+import { Plate } from '@alfalab/core-components-plate';
+import { OtherComponent } from '../OtherComponent';
+
+export const Component = () => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <div>
+            <Modal open={open}>
+                <Modal.Content>
+                    <Calendar />
+                    <CalendarMobile />
+                    <CoreAlert>Alert!!!</CoreAlert>
+                    <Plate>Plate</Plate>
+                    <OtherComponent />
+                </Modal.Content>
+            </Modal>
+
+            <Button onClick={() => setOpen()}>Open modal</Button>
+        </div>
+    );
+};

--- a/packages/codemod/src/delete-dist/__testfixtures__/transform-with-packages.output.tsx
+++ b/packages/codemod/src/delete-dist/__testfixtures__/transform-with-packages.output.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal } from '@alfalab/core-components-modal/esm';
+import { Button } from '@alfalab/core-components-button/cssm';
+import { Calendar, CalendarMobile } from '@alfalab/core-components-calendar/dist/modern';
+import { Alert as CoreAlert } from '@alfalab/core-components-alert/dist/esm';
+import { Plate } from '@alfalab/core-components-plate';
+import { OtherComponent } from '../OtherComponent';
+
+export const Component = () => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <div>
+            <Modal open={open}>
+                <Modal.Content>
+                    <Calendar />
+                    <CalendarMobile />
+                    <CoreAlert>Alert!!!</CoreAlert>
+                    <Plate>Plate</Plate>
+                    <OtherComponent />
+                </Modal.Content>
+            </Modal>
+
+            <Button onClick={() => setOpen()}>Open modal</Button>
+        </div>
+    );
+};

--- a/packages/codemod/src/delete-dist/__testfixtures__/transform.input.tsx
+++ b/packages/codemod/src/delete-dist/__testfixtures__/transform.input.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal } from '@alfalab/core-components-modal/dist/esm';
+import { Button } from '@alfalab/core-components-button/dist/cssm';
+import { Calendar, CalendarMobile } from '@alfalab/core-components-calendar/dist/modern';
+import { Alert as CoreAlert } from '@alfalab/core-components-alert/dist/esm';
+import { Plate } from '@alfalab/core-components-plate';
+import { OtherComponent } from '../OtherComponent';
+
+export const Component = () => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <div>
+            <Modal open={open}>
+                <Modal.Content>
+                    <Calendar />
+                    <CalendarMobile />
+                    <CoreAlert>Alert!!!</CoreAlert>
+                    <Plate>Plate</Plate>
+                    <OtherComponent />
+                </Modal.Content>
+            </Modal>
+
+            <Button onClick={() => setOpen()}>Open modal</Button>
+        </div>
+    );
+};

--- a/packages/codemod/src/delete-dist/__testfixtures__/transform.output.tsx
+++ b/packages/codemod/src/delete-dist/__testfixtures__/transform.output.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal } from '@alfalab/core-components-modal/esm';
+import { Button } from '@alfalab/core-components-button/cssm';
+import { Calendar, CalendarMobile } from '@alfalab/core-components-calendar/modern';
+import { Alert as CoreAlert } from '@alfalab/core-components-alert/esm';
+import { Plate } from '@alfalab/core-components-plate';
+import { OtherComponent } from '../OtherComponent';
+
+export const Component = () => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <div>
+            <Modal open={open}>
+                <Modal.Content>
+                    <Calendar />
+                    <CalendarMobile />
+                    <CoreAlert>Alert!!!</CoreAlert>
+                    <Plate>Plate</Plate>
+                    <OtherComponent />
+                </Modal.Content>
+            </Modal>
+
+            <Button onClick={() => setOpen()}>Open modal</Button>
+        </div>
+    );
+};

--- a/packages/codemod/src/delete-dist/__tests__/transform.test.ts
+++ b/packages/codemod/src/delete-dist/__tests__/transform.test.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line prefer-destructuring
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+jest.autoMockOff();
+
+defineTest(__dirname, 'transform', null, 'transform', { parser: 'tsx' });
+defineTest(__dirname, 'transform', { packages: 'modal,button' }, 'transform-with-packages', {
+    parser: 'tsx',
+});

--- a/packages/codemod/src/delete-dist/transform.ts
+++ b/packages/codemod/src/delete-dist/transform.ts
@@ -1,0 +1,33 @@
+const transformPaths = (fileInfo, api, options) => {
+    const j = api.jscodeshift;
+    const source = j(fileInfo.source);
+
+    const packages = options.packages ? options.packages.split(',') : [];
+
+    const importsForReplace = source
+        .find(j.ImportSpecifier)
+        .filter(path => {
+            const importFrom = path.parent.value.source.value;
+
+            if (packages.length > 0) {
+                const reList = packages.map(p => new RegExp(`^@alfalab/core-components-${p}/dist`));
+
+                return reList.some(re => re.test(importFrom));
+            }
+
+            const re = new RegExp('^(@alfalab/core-components-).+(/dist)');
+            return re.test(importFrom);
+        })
+        .map(p => p.parent);
+
+    importsForReplace.replaceWith(p => {
+        return j.importDeclaration(
+            p.node.specifiers,
+            j.stringLiteral(p.value.source.value.replace('/dist', '')),
+        );
+    });
+
+    return source.toSource({ quote: 'single' });
+};
+
+export default transformPaths;


### PR DESCRIPTION
Codemod удаляет '/dist' из импорта
'@alfalab/core-components-button/dist/esm' заменит на '@alfalab/core-components-button/esm'