### PR TITLE
feat(picker-button): extend options type

### DIFF
--- a/.changeset/hip-elephants-decide.md
+++ b/.changeset/hip-elephants-decide.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-picker-button": minor
+---
+
+feat(picker-button): extend options type

--- a/packages/picker-button/src/Component.test.tsx
+++ b/packages/picker-button/src/Component.test.tsx
@@ -156,4 +156,17 @@ describe('Render tests', () => {
             expect(container.getElementsByClassName('sideGap')).not.toBeNull();
         },
     );
+
+    it.each(pickerButtonVariants)('options group should have label', async (Component) => {
+        render(<Component options={[{ label: 'Валютный счёт', options }]} />);
+
+        clickPickerButton();
+
+        await waitFor(() => {
+            const renderedGroup = document.querySelector('.optgroup');
+
+            expect(renderedGroup).not.toBeNull();
+            expect(renderedGroup).toHaveTextContent('Валютный счёт');
+        });
+    });
 });

--- a/packages/picker-button/src/Component.tsx
+++ b/packages/picker-button/src/Component.tsx
@@ -6,7 +6,6 @@ import {
     BaseSelect,
     BaseSelectProps,
     Optgroup as DefaultOptgroup,
-    OptionShape,
     OptionsList as DefaultOptionsList,
 } from '@alfalab/core-components-select';
 
@@ -39,7 +38,7 @@ export type PickerButtonDesktopProps = Omit<
 > &
     Pick<ButtonProps, 'view' | 'loading' | 'leftAddons' | 'rightAddons'> & {
         options: Array<
-            OptionShape & {
+            BaseSelectProps['options'][0] & {
                 /**
                  * Иконка, отображающаяся слева от текстового представления пункта
                  */


### PR DESCRIPTION
# Опишите проблему
Фактически, компонент ButtonPicker поддерживается список опций в группе, но в интерфейсе это не указано
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/20581251/202737048-ededa134-7f57-4990-a05f-13780280471c.png">

Исправил тип

[Пример отображения группы в списке](https://core-ds.github.io/core-components/master/?path=/docs/%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D1%8B-%D0%BF%D0%B5%D1%81%D0%BE%D1%87%D0%BD%D0%B8%D1%86%D0%B0--page/code=const%20options%20%3D%20%5B%7B%0A%20%20%20%20label%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%B3%D1%80%D1%83%D0%BF%D0%BF%D1%8B%27%2C%0A%20%20%20%20options%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%20%D0%B4%D0%BB%D0%B8%D0%BD%D0%BD%D0%BE%D0%B3%D0%BE%20%D0%BD%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D1%8F%27%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%BE%D0%BF%D1%86%D0%B8%D0%B8%27%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%BE%D0%BF%D1%86%D0%B8%D0%B8%27%20%7D%2C%0A%20%20%20%20%5D%0A%7D%2C%7B%0A%20%20%20%20label%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%B3%D1%80%D1%83%D0%BF%D0%BF%D1%8B%202%27%2C%0A%20%20%20%20options%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%20%D0%B4%D0%BB%D0%B8%D0%BD%D0%BD%D0%BE%D0%B3%D0%BE%20%D0%BD%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D1%8F%27%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%BE%D0%BF%D1%86%D0%B8%D0%B8%27%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%7B%20key%3A%20%27%D0%9D%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%BE%D0%BF%D1%86%D0%B8%D0%B8%27%20%7D%2C%0A%20%20%20%20%5D%0A%7D%0A%5D%3B%0A%0Arender(%3CPickerButton%20options%3D%7Boptions%7D%20view%3D%27primary%27%20label%3D%27Picker%20button%27%20%2F%3E)%3B)