### PR TITLE
fix(textarea): некорректный размер PseudoTextarea 

### DIFF
--- a/.changeset/stupid-mayflies-give.md
+++ b/.changeset/stupid-mayflies-give.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-textarea': patch
+---
+
+Исправлено некорректное выделение текста который превышает maxLength

--- a/packages/textarea/src/components/PseudoTextArea.tsx
+++ b/packages/textarea/src/components/PseudoTextArea.tsx
@@ -18,8 +18,8 @@ export const PseudoTextArea = forwardRef<HTMLDivElement, PseudoTextAreaProps>(
         >
             <span>{stateValue.slice(0, maxLength)}</span>
             <span className={cn(styles.overflow)}>{stateValue.slice(maxLength)}</span>
-            {/* Пробел нужен для правильной позиции */}
-            &nbsp;
+            {/* Перенос строки нужен для правильной позиции */}
+            <br />
         </div>
     ),
 );

--- a/packages/textarea/src/index.module.css
+++ b/packages/textarea/src/index.module.css
@@ -284,3 +284,23 @@
         }
     }
 }
+
+/* Correct pseudoTextarea size */
+
+.pseudoTextarea.filled.hasInnerLabel {
+    &.s {
+        height: calc(100% - var(--textarea-s-filled-margin-top));
+    }
+
+    &.m {
+        height: calc(100% - var(--textarea-m-filled-margin-top));
+    }
+
+    &.l {
+        height: calc(100% - var(--textarea-l-filled-margin-top));
+    }
+
+    &.xl {
+        height: calc(100% - var(--textarea-xl-filled-margin-top));
+    }
+}


### PR DESCRIPTION
# Опишите проблему
 Если есть лейбл и нативный скроллбар то размер PseudoTextarea некорректный и мы видим выделение не в том месте где необходимо 

# Шаги для воспроизведения
1. Перейти на страницу textarea
2. Добавить пропсы maxLength, showCounter, label, nativeScrollbar.
3 Переполнить textarea

# Ожидаемое поведение
Выделение текста который превышает maxLength

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид


# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):


## Смартфон (если данных нет оставте блок пустым):


# Дополнительная информация

