### PR TITLE
feat(picker-button): show default button icon if right addon exists

### DIFF
--- a/.changeset/blue-ads-laugh.md
+++ b/.changeset/blue-ads-laugh.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-picker-button': major
+---
+
+При наличии правого аддона, дефолтная иконка кнопки не исчезает

--- a/packages/picker-button/src/field/Component.tsx
+++ b/packages/picker-button/src/field/Component.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, FC, SVGProps } from 'react';
+import React, { ButtonHTMLAttributes, FC, Fragment, SVGProps } from 'react';
 import cn from 'classnames';
 
 import { Button, ButtonProps } from '@alfalab/core-components-button';
@@ -47,7 +47,11 @@ export const Field = ({
             <Button
                 {...buttonProps}
                 rightAddons={
-                    rightAddons ?? (
+                    <Fragment>
+                        {rightAddons && (
+                            <span className={styles.addonsContainer}>{rightAddons}</span>
+                        )}
+
                         <span
                             className={cn(
                                 styles.iconContainer,
@@ -56,7 +60,7 @@ export const Field = ({
                         >
                             <Icon data-test-id='picker-button-icon' />
                         </span>
-                    )
+                    </Fragment>
                 }
                 block={true}
                 view={view}

--- a/packages/picker-button/src/field/index.module.css
+++ b/packages/picker-button/src/field/index.module.css
@@ -5,6 +5,11 @@
     transition: transform 0.15s ease-in-out;
 }
 
+.addonsContainer {
+    display: flex;
+    margin-right: var(--gap-2xs);
+}
+
 .open {
     transform: var(--arrow-transform);
 }


### PR DESCRIPTION
BREAKING CHANGE: При наличии правого аддона, дефолтная иконка кнопки не исчезает