### PR TITLE
fix(picker-button): removed option divider

### DIFF
--- a/.changeset/eighty-yaks-heal.md
+++ b/.changeset/eighty-yaks-heal.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-picker-button': patch
+---
+
+Удалены разделители опций в выпадающем списке для темы "click"

--- a/packages/picker-button/src/index.module.css
+++ b/packages/picker-button/src/index.module.css
@@ -19,5 +19,10 @@
 
     & .option {
         padding: 0 var(--gap-m);
+
+        &:before {
+            /* Удаляем разделители у опций выпадающего списка. */
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
Удалены разделители опций в выпадающем списке в теме клика