### PR TITLE
chore: fix tests

### DIFF
--- a/packages/attach/src/component.screenshots.test.tsx
+++ b/packages/attach/src/component.screenshots.test.tsx
@@ -63,6 +63,8 @@ describe('Attach | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/bottom-sheet/src/component.screenshots.test.tsx
+++ b/packages/bottom-sheet/src/component.screenshots.test.tsx
@@ -133,6 +133,8 @@ describe('BottomSheet | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/calendar-input/src/component.screenshots.test.tsx
+++ b/packages/calendar-input/src/component.screenshots.test.tsx
@@ -36,6 +36,8 @@ describe('CalendarInput | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/collapse/src/component.screenshots.test.tsx
+++ b/packages/collapse/src/component.screenshots.test.tsx
@@ -29,7 +29,7 @@ describe('Collapse | interactions tests', () => {
                 },
             });
 
-            await page.click('a');
+            await page.click('button[class*=component]');
 
             await matchHtml({
                 page,
@@ -44,6 +44,8 @@ describe('Collapse | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/confirmation-v1/src/component.screenshots.test.tsx
+++ b/packages/confirmation-v1/src/component.screenshots.test.tsx
@@ -185,6 +185,8 @@ describe.skip('ConfirmationV1 | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/gallery/src/component.screenshots.test.tsx
+++ b/packages/gallery/src/component.screenshots.test.tsx
@@ -29,6 +29,8 @@ describe('Gallery | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -70,6 +72,8 @@ describe('Gallery | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -98,6 +102,8 @@ describe('Gallery | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/input-autocomplete/src/component.screenshots.test.tsx
+++ b/packages/input-autocomplete/src/component.screenshots.test.tsx
@@ -37,6 +37,8 @@ describe('InputAutocomplete | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -76,6 +78,8 @@ describe('InputAutocompleteMobile | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/intl-phone-input/src/component.screenshots.test.tsx
+++ b/packages/intl-phone-input/src/component.screenshots.test.tsx
@@ -47,6 +47,8 @@ describe('IntlPhoneInput | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/keyboard-focusable/src/component.screenshots.test.tsx
+++ b/packages/keyboard-focusable/src/component.screenshots.test.tsx
@@ -27,6 +27,8 @@ describe('KeyboardFocusable | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -50,6 +52,8 @@ describe('KeyboardFocusable | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/picker-button/src/component.screenshots.test.tsx
+++ b/packages/picker-button/src/component.screenshots.test.tsx
@@ -43,6 +43,8 @@ describe('PickerButton', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -77,6 +79,8 @@ describe('PickerButton', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/scrollbar/src/Component.screenshots.test.tsx
+++ b/packages/scrollbar/src/Component.screenshots.test.tsx
@@ -56,6 +56,8 @@ describe('Scrollbar | interactions tests', () => {
             });
         } catch (e) {
             console.error(e.message);
+
+            throw e;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -87,6 +89,8 @@ describe('Scrollbar | interactions tests', () => {
             });
         } catch (e) {
             console.error(e.message);
+
+            throw e;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/select-with-tags/src/component.screenshots.test.tsx
+++ b/packages/select-with-tags/src/component.screenshots.test.tsx
@@ -112,6 +112,8 @@ describe('SelectWithTags | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/select/src/component.screenshots.test.tsx
+++ b/packages/select/src/component.screenshots.test.tsx
@@ -190,6 +190,8 @@ describe('Select | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }
@@ -230,6 +232,8 @@ describe('Select | interactions tests', () => {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error.message);
+
+            throw error;
         } finally {
             await closeBrowser({ browser, context, page });
         }

--- a/packages/tooltip/src/component.screenshots.test.tsx
+++ b/packages/tooltip/src/component.screenshots.test.tsx
@@ -54,7 +54,9 @@ describe('Tooltip', () => {
                 });
             } catch (error) {
                 // eslint-disable-next-line no-console
-                await console.error(error.message);
+                console.error(error.message);
+
+                throw error;
             }
         }
 
@@ -96,7 +98,9 @@ describe('Tooltip', () => {
                 });
             } catch (error) {
                 // eslint-disable-next-line no-console
-                await console.error(error.message);
+                console.error(error.message);
+
+                throw error;
             }
         }
 
@@ -138,7 +142,9 @@ describe('Tooltip', () => {
                 });
             } catch (error) {
                 // eslint-disable-next-line no-console
-                await console.error(error.message);
+                console.error(error.message);
+
+                throw error;
             }
         }
 


### PR DESCRIPTION
В скриншот тестах при возникновении ошибок, например, не найден указанный селектор на странице, тест завершался успехом из-за того, что ошибки перехватывались в catch.