### PR TITLE
fix: omit enterKeyHint prop

### DIFF
--- a/packages/attach/src/Component.tsx
+++ b/packages/attach/src/Component.tsx
@@ -21,7 +21,7 @@ import styles from './index.module.css';
 
 export type AttachProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'value' | 'defaultValue' | 'onChange' | 'multiple'
+    'size' | 'type' | 'value' | 'defaultValue' | 'onChange' | 'multiple' | 'enterKeyHint'
 > & {
     /**
      * Содержимое кнопки для выбора файла

--- a/packages/checkbox/src/Component.tsx
+++ b/packages/checkbox/src/Component.tsx
@@ -10,7 +10,7 @@ import styles from './index.module.css';
 type NativeProps = InputHTMLAttributes<HTMLInputElement>;
 type Align = 'start' | 'center';
 
-export type CheckboxProps = Omit<NativeProps, 'size' | 'onChange'> & {
+export type CheckboxProps = Omit<NativeProps, 'size' | 'onChange' | 'enterKeyHint'> & {
     /**
      * Управление состоянием вкл/выкл чекбокса (native prop)
      */

--- a/packages/code-input/src/components/input/component.tsx
+++ b/packages/code-input/src/components/input/component.tsx
@@ -13,7 +13,7 @@ import styles from './index.module.css';
 
 export type InputProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'onChange' | 'onKeyDown'
+    'value' | 'onChange' | 'onKeyDown' | 'enterKeyHint'
 > & {
     index: number;
     value: string;

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -27,7 +27,14 @@ const colorStyles = {
 
 export type InputProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'value' | 'defaultValue' | 'onChange' | 'onClick' | 'onMouseDown'
+    | 'size'
+    | 'type'
+    | 'value'
+    | 'defaultValue'
+    | 'onChange'
+    | 'onClick'
+    | 'onMouseDown'
+    | 'enterKeyHint'
 > & {
     /**
      * Значение поля ввода

--- a/packages/pure-input/src/Component.tsx
+++ b/packages/pure-input/src/Component.tsx
@@ -5,7 +5,10 @@ import { useFocus } from '@alfalab/hooks';
 
 import styles from './index.module.css';
 
-export type PureInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'> & {
+export type PureInputProps = Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'enterKeyHint'
+> & {
     /**
      * Растягивает компонент на ширину контейнера
      */

--- a/packages/radio/src/Component.tsx
+++ b/packages/radio/src/Component.tsx
@@ -10,7 +10,7 @@ type Align = 'start' | 'center';
 
 export type RadioProps = Omit<
     NativeProps,
-    'size' | 'type' | 'onChange' | 'checked' | 'disabled' | 'name' | 'className'
+    'size' | 'type' | 'onChange' | 'checked' | 'disabled' | 'name' | 'className' | 'enterKeyHint'
 > & {
     /**
      * Идентификатор для систем автоматизированного тестирования

--- a/packages/switch/src/Component.tsx
+++ b/packages/switch/src/Component.tsx
@@ -16,7 +16,7 @@ type Align = 'start' | 'center';
 
 export type SwitchProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'type' | 'hint' | 'onChange' | 'disabled'
+    'type' | 'hint' | 'onChange' | 'disabled' | 'enterKeyHint'
 > & {
     /**
      * Управление состоянием вкл/выкл компонента


### PR DESCRIPTION
Обнаружили несовместимость типов @react/types 16 и 18 версии. В интерфейсе InputHTMLAttributes в 16 версии реакта отсутствует свойство enterKeyHint, а forwardRef имеет следующий дженерик - 
`type PropsWithoutRef<P> = P extends any ? ('ref' extends keyof P ? Pick<P, Exclude<keyof P, 'ref'>> : P) : P;`
В итоге, если c 18 версией @react/types указать - `forwardRef<anyType, InputHTMLAttributes<anyType>>()`, то получим в результате тип `ForwardRefExoticComponent<Pick<InputHTMLAttributes>, 'enterKeyHint' | ... etc>`. Все это приводит к тому что свойство enterKeyHint становится обязательным при использовании с 16 версией типов.

Из этой ситуации вижу три выхода - 
1) Обновить версию типов на проекте (что не является хорошим вариантом, к тому же мы поддерживаем 16 реакт).
2) Исключить свойство в исходниках из InputHTMLAttributes (что и сделано в текущем ПРе)
3) Вручную добавить это свойство к типам, которые включают в себя InputHTMLAttributes (
  type InputProps = InputHTMLAttributes<HTMLInputElement> & {enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'}
)