### PR TITLE
fix(calendar-range): fix divider margin

### DIFF
--- a/packages/calendar-range/src/docs/description.mdx
+++ b/packages/calendar-range/src/docs/description.mdx
@@ -86,3 +86,51 @@ render(() => {
     );
 });
 ```
+
+
+### C внешним лейблом для CalendarInput
+
+```jsx live
+// import { startOfDay, subMonths, addMonths, startOfMonth, startOfDay } from 'date-fns';
+// import { parseDateString } from '@alfalab/core-components/calendar-input';
+
+render(() => {
+    const [calendarPosition, setCalendarPosition] = React.useState('static');
+
+    const defaultDate = parseDateString('10.03.2022');
+    const [valueFrom, setValueFrom] = React.useState({ value: '', date: null });
+    const [valueTo, setValueTo] = React.useState({ value: '', date: null });
+
+    const minDate = subMonths(startOfDay(defaultDate), 3).getTime();
+    const maxDate = addMonths(startOfDay(defaultDate), 3).getTime();
+
+    return (
+        <Space size='l'>
+            <RadioGroup
+                label='calendarPosition'
+                direction='horizontal'
+                onChange={(_, { value }) => setCalendarPosition(value)}
+                value={calendarPosition}
+            >
+                <Radio label='static' value='static' />
+                <Radio label='popover' value='popover' />
+            </RadioGroup>
+            <CalendarRange
+                valueFrom={valueFrom.value}
+                valueTo={valueTo.value}
+                inputFromProps={ { label: 'Дата начала', labelView: 'outer' } }
+                inputToProps={ { label: 'Дата окончания', labelView: 'outer' } }
+                minDate={minDate}
+                maxDate={maxDate}
+                defaultMonth={startOfMonth(defaultDate)}
+                offDays={[startOfDay(defaultDate)]}
+                calendarPosition={calendarPosition}
+                onChange={({ valueFrom, valueTo, dateFrom, dateTo }) => {
+                    setValueFrom({ value: valueFrom, date: dateFrom });
+                    setValueTo({ value: valueTo, date: dateTo });
+                }}
+            />
+        </Space>
+    );
+});
+```

--- a/packages/calendar-range/src/views/index.module.css
+++ b/packages/calendar-range/src/views/index.module.css
@@ -34,6 +34,10 @@
     }
 }
 
+.outerLabel {
+    margin-top: 24px;
+}
+
 .static {
     & .calendar {
         width: var(--calendar-inner-width);

--- a/packages/calendar-range/src/views/popover.tsx
+++ b/packages/calendar-range/src/views/popover.tsx
@@ -169,6 +169,18 @@ export const CalendarRangePopover: FC<CalendarRangePopoverProps> = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasValidateError]);
 
+    const checkForLabel = () => {
+        if (
+            inputFromProps.label &&
+            inputFromProps.labelView === 'outer' &&
+            inputToProps.label &&
+            inputToProps.labelView === 'outer'
+        ) {
+            return styles.outerLabel;
+        }
+        return '';
+    };
+
     return (
         <div className={cn(styles.component, className)} data-test-id={dataTestId}>
             <CalendarInput
@@ -193,7 +205,7 @@ export const CalendarRangePopover: FC<CalendarRangePopoverProps> = ({
                 }}
             />
 
-            <span className={styles.divider} />
+            <span className={cn(styles.divider, checkForLabel())} />
 
             <CalendarInput
                 {...inputToProps}

--- a/packages/calendar-range/src/views/static.tsx
+++ b/packages/calendar-range/src/views/static.tsx
@@ -225,6 +225,18 @@ export const CalendarRangeStatic: FC<CalendarRangeStaticProps> = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasValidateError]);
 
+    const checkForLabel = () => {
+        if (
+            inputFromProps.label &&
+            inputFromProps.labelView === 'outer' &&
+            inputToProps.label &&
+            inputToProps.labelView === 'outer'
+        ) {
+            return styles.outerLabel;
+        }
+        return '';
+    };
+
     const rangeProps = useSelectionProps(period.selectedFrom, period.selectedTo, highlightedDate);
 
     const { calendarProps: calendarFromProps, ...dateInputFromProps } = inputFromProps;
@@ -271,7 +283,7 @@ export const CalendarRangeStatic: FC<CalendarRangeStaticProps> = ({
                 />
             </div>
 
-            <span className={styles.divider} />
+            <span className={cn(styles.divider, checkForLabel())} />
 
             <div>
                 <DateInput


### PR DESCRIPTION
# Опишите проблему
Divider в CalendarRange уплывает вверх при наличии label у CalendarInput

# Шаги для воспроизведения
1. Добавить label в пропсы inputFromProps и inputToProps
2. Так же указать label внешним = labelView: 'outer'

# Ожидаемое поведение
Ожидается что Divider будет находится по середине с инпутом

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый     
<img width="529" alt="Снимок экрана 2022-10-20 в 21 15 24" src="https://user-images.githubusercontent.com/56194853/197030546-7f14ad99-1281-48b5-b4df-5a0c6881c581.png">
Фактический
<img width="526" alt="Снимок экрана 2022-10-20 в 21 36 38" src="https://user-images.githubusercontent.com/56194853/197030590-a7e43b3b-ff85-445c-a437-69424ef2ab4f.png">


# Дополнительная информация
Реализация не идеальна, можно подумать над более элегантной реализацией
