### PR TITLE
feat(intl-phone-input): add ruNumber priority and empty country state

### DIFF
--- a/packages/intl-phone-input/src/component.test.tsx
+++ b/packages/intl-phone-input/src/component.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { IntlPhoneInput } from './index';
 
@@ -146,7 +147,7 @@ describe('IntlPhoneInput', () => {
         );
         const input = await screen.getByDisplayValue('');
 
-        fireEvent.change(input, { target: { value: '+998 12 345 67 89' } });
+        fireEvent.change(input, { target: { value: '+998 12 345 67 89', selectionStart: 0 } });
 
         expect(onCountryChange).toBeCalledWith('UZ');
         expect(onCountryChange).toHaveBeenCalledTimes(1);
@@ -195,5 +196,123 @@ describe('IntlPhoneInput', () => {
         const countrySelect = queryByTestId('countries-select');
 
         expect(countrySelect).toBeNull();
+    });
+
+    it('should show empty country', async () => {
+        const onCountryChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                value=''
+                onChange={() => null}
+                dataTestId={testId}
+                onCountryChange={onCountryChange}
+                canBeEmptyCountry={true}
+                defaultCountryIso2='ru'
+            />,
+        );
+
+        const input = screen.getByDisplayValue('');
+
+        fireEvent.change(input, { target: { value: '+', selectionStart: 0 } });
+
+        const icons = screen.getAllByRole('img');
+
+        expect(icons[0]).toHaveClass('emptyCountryIcon');
+        expect(onCountryChange).toBeCalledWith(undefined);
+    });
+
+    it('should call `onChange` with value "+7" when type "8" in empty field with `ruNumberPriority`', async () => {
+        const onChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                value=''
+                onChange={onChange}
+                dataTestId={testId}
+                ruNumberPriority={true}
+                defaultCountryIso2='ru'
+            />,
+        );
+
+        const input = screen.getByDisplayValue('');
+
+        userEvent.type(input, '8');
+
+        await waitFor(() => {
+            expect(onChange).toBeCalledWith('+7');
+        });
+    });
+
+    it('should call `onChange` with value "+7 9" when type "9" in empty field with `ruNumberPriority`', async () => {
+        const onChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                value=''
+                onChange={onChange}
+                dataTestId={testId}
+                ruNumberPriority={true}
+                defaultCountryIso2='ru'
+            />,
+        );
+
+        const input = screen.getByDisplayValue('');
+
+        userEvent.type(input, '9');
+
+        await waitFor(() => {
+            expect(onChange).toBeCalledWith('+7 9');
+        });
+    });
+
+    it('should call `onChange` with value "+7" when type "7" in empty field with `ruNumberPriority`', async () => {
+        const onChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                value=''
+                onChange={onChange}
+                dataTestId={testId}
+                ruNumberPriority={true}
+                defaultCountryIso2='ru'
+            />,
+        );
+
+        const input = screen.getByDisplayValue('');
+
+        userEvent.type(input, '7');
+
+        await waitFor(() => {
+            expect(onChange).toBeCalledWith('+7');
+        });
+    });
+
+    it('should not render country select when use `staticFlag`', () => {
+        const onChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                value=''
+                onChange={onChange}
+                dataTestId={testId}
+                staticFlag={true}
+                defaultCountryIso2='ru'
+            />,
+        );
+
+        const countrySelect = screen.queryByTestId('countries-select');
+
+        expect(countrySelect).toBeNull();
+    });
+
+    it('should show "+" when clear value', async () => {
+        const onChange = jest.fn();
+        render(<IntlPhoneInput value='+7' onChange={onChange} canClear={true} />);
+
+        const clearButton = await screen.findByLabelText('Очистить');
+
+        expect(clearButton).toBeInTheDocument();
+
+        fireEvent.click(clearButton);
+
+        await waitFor(() => {
+            expect(onChange).toBeCalledWith('+');
+        });
     });
 });

--- a/packages/intl-phone-input/src/components/select-field/component.tsx
+++ b/packages/intl-phone-input/src/components/select-field/component.tsx
@@ -3,10 +3,16 @@ import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 import { FieldProps } from '@alfalab/core-components-select';
 import { useFocus } from '@alfalab/hooks';
+import WorldMagnifierMIcon from '@alfalab/icons-glyph/WorldMagnifierMIcon';
 
 import { FlagIcon } from '../flag-icon';
 
 import styles from './index.module.css';
