### PR TITLE
feat(pure-cell): replace flex gap to margins for correct work on ios13

### DIFF
--- a/packages/pure-cell/src/index.module.css
+++ b/packages/pure-cell/src/index.module.css
@@ -11,14 +11,20 @@
 .horizontal {
     display: flex;
     width: 100%;
-    grid-column-gap: var(--gap-m);
+
+    & > section:not(:last-child) {
+        margin-right: var(--gap-m);
+    }
 }
 
 .vertical {
     display: flex;
     align-items: center;
     flex-direction: column;
-    grid-row-gap: var(--gap-s);
+
+    & > section:not(:last-child) {
+        margin-bottom: var(--gap-s);
+    }
 }
 
 .button {


### PR DESCRIPTION
# Опишите проблему
Не применяются отступы(gap) для чалдов flex контейнера компонента PureCell на ios13 и ниже. 
https://caniuse.com/?search=flex-gap

# Шаги для воспроизведения
1. Открыть https://core-ds.github.io/core-components/master/?path=/docs/components-cells-purecell--pure-cell
на ios13

# Ожидаемое поведение
Отступы остаются на ios13 и ниже. 




