### PR TITLE
fix(calendar-range): correct divider position

### DIFF
--- a/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
@@ -699,7 +699,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
       </div>
     </div>
     <span
-      class="divider"
+      class="component s"
     />
     <div>
       <div

--- a/packages/calendar-range/src/components/divider/Component.tsx
+++ b/packages/calendar-range/src/components/divider/Component.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import cn from 'classnames';
+
+import { CalendarRangeProps } from '../../Component';
+
+import styles from './index.module.css';
+
+type Props = {
+    inputFromProps?: CalendarRangeProps['inputFromProps'];
+    inputToProps?: CalendarRangeProps['inputToProps'];
+};
+
+export const Divider: FC<Props> = ({ inputFromProps, inputToProps }) => {
+    const outer =
+        inputFromProps?.label &&
+        inputFromProps?.labelView === 'outer' &&
+        inputToProps?.label &&
+        inputToProps?.labelView === 'outer';
+
+    const size = inputFromProps?.size || inputToProps?.size || 's';
+
+    return <span className={cn(styles.component, styles[size], { [styles.outer]: outer })} />;
+};

--- a/packages/calendar-range/src/components/divider/index.module.css
+++ b/packages/calendar-range/src/components/divider/index.module.css
@@ -1,0 +1,41 @@
+@import '../../../../themes/src/default.css';
+@import '../../../../calendar/src/vars.css';
+
+.component {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    margin: 0 var(--gap-xs);
+
+    &:after {
+        content: '';
+        display: block;
+        width: 100%;
+        height: 1px;
+        background-color: var(--color-light-graphic-primary);
+    }
+}
+
+.outer {
+    position: relative;
+
+    /* FormControl .above height + margin-bottom */
+    top: 24px;
+}
+
+.s {
+    height: var(--size-s-height);
+}
+
+.m {
+    height: var(--size-m-height);
+}
+
+.l {
+    height: var(--size-l-height);
+}
+
+.xl {
+    height: var(--size-xl-height);
+}

--- a/packages/calendar-range/src/components/divider/index.ts
+++ b/packages/calendar-range/src/components/divider/index.ts
@@ -1,0 +1,1 @@
+export * from './Component';

--- a/packages/calendar-range/src/views/index.module.css
+++ b/packages/calendar-range/src/views/index.module.css
@@ -17,23 +17,6 @@
     }
 }
 
-.divider {
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 16px;
-    margin: 0 var(--gap-xs);
-
-    &:after {
-        content: '';
-        display: block;
-        width: 100%;
-        height: 1px;
-        background-color: var(--color-light-graphic-primary);
-    }
-}
-
 .static {
     & .calendar {
         width: var(--calendar-inner-width);

--- a/packages/calendar-range/src/views/popover.tsx
+++ b/packages/calendar-range/src/views/popover.tsx
@@ -11,6 +11,7 @@ import {
 import { isCompleteDateInput } from '@alfalab/core-components-date-input';
 
 import { CalendarRangeProps } from '../Component';
+import { Divider } from '../components/divider';
 import { usePopoverViewMonthes } from '../hooks';
 
 import styles from './index.module.css';
@@ -190,7 +191,7 @@ export const CalendarRangePopover: FC<CalendarRangePopoverProps> = ({
                 }}
             />
 
-            <span className={styles.divider} />
+            <Divider inputFromProps={inputFromProps} inputToProps={inputToProps} />
 
             <CalendarInput
                 {...inputToProps}

--- a/packages/calendar-range/src/views/static.tsx
+++ b/packages/calendar-range/src/views/static.tsx
@@ -20,6 +20,7 @@ import {
 } from '@alfalab/core-components-date-input';
 
 import { CalendarRangeProps } from '../Component';
+import { Divider } from '../components/divider';
 import { useSelectionProps, useStaticViewMonthes } from '../hooks';
 import { isDayButton } from '../utils';
 
@@ -274,7 +275,7 @@ export const CalendarRangeStatic: FC<CalendarRangeStaticProps> = ({
                 />
             </div>
 
-            <span className={styles.divider} />
+            <Divider inputFromProps={inputFromProps} inputToProps={inputToProps} />
 
             <div>
                 <DateInput


### PR DESCRIPTION
# Опишите проблему
Divider в CalendarRange уплывает вверх при наличии label у CalendarInput

# Шаги для воспроизведения
1. Добавить label в пропсы inputFromProps и inputToProps
2. Так же указать label внешним = labelView: 'outer'

# Ожидаемое поведение
Ожидается что Divider будет находится по середине с инпутом

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый     
<img width="529" alt="Снимок экрана 2022-10-20 в 21 15 24" src="https://user-images.githubusercontent.com/56194853/197030546-7f14ad99-1281-48b5-b4df-5a0c6881c581.png">
Фактический
<img width="526" alt="Снимок экрана 2022-10-20 в 21 36 38" src="https://user-images.githubusercontent.com/56194853/197030590-a7e43b3b-ff85-445c-a437-69424ef2ab4f.png">

