### PR TITLE
fix: purgecss fixes

### DIFF
--- a/bin/purgecss.sh
+++ b/bin/purgecss.sh
@@ -4,9 +4,4 @@
 node --max-old-space-size=4096 bin/purgecss.js
 
 # удаляем неиспользуемые css-переменные из сборки во всех подпакетах
-lerna exec --parallel \
-    --ignore @alfalab/core-components-vars \
-    --ignore @alfalab/core-components-themes \
-    --ignore @alfalab/core-components-grid \
-    --ignore @alfalab/core-components-toast-plate \
-    -- node ../../bin/purgecss.js
+lerna exec --parallel -- node ../../bin/purgecss.js

--- a/packages/bank-card/src/index.module.css
+++ b/packages/bank-card/src/index.module.css
@@ -1,5 +1,6 @@
 @import '../../themes/src/default.css';
 
+/* purgecss ignore */
 .component {
     /* TODO: как это будет собираться и работать в webView */
     --form-control-border-radius: 0;


### PR DESCRIPTION
### Проблемы
1. purgecss по какой-то причине удалял используемые селекторы
2. у нас не работал игнор для отдельных пакетов (не работал для bank-card)

### Изменения
1. Теперь игнор пакетов настраивается в одном месте. Работает для отдельных пакетов и для рута
2. Заставляем purgecss игнорировать ВСЕ селекторы, чтобы он не удалил лишнего. Переменные внутри селекторов все равно могут удалиться, поэтому там где нужно — нужно юзать `/* purgecss ignore */` (bank-card)