### PR TITLE
chore: fix purgecss script

### DIFF
--- a/bin/purgecss.sh
+++ b/bin/purgecss.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# удаляем неиспользуемые css-переменные из сборки в root-пакете
-node --max-old-space-size=4096 bin/purgecss.js
-
 # удаляем неиспользуемые css-переменные из сборки во всех подпакетах
-lerna exec --parallel -- node ../../bin/purgecss.js
+lerna exec --concurrency 10 node ../../bin/purgecss.js


### PR DESCRIPTION
- До этого фикса purgeCss для рут пакета запускался в одном потоке и скоуп js файлов для поиска был не ограничен(включал в себя весь dist). 
- После фикса будет параллельно запускаться 10 процессов и скоуп поиска будет ограничен отдельным пакетом(action-button, amount и т.п), а не всем dist.

PurgeCss до фикса отрабатывал примерно за 10 минут, после около 30 сек.
