### PR TITLE
fix(loader): fix margin-right

### DIFF
--- a/packages/loader/src/index.module.css
+++ b/packages/loader/src/index.module.css
@@ -31,6 +31,7 @@
     & div:nth-child(3) {
         animation-delay: 300ms;
         transform-origin: 85% 50%;
+        margin-right: 0;
     }
 }
 


### PR DESCRIPTION
Отцентравала лоадер в кнопках, убрав у крайнего элемента отступ 
