### PR TITLE
fix(intl-phone-input): fix cleare dialcode

### DIFF
--- a/.changeset/ten-shrimps-mix.md
+++ b/.changeset/ten-shrimps-mix.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-intl-phone-input": patch
+---
+
+Исправлен дефект позволяющий удалить `dialCode` при выключеном `clearableCountryCode`

--- a/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
+++ b/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
@@ -43,8 +43,32 @@ exports[`IntlPhoneInput should match snapshot 1`] = `
                     class="flagIconContainer"
                   >
                     <span
-                      class="flagIcon ru"
-                    />
+                      class="flagIcon"
+                      data-test-id="flag-icon-ru"
+                    >
+                      <svg
+                        fill="none"
+                        height="24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M22.2 4.1H1.8C.8 4.1 0 5 0 6v3.5h24V5.9c0-1-.8-1.8-1.8-1.8Z"
+                          fill="#F5F5F5"
+                        />
+                        <path
+                          d="M0 18C0 19 .8 20 1.8 20h20.4c1 0 1.8-.8 1.8-1.8v-3.5H0v3.5Z"
+                          fill="#FF4B55"
+                        />
+                        <path
+                          d="M24 9.4H0v5.2h24V9.4Z"
+                          fill="#41479B"
+                        />
+                      </svg>
+                    </span>
                   </span>
                   <svg
                     class="arrow"

--- a/packages/intl-phone-input/src/component.test.tsx
+++ b/packages/intl-phone-input/src/component.test.tsx
@@ -367,7 +367,7 @@ describe('IntlPhoneInput', () => {
 
         const input = screen.getByDisplayValue('+7 928 123-45-67');
 
-        userEvent.clear(input);
+        await userEvent.clear(input);
 
         await waitFor(() => {
             expect(onChange).toHaveBeenCalledWith('+7');

--- a/packages/intl-phone-input/src/component.test.tsx
+++ b/packages/intl-phone-input/src/component.test.tsx
@@ -59,11 +59,11 @@ describe('IntlPhoneInput', () => {
     });
 
     it('should have default country flag icon', () => {
-        const { container } = render(<IntlPhoneInput value='' onChange={jest.fn()} />);
+        render(<IntlPhoneInput value='' onChange={jest.fn()} />);
 
-        const flagComponent = container.querySelector('.flagIcon');
+        const flagComponent = screen.getByTestId('flag-icon-ru');
 
-        expect(flagComponent).toHaveClass('ru');
+        expect(flagComponent).toBeInTheDocument();
     });
 
     it('should have passed country flag icon', () => {
@@ -73,13 +73,18 @@ describe('IntlPhoneInput', () => {
 
         const flagComponent = container.querySelector('.flagIcon');
 
-        expect(flagComponent).toHaveClass('az');
+        expect(flagComponent).toHaveAttribute('data-test-id', 'flag-icon-az');
     });
 
     it('should set new country flag icon from props', async () => {
         const { container } = render(<IntlPhoneInput value='+61' onChange={jest.fn()} />);
 
-        await waitFor(() => expect(container.querySelector('.flagIcon')).toHaveClass('au'));
+        await waitFor(() =>
+            expect(container.querySelector('.flagIcon')).toHaveAttribute(
+                'data-test-id',
+                'flag-icon-au',
+            ),
+        );
     });
 
     it('should call `onChange` callback after select was changed', async () => {
@@ -315,7 +320,7 @@ describe('IntlPhoneInput', () => {
         });
     });
 
-    it.only('should format number when set unformated value', async () => {
+    it('should format number when set unformated value', async () => {
         const onChange = jest.fn();
         const onCountryChange = jest.fn();
         const RenderComponent = () => {
@@ -347,6 +352,25 @@ describe('IntlPhoneInput', () => {
         await waitFor(async () => {
             expect(onChange).toHaveBeenCalledWith('+7 949 123-45-67');
             expect(onCountryChange).toHaveBeenCalledWith('RU');
+        });
+    });
+
+    it('should be not clearable country code', async () => {
+        const onChange = jest.fn();
+        render(
+            <IntlPhoneInput
+                clearableCountryCode={false}
+                value='+7 928 123-45-67'
+                onChange={onChange}
+            />,
+        );
+
+        const input = screen.getByDisplayValue('+7 928 123-45-67');
+
+        userEvent.clear(input);
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith('+7');
         });
     });
 });

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -214,10 +214,21 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
             return targetCountry;
         };
 
+        const addCountryCode = (inputValue: string) => {
+            if (clearableCountryCode || !countryIso2) {
+                return inputValue.length === 1 && inputValue !== '+'
+                    ? `+${inputValue}`
+                    : inputValue;
+            }
+            const country = countriesHash[countryIso2];
+
+            return formatPhoneWithUnclearableCountryCode(inputValue, country);
+        };
+
         const setCountryByDialCode = (inputValue: string) => {
             const country = getCountryByNumber(inputValue);
 
-            onChange(formatPhone(inputValue));
+            onChange(formatPhone(addCountryCode(inputValue)));
             if (country) {
                 setCountryIso2(country.iso2);
                 handleCountryChange(country.iso2);
@@ -235,17 +246,6 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
                     setCountryByDialCode(inputValue);
                 }
             }
-        };
-
-        const addCountryCode = (inputValue: string) => {
-            if (clearableCountryCode || !countryIso2) {
-                return inputValue.length === 1 && inputValue !== '+'
-                    ? `+${inputValue}`
-                    : inputValue;
-            }
-            const country = countriesHash[countryIso2];
-
-            return formatPhoneWithUnclearableCountryCode(inputValue, country);
         };
 
         const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/intl-phone-input/src/components/flag-icon/component.tsx
+++ b/packages/intl-phone-input/src/components/flag-icon/component.tsx
@@ -23,6 +23,7 @@ export const FlagIcon: FC<FlagIconProps> = ({ country = '', className }) =>
     flagSprite[country] ? (
         <span
             className={cn(styles.flagIcon, className)}
+            data-test-id={`flag-icon-${country}`}
             dangerouslySetInnerHTML={{ __html: flagSprite[country] }}
         />
     ) : (


### PR DESCRIPTION
При выключенном пропсе clearableCountryCode можно было нажать ctrl+a и потом удалить весь номер вместе с кодом страны. Теперь код страны остаётся