+
+export const EMPTY_COUNTRY_SELECT_FIELD = {
+    value: 'EMPTY_COUNTRY_SELECT_VALUE',
+    key: 'EMPTY_COUNTRY_SELECT_KEY',
+};
 
 export const SelectField: FC<FieldProps> = ({
     selected,
@@ -30,11 +36,13 @@ export const SelectField: FC<FieldProps> = ({
             })}
         >
             <div {...innerProps} className={styles.inner}>
-                {selected && (
-                    <span className={styles.flagIconContainer}>
+                <span className={styles.flagIconContainer}>
+                    {!selected || selected === EMPTY_COUNTRY_SELECT_FIELD ? (
+                        <WorldMagnifierMIcon className={styles.emptyCountryIcon} />
+                    ) : (
                         <FlagIcon country={selected.value} />
-                    </span>
-                )}
+                    )}
+                </span>
                 {Arrow}
             </div>
         </div>

--- a/packages/intl-phone-input/src/components/select-field/index.module.css
+++ b/packages/intl-phone-input/src/components/select-field/index.module.css
@@ -16,6 +16,10 @@
     margin-right: var(--gap-2xs);
 }
 
+.emptyCountryIcon {
+    color: var(--color-light-graphic-secondary);
+}
+
 .disabled {
     cursor: var(--disabled-cursor);
 }

--- a/packages/intl-phone-input/src/components/select/component.tsx
+++ b/packages/intl-phone-input/src/components/select/component.tsx
@@ -10,7 +10,7 @@ import {
 } from '@alfalab/core-components-select';
 import { Country } from '@alfalab/utils';
 
-import { SelectField } from '../select-field';
+import { EMPTY_COUNTRY_SELECT_FIELD, SelectField } from '../select-field';
 import { FlagIcon } from '../flag-icon';
 
 import styles from './index.module.css';
@@ -19,7 +19,7 @@ type CountriesSelectProps = Pick<
     SelectProps,
     'size' | 'dataTestId' | 'disabled' | 'onChange' | 'preventFlip'
 > & {
-    selected: string;
+    selected?: string;
     countries: Country[];
     fieldWidth: number | null;
 };
