### PR TITLE
fix(calendar-input): should pass valid input value if error is set

### DIFF
--- a/.changeset/eighty-seas-visit.md
+++ b/.changeset/eighty-seas-visit.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-calendar-input': patch
+---
+
+Внешняя ошибка больше не влияет на вызов onChange

--- a/packages/calendar-input/src/Component.tsx
+++ b/packages/calendar-input/src/Component.tsx
@@ -219,7 +219,7 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
 
         const checkInputValueIsValid = useCallback(
             (newInputValue?: string) => {
-                if (!newInputValue || error) return false;
+                if (!newInputValue) return false;
 
                 const dateValue = parseDateString(newInputValue).getTime();
 
@@ -230,7 +230,7 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
                     !offDays.includes(dateValue)
                 );
             },
-            [error, maxDate, minDate, offDays],
+            [maxDate, minDate, offDays],
         );
 
         const inputDisabled = disabled || readOnly;


### PR DESCRIPTION
fix #276

Кажется, что наличие внешней ошибки не должно влиять на работу компонента