### PR TITLE
fix(textarea): фикс бага переполнения при переданом пропсе value

### DIFF
--- a/.changeset/lovely-pandas-mate.md
+++ b/.changeset/lovely-pandas-mate.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-textarea': patch
+---
+
+Исправлен баг в textarea, при передаче пропа value не работала механика переполнения

--- a/packages/textarea/src/Component.tsx
+++ b/packages/textarea/src/Component.tsx
@@ -78,8 +78,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         const filled = Boolean(uncontrolled ? stateValue : value);
         const hasInnerLabel = label && labelView === 'inner';
         const hasOverflow = Boolean(
-            (maxLength && stateValue.slice(maxLength)) || (maxLength && value?.slice(maxLength)),
-        );
+            (maxLength && value?.slice(maxLength)) || (maxLength && stateValue.slice(maxLength)),
+        );  
 
         useEffect(() => {
             const pseudoNode = pseudoTextareaRef.current;
@@ -209,7 +209,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                         <PseudoTextArea
                             value={value ?? stateValue}
                             size={size}
-                            maxLength={maxLength}
+                            maxLength={maxLength as number}
                             pseudoTextareaClassName={cn(
                                 textareaClassNameCalc,
                                 styles.customScrollbar,
@@ -290,7 +290,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                             <PseudoTextArea
                                 value={value ?? stateValue}
                                 size={size}
-                                maxLength={maxLength}
+                                maxLength={maxLength as number}
                                 pseudoTextareaClassName={cn(
                                     textareaClassNameCalc,
                                     styles.nativeScrollbar,

--- a/packages/textarea/src/Component.tsx
+++ b/packages/textarea/src/Component.tsx
@@ -77,7 +77,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
         const filled = Boolean(uncontrolled ? stateValue : value);
         const hasInnerLabel = label && labelView === 'inner';
-        const hasOverflow = Boolean(maxLength && stateValue.slice(maxLength));
+        const hasOverflow = Boolean(
+            (maxLength && stateValue.slice(maxLength)) || (maxLength && value?.slice(maxLength)),
+        );
 
         useEffect(() => {
             const pseudoNode = pseudoTextareaRef.current;
@@ -205,7 +207,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 >
                     {hasOverflow && (
                         <PseudoTextArea
-                            stateValue={stateValue}
+                            value={value ?? stateValue}
                             size={size}
                             maxLength={maxLength}
                             pseudoTextareaClassName={cn(
@@ -216,7 +218,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                         />
                     )}
 
-                    <TextareaAutosize {...textareaProps} minRows={minRowsValue} />
+                    <TextareaAutosize
+                        {...textareaProps}
+                        minRows={minRowsValue}
+                        style={{ overflow: 'hidden' }}
+                    />
 
                     {/* Используется только для вычисления размера контейнера */}
                     <TextareaAutosize
@@ -282,7 +288,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                     <>
                         {hasOverflow && (
                             <PseudoTextArea
-                                stateValue={stateValue}
+                                value={value ?? stateValue}
                                 size={size}
                                 maxLength={maxLength}
                                 pseudoTextareaClassName={cn(

--- a/packages/textarea/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Component.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`Textarea Snapshots tests should match snapshot with custom scrollbar 1`
                         autocomplete="on"
                         class="textarea textarea s"
                         rows="1"
+                        style="overflow: hidden;"
                       >
                         value
                       </textarea>

--- a/packages/textarea/src/components/PseudoTextArea.tsx
+++ b/packages/textarea/src/components/PseudoTextArea.tsx
@@ -13,7 +13,11 @@ type PseudoTextAreaProps = {
      * Значение PseudoTextArea, разделяется на 2 части по maxLength
      */
     value: string;
-} & Pick<TextareaIncomeProps, 'size' | 'maxLength'>;
+    /**
+     * Максимальное количество символов, символы свыше maxLength будут выделены
+     */
+    maxLength: number;
+} & Pick<TextareaIncomeProps, 'size'>;
 
 export const PseudoTextArea = forwardRef<HTMLDivElement, PseudoTextAreaProps>(
     ({ size = 's', pseudoTextareaClassName, maxLength, value }, ref) => (

--- a/packages/textarea/src/components/PseudoTextArea.tsx
+++ b/packages/textarea/src/components/PseudoTextArea.tsx
@@ -5,19 +5,25 @@ import styles from '../index.module.css';
 import { TextareaIncomeProps } from '../typings';
 
 type PseudoTextAreaProps = {
-    pseudoTextareaClassName: string;
-    stateValue: string;
-} & TextareaIncomeProps;
+    /**
+     * Дополнительный класс компонента
+     */
+    pseudoTextareaClassName?: string;
+    /**
+     * Значение PseudoTextArea, разделяется на 2 части по maxLength
+     */
+    value: string;
+} & Pick<TextareaIncomeProps, 'size' | 'maxLength'>;
 
 export const PseudoTextArea = forwardRef<HTMLDivElement, PseudoTextAreaProps>(
-    ({ size = 's', pseudoTextareaClassName = '', maxLength, stateValue }, ref) => (
+    ({ size = 's', pseudoTextareaClassName, maxLength, value }, ref) => (
         <div
             className={cn(styles.pseudoTextarea, styles[size], pseudoTextareaClassName)}
             ref={ref}
             hidden={true}
         >
-            <span>{stateValue.slice(0, maxLength)}</span>
-            <span className={cn(styles.overflow)}>{stateValue.slice(maxLength)}</span>
+            <span>{value.slice(0, maxLength)}</span>
+            <span className={cn(styles.overflow)}>{value.slice(maxLength)}</span>
             {/* Перенос строки нужен для правильной позиции */}
             <br />
         </div>


### PR DESCRIPTION
# Опишите проблему
При передаче пропа value не работает механика переполнения

# Шаги для воспроизведения
1. Перейти на страницу [Textarea](https://core-ds.github.io/core-components/master/?path=/docs/components-forms-inputs-textarea--textarea)
2. передать проп maxLength и value превышающее maxLength

# Ожидаемое поведение
Переполненный контент будете выделен

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):


## Смартфон (если данных нет оставте блок пустым):


# Дополнительная информация