@@ -69,7 +69,7 @@ export const CountriesSelect: FC<CountriesSelectProps> = ({
                 disabled={disabled}
                 size={size}
                 options={options}
-                selected={selected}
+                selected={selected || EMPTY_COUNTRY_SELECT_FIELD}
                 onChange={onChange}
                 Field={SelectField}
                 OptionsList={renderOptionsList}

--- a/packages/intl-phone-input/src/docs/Component.stories.mdx
+++ b/packages/intl-phone-input/src/docs/Component.stories.mdx
@@ -29,6 +29,10 @@ import Changelog from '../../CHANGELOG.md';
         const size = select('size', ['s', 'm', 'l', 'xl'], 'm');
         const block = boolean('block', false);
         const disabled = boolean('disabled', false);
+        const staticFlag = boolean('staticFlag', false);
+        const canBeEmptyCountry = boolean('canBeEmptyCountry', false);
+        const ruNumberPriority = boolean('ruNumberPriority', false);
+        const canClear = boolean('canClear', false);
         const label = text('label', 'Номер телефона');
         const clearableCountryCode = boolean('clearableCountryCode', true);
         const handleCountryChange = React.useCallback(countryCode => {
@@ -43,6 +47,10 @@ import Changelog from '../../CHANGELOG.md';
                     block={block}
                     label={label}
                     disabled={disabled}
+                    canBeEmptyCountry={canBeEmptyCountry}
+                    staticFlag={staticFlag}
+                    canClear={canClear}
+                    ruNumberPriority={ruNumberPriority}
                     defaultCountryIso2='RU'
                     readOnly={boolean('readOnly', false)}
                     onCountryChange={handleCountryChange}

--- a/packages/intl-phone-input/src/index.module.css
+++ b/packages/intl-phone-input/src/index.module.css
@@ -8,3 +8,16 @@
         padding-left: 0;
     }
 }
+
+.flagIconWrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 24px;
+    height: 24px;
+    margin-left: var(--gap-s);
+}
+
+.emptyCountryIcon {
+    color: var(--color-light-graphic-secondary);
+}

--- a/packages/intl-phone-input/src/utils/preparePasteData.test.ts
+++ b/packages/intl-phone-input/src/utils/preparePasteData.test.ts
@@ -1,0 +1,37 @@
+import { preparePasteData } from './preparePasteData';
+
+describe('preparePasteData', () => {
+    it('should return number with +7 when paste number start with "7" or "8" in empty field', () => {
+        expect(preparePasteData('', '79491234567', 0, 0)).toEqual('+79491234567');
+        expect(preparePasteData('', '89491234567', 0, 0)).toEqual('+79491234567');
+    });
+
+    it('should return number with +7 when paste number doesn\'t start with "7" or "8" in empty field', () => {
+        expect(preparePasteData('', '6491234567', 0, 0)).toEqual('+76491234567');
+        expect(preparePasteData('', '9491234567', 0, 0)).toEqual('+79491234567');
+    });
+
+    it('should return number when paste number start with "+" in empty field', () => {
+        expect(preparePasteData('', '+79491234567', 0, 0)).toEqual('+79491234567');
+    });
+
+    it('should return number when paste number with letters in empty field', () => {
+        expect(preparePasteData('', '123aaa456', 0, 0)).toEqual('+7123456');
+    });
+
+    it('should return number when paste number in field with "+"', () => {
+        expect(preparePasteData('+', '79491234567', 0, 0)).toEqual('+79491234567');
+    });
+
+    it('should return number when paste number in field with partitial number', () => {
+        expect(preparePasteData('+7949', '1234567', 5, 5)).toEqual('+79491234567');
+    });
+
+    it('should return old number when paste only letters in field with partitial number', () => {
+        expect(preparePasteData('+7949', 'aaaaaaa', 5, 5)).toEqual('+7949');
+    });
+
+    it('should return number when paste number in the middle of field', () => {
+        expect(preparePasteData('+7949', '1234567', 2, 2)).toEqual('+71234567949');
+    });
+});

--- a/packages/intl-phone-input/src/utils/preparePasteData.ts
+++ b/packages/intl-phone-input/src/utils/preparePasteData.ts
@@ -1,0 +1,51 @@
+/**
+ * Подготовка данных для вставки из буфера обмена.
+ * @param phoneValue Телефон уже введённый в поле ввода.
+ * @param phoneFromBuffer Текст номера телефона из буфера обмена.
+ * @param input Input в который осуществляется вставка.
+ */
+export function preparePasteData(
+    phoneValue: string,
+    phoneFromBuffer: string,
+    selectionStart?: number,
+    selectionEnd?: number,
+) {
+    const trimNuber = phoneFromBuffer.trim();
+    const cutNumberWithPlus = trimNuber.replace(/[^+\d]/g, '');
+    const isTextHavePlus = cutNumberWithPlus[0] === '+';
+    const cutNumber = trimNuber.replace(/[^\d]/g, '');
+    const isRuNumberInBuffer = cutNumber[0] === '7' || cutNumber[0] === '8';
+    let resultNumber = '';
+
+    // вставка в поле c "+"
+    if (phoneValue === '+') {
+        resultNumber = `+${cutNumber}`;
+        // вставка в поле, в которое введена часть номера
+    } else if (phoneValue) {
+        const startText = phoneValue.substring(0, selectionStart || 0);
+        const endText = phoneValue.substring(selectionEnd || 0);
+        const isSelectPlus = selectionStart === 0 && selectionEnd !== 0;
+
+        if (selectionStart === 0 && selectionEnd === 0 && !isTextHavePlus) {
+            resultNumber = `+${cutNumber}${phoneValue.substring(1)}`.replace(/[^+\d]/g, '');
+        } else if (!isTextHavePlus && !isSelectPlus) {
+            resultNumber = `${startText}${cutNumber}${endText}`.replace(/[^+\d]/g, '');
+        } else if (isTextHavePlus && isSelectPlus) {
+            resultNumber = `${cutNumberWithPlus}${endText}`.replace(/[^+\d]/g, '');
+        }
+        // вставка в пустое поле
+    } else if (!phoneValue) {
+        // вставка номера начинающегося с "+" в пустое поле
+        if (isTextHavePlus) {
+            resultNumber = cutNumberWithPlus;
+            // вставка номера начинающегося с "7" или "8" в пустое поле
+        } else if (isRuNumberInBuffer) {
+            resultNumber = `+7${cutNumber.substring(1)}`;
+            // вставка номера начинающегося НЕ с "7", "8", "+" в пустое поле
+        } else {
+            resultNumber = `+7${cutNumber}`;
+        }
+    }
+
+    return resultNumber;
+}


### PR DESCRIPTION
макеты https://www.figma.com/file/cdNnkh2QdxuvYLrBm4cubM/branch/pxLATDZssLAEKvbtCMeQdP/Web-%3A%3A-Core-Default-Components?node-id=65619%3A78962
добавлены пропсы:
staticFlag - отключает селект выбора страны
canBeEmptyCountry - добавляет состояние невыбранной страны
ruNumberPriority - приоритет ввода российского номера (при дефолтно выбранном российском флаге ввод числа добавит 
 +7)
canClear - необходим для сброса страны при очистке поля
