### PR TITLE
feat: Новый cdn alfabank.servicecdn.ru

### DIFF
--- a/.storybook/public/global.css
+++ b/.storybook/public/global.css
@@ -6,26 +6,28 @@
 /* stylelint-disable */
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_regular.woff2')
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_regular.woff2')
             format('woff2'),
-        url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_regular.woff')
+        url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_regular.woff')
             format('woff');
     font-weight: 400;
     font-style: normal;
 }
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_medium.woff2')
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_medium.woff2')
             format('woff2'),
-        url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_medium.woff') format('woff');
+        url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_medium.woff')
+            format('woff');
     font-weight: 500;
     font-style: normal;
 }
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_bold.woff2')
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_bold.woff2')
             format('woff2'),
-        url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_bold.woff') format('woff');
+        url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_bold.woff')
+            format('woff');
     font-weight: 700;
     font-style: normal;
 }
@@ -205,7 +207,7 @@ select.select {
     padding-right: var(--gap-xl);
     -webkit-appearance: none;
     appearance: none;
-    background-image: url(https://alfabank.gcdn.co/icons/glyph_chevron-down-compact_m.svg);
+    background-image: url(https://alfabank.servicecdn.ru/icons/glyph_chevron-down-compact_m.svg);
     background-repeat: no-repeat;
     background-position: right center;
 }

--- a/docs/6.typography.stories.mdx
+++ b/docs/6.typography.stories.mdx
@@ -48,22 +48,22 @@ import { Meta } from '@storybook/addon-docs';
 ```css
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_regular.woff2') format('woff2'),
-         url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_regular.woff') format('woff');
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_regular.woff2') format('woff2'),
+         url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_regular.woff') format('woff');
     font-weight: 400;
     font-style: normal;
 }
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_medium.woff2') format('woff2'),
-         url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_medium.woff') format('woff');
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_medium.woff2') format('woff2'),
+         url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_medium.woff') format('woff');
     font-weight: 500;
     font-style: normal;
 }
 @font-face {
     font-family: 'Styrene UI';
-    src: url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_bold.woff2') format('woff2'),
-         url('https://alfabank.gcdn.co/media/fonts/styrene-ui/styrene-ui_bold.woff') format('woff');
+    src: url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_bold.woff2') format('woff2'),
+         url('https://alfabank.servicecdn.ru/media/fonts/styrene-ui/styrene-ui_bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
@@ -71,7 +71,7 @@ import { Meta } from '@storybook/addon-docs';
 
 Есть вариант с CDN:
 
-`https://alfabank.gcdn.co/media/fonts/styrene-ui/font.css`
+`https://alfabank.servicecdn.ru/media/fonts/styrene-ui/font.css`
 
 Для всех Styrene-элементов должна быть включена настройка `font-feature-settings: 'ss01';`, и рекомендуем не забыть про сглаживание
 `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;`.

--- a/packages/cdn-icon/src/Component.tsx
+++ b/packages/cdn-icon/src/Component.tsx
@@ -27,7 +27,7 @@ export const CDNIcon: React.FC<CDNIconProps> = ({ name, color, dataTestId, class
 
     useEffect(() => {
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', `https://alfabank.gcdn.co/icons/${name}.svg`);
+        xhr.open('GET', `https://alfabank.servicecdn.ru/icons/${name}.svg`);
         xhr.send();
         xhr.onload = function onload() {
             const svg = xhr.response;

--- a/packages/cdn-icon/src/Component.tsx
+++ b/packages/cdn-icon/src/Component.tsx
@@ -17,17 +17,28 @@ type CDNIconProps = {
      */
     className?: string;
     /**
+     * Базовый адрес cdn хранилища c иконками
+     * @default https://alfabank.servicecdn.ru/icons
+     */
+    baseUrl?: string;
+    /**
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
 };
 
-export const CDNIcon: React.FC<CDNIconProps> = ({ name, color, dataTestId, className }) => {
+export const CDNIcon: React.FC<CDNIconProps> = ({
+    name,
+    color,
+    dataTestId,
+    className,
+    baseUrl = 'https://alfabank.servicecdn.ru/icons',
+}) => {
     const [icon, setIcon] = useState('');
 
     useEffect(() => {
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', `https://alfabank.servicecdn.ru/icons/${name}.svg`);
+        xhr.open('GET', `${baseUrl}/${name}.svg`);
         xhr.send();
         xhr.onload = function onload() {
             const svg = xhr.response;
@@ -35,7 +46,7 @@ export const CDNIcon: React.FC<CDNIconProps> = ({ name, color, dataTestId, class
         };
 
         return () => xhr.abort();
-    }, [name]);
+    }, [name, baseUrl]);
 
     return (
         <span

--- a/packages/gallery/src/vars.css
+++ b/packages/gallery/src/vars.css
@@ -1,3 +1,3 @@
 :root {
-    --gallery-broken-image-icon: url('https://alfabank.gcdn.co/icons/art_no-image_s.svg');
+    --gallery-broken-image-icon: url('https://alfabank.servicecdn.ru/icons/art_no-image_s.svg');
 }

--- a/packages/input/src/default.module.css
+++ b/packages/input/src/default.module.css
@@ -5,8 +5,8 @@
     --input-placeholder-color: var(--color-light-text-secondary);
     --input-focus-placeholder-color: var(--color-light-text-tertiary);
     --input-with-label-placeholder-color: var(--color-light-text-tertiary);
-    --input-error-icon: url('https://alfabank.gcdn.co/icons/glyph_alert-circle_m_negative.svg');
-    --input-success-icon: url('https://alfabank.gcdn.co/icons/icon_ok_s_color.svg');
+    --input-error-icon: url('https://alfabank.servicecdn.ru/icons/glyph_alert-circle_m_negative.svg');
+    --input-success-icon: url('https://alfabank.servicecdn.ru/icons/icon_ok_s_color.svg');
     --input-caret-color: var(--input-color);
 
     /* disabled */

--- a/packages/input/src/inverted.module.css
+++ b/packages/input/src/inverted.module.css
@@ -5,8 +5,8 @@
     --input-inverted-placeholder-color: var(--color-light-text-secondary-inverted-transparent);
     --input-inverted-focus-placeholder-color: var(--color-light-text-tertiary-inverted);
     --input-inverted-with-label-placeholder-color: var(--color-light-text-tertiary-inverted);
-    --input-inverted-error-icon: url('https://alfabank.gcdn.co/icons/glyph_alert-circle_m_negative.svg');
-    --input-inverted-success-icon: url('https://alfabank.gcdn.co/icons/icon_ok_s_color.svg');
+    --input-inverted-error-icon: url('https://alfabank.servicecdn.ru/icons/glyph_alert-circle_m_negative.svg');
+    --input-inverted-success-icon: url('https://alfabank.servicecdn.ru/icons/icon_ok_s_color.svg');
     --input-inverted-caret-color: var(--input-inverted-color);
 
     /* disabled */

--- a/packages/plate/src/index.module.css
+++ b/packages/plate/src/index.module.css
@@ -6,8 +6,8 @@
     --plate-border-radius: var(--border-radius-m);
 
     /* icons */
-    --plate-closer-icon: url('https://alfabank.gcdn.co/icons/glyph_cross_m.svg');
-    --plate-arrow-icon: url('https://alfabank.gcdn.co/icons/glyph_chevron-down_m.svg');
+    --plate-closer-icon: url('https://alfabank.servicecdn.ru/icons/glyph_cross_m.svg');
+    --plate-arrow-icon: url('https://alfabank.servicecdn.ru/icons/glyph_chevron-down_m.svg');
 }
 
 .component {

--- a/packages/screenshot-utils/helpers.ts
+++ b/packages/screenshot-utils/helpers.ts
@@ -87,8 +87,8 @@ export const matchHtml = async ({
 }: MatchHtmlParams) => {
     let pageHtml = await getPageHtml(page, css);
 
-    // FIXME: gcdn.co недоступен на playwright сервере
-    pageHtml = pageHtml.replace(/alfabank\.gcdn\.co/g, 'alfabank.st');
+    // FIXME: servicecdn.ru недоступен на playwright сервере
+    pageHtml = pageHtml.replace(/alfabank\.servicecdn\.ru/g, 'alfabank.st');
 
     const image = await axios.post(
         playwrightUrl,

--- a/packages/select/src/vars.css
+++ b/packages/select/src/vars.css
@@ -40,7 +40,7 @@
     --select-checkmark-unselected-opacity: 0;
     --select-checkmark-background: var(--color-light-graphic-primary);
     --select-checkmark-border-radius: var(--border-radius-circle);
-    --select-mobile-checkmark-background: url('https://alfabank.gcdn.co/icons/glyph_checkmark_m.svg');
+    --select-mobile-checkmark-background: url('https://alfabank.servicecdn.ru/icons/glyph_checkmark_m.svg');
 
     /* optgroup */
 

--- a/packages/themes/src/mixins/input/site.css
+++ b/packages/themes/src/mixins/input/site.css
@@ -1,4 +1,4 @@
 @define-mixin input-site {
-    --input-error-icon: url('https://alfabank.gcdn.co/icons/icon_error_m_color.svg');
-    --input-inverted-error-icon: url('https://alfabank.gcdn.co/icons/icon_error_m_color.svg');
+    --input-error-icon: url('https://alfabank.servicecdn.ru/icons/icon_error_m_color.svg');
+    --input-inverted-error-icon: url('https://alfabank.servicecdn.ru/icons/icon_error_m_color.svg');
 }

--- a/packages/themes/src/mixins/select/click.css
+++ b/packages/themes/src/mixins/select/click.css
@@ -14,9 +14,9 @@
     --select-checkmark-size: 24px;
     --select-checkmark-before-display: none;
     --select-checkmark-after-display: 'flex';
-    --select-checkmark-background: url('https://alfabank.gcdn.co/icons/glyph_checkmark-circle_m_color.svg');
+    --select-checkmark-background: url('https://alfabank.servicecdn.ru/icons/glyph_checkmark-circle_m_color.svg');
     --select-checkmark-border-radius: 0;
-    --select-mobile-checkmark-background: url('https://alfabank.gcdn.co/icons/glyph_checkmark-circle_m_color.svg');
+    --select-mobile-checkmark-background: url('https://alfabank.servicecdn.ru/icons/glyph_checkmark-circle_m_color.svg');
 
     /* select mobile footer */
 


### PR DESCRIPTION
- Изменил alfabank.gcdn.co на alfabank.servicecdn.ru

BREAKING CHANGE: Добавьте новый домен в список разрешенных 'img-src': `'self' alfabank.servicecdn.ru
data: 'self'`

