### PR TITLE
chore: code editor themes

### DIFF
--- a/.storybook/addons/mode-switcher/utils.js
+++ b/.storybook/addons/mode-switcher/utils.js
@@ -1,6 +1,7 @@
 import { getMobileFrames, getOrCreateStyleTag } from '../utils';
 
 import darkStyles from '!!postcss-loader!./dark.css';
+import codeEditorDarkTheme from '!!postcss-loader!../../blocks/code-editor/github-dark-theme.css';
 
 export const MODES = ['light', 'dark'];
 export const MODE_COLORS_TAG_ID = 'mode-colors';
@@ -20,7 +21,7 @@ export function setModeVarsInMobileFrame(mode) {
 }
 
 export function setModeVars(mode, doc) {
-    const vars = mode === 'dark' ? darkStyles : '';
+    const vars = mode === 'dark' ? `${darkStyles}\n${codeEditorDarkTheme}` : '';
 
     getOrCreateStyleTag(MODE_COLORS_TAG_ID, null, doc).innerHTML = vars;
 }

--- a/.storybook/blocks/code-editor/github-dark-theme.css
+++ b/.storybook/blocks/code-editor/github-dark-theme.css
@@ -1,0 +1,75 @@
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #8b949e;
+}
+.token.interpolation,
+.token.property,
+.token.tag,
+.token.attr-name,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #79c0ff;
+}
+.token-line > span[class='token tag'],
+.token.tag.class-name,
+.token.script.punctuation {
+    color: #7ee787;
+}
+.token.parameter {
+    color: #ffa657;
+}
+span[class='token tag script language-javascript tag punctuation'] {
+    color: #c9d1d9 !important;
+}
+.token.punctuation {
+    color: #c9d1d9;
+}
+.token.selector,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #a5d6ff;
+}
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+    color: #a5d6ff;
+    background: #161b22;
+}
+.token.tag.script.script-punctuation.punctuation,
+.token.tag.attr-value.punctuation.attr-equals,
+.token.atrule,
+.token.attr-value,
+.token.keyword,
+.token.operator {
+    color: #ff7b72;
+}
+.token.function,
+.token.class-name,
+.token.tag.script.parameter.punctuation {
+    color: #d2a8ff;
+}
+.token.regex,
+.token.important,
+.token.variable,
+.token.tag.attr-value,
+.token.tag.attr-value.punctuation {
+    color: #a8daff;
+}
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
+.token.italic {
+    font-style: italic;
+}
+.token.entity {
+    cursor: help;
+}

--- a/.storybook/blocks/code-editor/github-light-theme.css
+++ b/.storybook/blocks/code-editor/github-light-theme.css
@@ -1,0 +1,74 @@
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #6e7781;
+}
+.token.interpolation,
+.token.property,
+.token.tag,
+.token.attr-name,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #0550ae;
+}
+.token-line > span[class='token tag'],
+.token.tag.class-name,
+.token.script.punctuation {
+    color: #116329;
+}
+.token.parameter {
+    color: #953800;
+}
+span[class='token tag script language-javascript tag punctuation'] {
+    color: #24292f !important;
+}
+.token.punctuation {
+    color: #24292f;
+}
+.token.selector,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #0a3069;
+}
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+    color: #0550ae;
+}
+.token.tag.script.script-punctuation.punctuation,
+.token.tag.attr-value.punctuation.attr-equals,
+.token.atrule,
+.token.attr-value,
+.token.keyword,
+.token.operator {
+    color: #cf222e;
+}
+.token.function,
+.token.class-name,
+.token.tag.script.parameter.punctuation {
+    color: #8250df;
+}
+.token.regex,
+.token.important,
+.token.variable,
+.token.tag.attr-value,
+.token.tag.attr-value.punctuation {
+    color: #0a3069;
+}
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
+.token.italic {
+    font-style: italic;
+}
+.token.entity {
+    cursor: help;
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,6 +6,7 @@ import { setGuidelinesStyles } from './addons/utils';
 import { LIVE_EXAMPLES_ADDON_ID } from 'storybook-addon-live-examples';
 
 import guidelinesStyles from '!!postcss-loader!./public/guidelines.css';
+import './blocks/code-editor/github-light-theme.css';
 
 import alfaTheme from './theme';
 import scope from './scope';
@@ -17,8 +18,11 @@ if (window.location.href.includes('guidelines')) {
     setGuidelinesStyles(guidelinesStyles);
 }
 
+const editorTheme = { styles: [] };
+
 addons.setConfig({
     [LIVE_EXAMPLES_ADDON_ID]: {
+        editorTheme,
         sandboxPath: '/docs/sandbox--page',
         mobileFrameName: 'mobileframe--page',
         desktopText: 'Переключить на декстопную версию',

--- a/.storybook/public/global.css
+++ b/.storybook/public/global.css
@@ -485,6 +485,10 @@ pre.sbdocs-pre > div {
     margin: 0;
 }
 
+pre.sbdocs-pre div[code] {
+    font-family: Menlo, Monaco, 'Courier New', monospace !important;
+}
+
 pre.sbdocs-pre.sbdocs {
     margin: var(--gap-xl) 0;
 }


### PR DESCRIPTION
К сожалению невозможно точь-в-точь перенести тему из vscode - https://vscodethemes.com/e/github.github-vscode-theme/github-dark-dimmed?language=javascript. Prism.js парсит код все же примитивнее вскода:) 