### PR TITLE
fix(modal): add icons-glyph dependency

### DIFF
--- a/.changeset/eleven-guests-vanish.md
+++ b/.changeset/eleven-guests-vanish.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-modal': patch
+---
+
+Добавили зависимость @alfalab/icons-glyph в компонент Modal

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -17,6 +17,7 @@
         "@alfalab/core-components-button": "^6.1.2",
         "@alfalab/core-components-icon-button": "^5.0.5",
         "@alfalab/core-components-mq": "^4.0.1",
+        "@alfalab/icons-glyph": "^2.71.0",
         "classnames": "^2.3.1",
         "react-transition-group": "^4.4.1"
     },


### PR DESCRIPTION
У модалки не было зависимости @alfalab/icons-glyph, а иконка используется в компоненте Modal / Closer
