### PR TITLE
feat(select): options filter capability

### DIFF
--- a/packages/select/src/components/base-select-mobile/Component.tsx
+++ b/packages/select/src/components/base-select-mobile/Component.tsx
@@ -25,7 +25,7 @@ import { BaseOption } from '@alfalab/core-components-select';
 import { getDataTestId } from '../../../../utils/getDataTestId';
 import { OptionsListWithApply } from '../../presets/useSelectWithApply/options-list-with-apply';
 import { BaseSelectProps, OptionProps, OptionShape } from '../../typings';
-import { processOptions } from '../../utils';
+import { getFilteredOptions, processOptions } from '../../utils';
 import { Arrow as DefaultArrow } from '../arrow';
 import { BaseCheckmark } from '../base-checkmark';
 import { Field as DefaultField } from '../field';
@@ -106,6 +106,7 @@ export const BaseSelectMobile = forwardRef(
             footer,
             isBottomSheet,
             bottomSheetProps,
+            filterProps: { filterFunction, filterValue } = {},
         }: SelectMobileProps,
         ref,
     ) => {
@@ -360,6 +361,14 @@ export const BaseSelectMobile = forwardRef(
             toggleMenu();
         };
 
+        const finalOptions = useMemo(() => {
+            if (filterFunction) {
+                return getFilteredOptions(options, filterValue || '', filterFunction);
+            }
+
+            return options;
+        }, [filterFunction, filterValue, options]);
+
         return (
             <div
                 {...getComboboxProps({
@@ -427,7 +436,7 @@ export const BaseSelectMobile = forwardRef(
                                 flatOptions={flatOptions}
                                 highlightedIndex={highlightedIndex}
                                 size={size}
-                                options={options}
+                                options={finalOptions}
                                 OptionsList={OptionsList}
                                 Optgroup={Optgroup}
                                 Option={Option}
@@ -457,7 +466,7 @@ export const BaseSelectMobile = forwardRef(
                                 flatOptions={flatOptions}
                                 highlightedIndex={highlightedIndex}
                                 size={size}
-                                options={options}
+                                options={finalOptions}
                                 OptionsList={OptionsList}
                                 Optgroup={Optgroup}
                                 Option={Option}

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -23,7 +23,7 @@ import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
 import { getDataTestId } from '../../../../utils/getDataTestId';
 import { BaseSelectProps, OptionShape } from '../../typings';
-import { processOptions } from '../../utils';
+import { getFilteredOptions, processOptions } from '../../utils';
 import { NativeSelect } from '../native-select';
 
 import styles from './index.module.css';
@@ -79,6 +79,7 @@ export const BaseSelect = forwardRef(
             zIndexPopover,
             showEmptyOptionsList = false,
             visibleOptions,
+            filterProps: { filterFunction, filterValue } = {},
         }: BaseSelectProps,
         ref,
     ) => {
@@ -345,10 +346,18 @@ export const BaseSelect = forwardRef(
             };
         }, [calcOptionsListWidth, open, optionsListWidth]);
 
+        const finalOptions = useMemo(() => {
+            if (filterFunction) {
+                return getFilteredOptions(options, filterValue || '', filterFunction);
+            }
+
+            return options;
+        }, [filterFunction, filterValue, options]);
+
         useLayoutEffect_SAFE_FOR_SSR(calcOptionsListWidth, [
             open,
             optionsListWidth,
-            options,
+            finalOptions,
             selectedItems,
         ]);
 
@@ -374,10 +383,18 @@ export const BaseSelect = forwardRef(
                     name={name}
                     value={value}
                     onChange={handleNativeSelectChange}
-                    options={options}
+                    options={finalOptions}
                 />
             );
-        }, [multiple, selectedItems, disabled, name, handleNativeSelectChange, options, menuProps]);
+        }, [
+            multiple,
+            selectedItems,
+            disabled,
+            name,
+            handleNativeSelectChange,
+            finalOptions,
+            menuProps,
+        ]);
 
         const needRenderOptionsList = flatOptions.length > 0 || showEmptyOptionsList;
 
@@ -453,7 +470,7 @@ export const BaseSelect = forwardRef(
                                     highlightedIndex={highlightedIndex}
                                     open={open}
                                     size={size}
-                                    options={options}
+                                    options={finalOptions}
                                     Optgroup={Optgroup}
                                     Option={Option}
                                     selectedItems={selectedItems}

--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -37,6 +37,7 @@ export const OptionsList = forwardRef(
             footer,
             optionsListWidth,
             nativeScrollbar: nativeScrollbarProp,
+            useOptionsIds = false,
         }: OptionsListProps,
         ref,
     ) => {
@@ -58,7 +59,9 @@ export const OptionsList = forwardRef(
                 key={group.label}
                 size={size}
             >
-                {group.options.map((option) => renderOption(option, counter()))}
+                {group.options.map((option) =>
+                    renderOption(option, useOptionsIds ? option.id || 0 : counter()),
+                )}
             </Optgroup>
         );
 
@@ -77,7 +80,9 @@ export const OptionsList = forwardRef(
         const renderListItems = () => (
             <React.Fragment>
                 {options.map((option) =>
-                    isGroup(option) ? renderGroup(option) : renderOption(option, counter()),
+                    isGroup(option)
+                        ? renderGroup(option)
+                        : renderOption(option, useOptionsIds ? option.id || 0 : counter()),
                 )}
 
                 {emptyPlaceholder && options.length === 0 && (

--- a/packages/select/src/docs/description.mdx
+++ b/packages/select/src/docs/description.mdx
@@ -950,6 +950,66 @@ render(() => {
 });
 ```
 
+## Возможность фильтрации списка `options`
+
+```jsx live mobileHeight=640
+render(() => {
+    const options = React.useMemo(
+        () => [
+            { key: '1', content: 'Neptunium' },
+            { key: '2', content: 'Plutonium' },
+            { key: '3', content: 'Americium' },
+            { key: '4', content: 'Curium' },
+            { key: '5', content: 'Berkelium' },
+            { key: '6', content: 'Californium' },
+            { key: '7', content: 'Einsteinium' },
+            { key: '8', content: 'Fermium' },
+        ],
+        [],
+    );
+
+    const [selected, setSelected] = React.useState();
+
+    const [search, setSearch] = React.useState();
+
+    const handleChange = ({ selectedMultiple }) => {
+        setSelected(selectedMultiple);
+    };
+
+    const filterFunction = (optionsToFilter, filterValue) => {
+        return optionsToFilter.filter(
+            (item) =>
+                item.key.toLowerCase().includes(filterValue.toLowerCase()) ||
+                item.content.toLowerCase().includes(filterValue.toLowerCase())
+        );
+    }
+
+    return (
+        <div style={{ width: document.body.clientWidth < 450 ? '100%' : 320 }}>
+            <Input value={search}  onChange={ (_, { value }) => setSearch(value) } placeholder="Введите значение" />
+            <br />
+            <Select
+                allowUnselect={true}
+                block={true}
+                size='m'
+                options={options}
+                placeholder='Выберите элемент'
+                multiple={true}
+                onChange={handleChange}
+                selected={selected}
+                optionsListProps={
+                    useOptionsIds: true,
+                }
+                filterProps={{
+                    filterFunction: filterFunction,
+                    filterValue: search,
+                }}
+            />
+        </div>
+    );
+});
+```
+
 ## Другие селекты
 
 На основе селекта построены такие компоненты как [PickerButton](?path=/docs/pickerbutton--picker-button) и

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -37,6 +37,11 @@ export type OptionShape = {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value?: any;
+
+    /**
+     * Уникальный id, необходим в случае, если нужно фильтровать / сортировать options
+     */
+    id?: number;
 };
 
 export type GroupShape = {
@@ -56,6 +61,21 @@ export type BaseSelectChangePayload = {
     selectedMultiple: OptionShape[];
     initiator: OptionShape | null;
     name?: string;
+};
+
+export type FilterProps = {
+    /**
+     * Фильтр функция для переданных options
+     */
+    filterFunction?: (
+        options: Array<OptionShape | GroupShape>,
+        filterValue: string,
+    ) => Array<OptionShape | GroupShape>;
+
+    /**
+     * Поисковая строка для фильтра
+     */
+    filterValue?: string;
 };
 
 export type BaseSelectProps = {
@@ -311,6 +331,11 @@ export type BaseSelectProps = {
      * Показывать OptionsList, если он пустой
      */
     showEmptyOptionsList?: boolean;
+
+    /**
+     * Возможность фильтровать options внутри select
+     */
+    filterProps?: FilterProps;
 };
 
 // TODO: использовать InputProps
@@ -556,6 +581,12 @@ export type OptionsListProps = {
      * Обработчик отмены изменений
      */
     onClear?: () => void;
+
+    /**
+     * Использовать поле id из OptionShape в качестве индекса option в OptionList
+     * Необходимо для корректной работы option после сортировки / фильтрации массива options
+     */
+    useOptionsIds?: boolean;
 };
 
 export type OptgroupProps = {

--- a/packages/select/src/utils.test.tsx
+++ b/packages/select/src/utils.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { joinOptions, processOptions } from './utils';
-import { OptionShape } from './typings';
+import { getFilteredOptions, joinOptions, processOptions } from './utils';
+import { GroupShape, OptionShape } from './typings';
 
 describe('joinOptions', () => {
     const textOptions: OptionShape[] = [
@@ -123,5 +123,39 @@ describe('processOptions', () => {
             options[1],
             options[2],
         ]);
+    });
+});
+
+describe('getFilteredOptions', () => {
+    const textOptions: OptionShape[] = [
+        { key: '1', content: 'Neptunium' },
+        { key: '2', content: 'Plutonium' },
+        { key: '3', content: 'Americium' },
+        { key: '42', content: 'Curium' },
+    ];
+
+    const filterFunction = (options: Array<OptionShape | GroupShape>, filterValue: string) => {
+        return options.filter((option) =>
+            (option as OptionShape).key.toLowerCase().includes(filterValue.toLowerCase()),
+        );
+    };
+
+    it('should return 1 option with key contains "1"', () => {
+        expect(getFilteredOptions(textOptions, '1', filterFunction)).toEqual([textOptions[0]]);
+    });
+
+    it('should return 2 options with key contains "2"', () => {
+        expect(getFilteredOptions(textOptions, '2', filterFunction)).toEqual([
+            textOptions[1],
+            textOptions[3],
+        ]);
+    });
+
+    it('should return 0 options with key contains "333"', () => {
+        expect(getFilteredOptions(textOptions, '333', filterFunction)).toEqual([]);
+    });
+
+    it('should return exact same options array with empty filterValue', () => {
+        expect(getFilteredOptions(textOptions, '', filterFunction)).toEqual(textOptions);
     });
 });

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -66,6 +66,21 @@ export function processOptions(
     return { flatOptions, selectedOptions };
 }
 
+export const getFilteredOptions = (
+    options: Array<OptionShape | GroupShape>,
+    filterValue: string,
+    filterFunction: (
+        options: Array<OptionShape | GroupShape>,
+        filterValue: string,
+    ) => Array<OptionShape | GroupShape>,
+): Array<OptionShape | GroupShape> => {
+    if (!filterFunction || !filterValue) {
+        return options;
+    }
+
+    return filterFunction(options, filterValue);
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type useVisibleOptionsArgs = {
     /**


### PR DESCRIPTION
# Опишите проблему
Появилась необходимость фильтровать опции в Select через поисковую строку. При фильтрации массива Options извне - пропадает выделение выбранных пунктов в SelectMobile

# Как воспроизвести
Код для сэндбокса
```
const options = [
        { key: '1', content: 'Neptunium' },
        { key: '2', content: 'Plutonium' },
        { key: '3', content: 'Americium' },
        { key: '4', content: 'Curium' },
        { key: '5', content: 'Berkelium' },
        { key: '6', content: 'Californium' },
        { key: '7', content: 'Einsteinium' },
        { key: '8', content: 'Fermium' },
    ];
    
render(() => {
    const [search, setSearch] = React.useState('');
    const filteredOptions = React.useMemo(() => {
        if(!search) {
          return options;
        }
        
        return options.filter((option) => option.content.includes(search));
    }, [search]);

    return (
        <div style={{ width: document.body.clientWidth < 450 ? '100%' : 320 }}>
            <Input value={ search } onChange={ (_, { value }) => setSearch(value) }  />
            <SelectMobile
                allowUnselect={true}
                size='m'
                multiple
                options={filteredOptions}
                placeholder='Одиночный выбор'
                Option={BaseOption}
                block={true}
            />
          
        </div>
    );
});
```

## Шаги воспроизведения
- Открыть SelectMobile
- Выбрать несколько любых пунктов меню
- Нажать "Применить"
- Ввести в поисковую строку символ (например "е")

## Ожидаемое поведение
- Выбранные пункты меню остались выбранными

## Фактическое поведение
- Все пункты перестали быть выделенными


P.S. Если повторить то же самое с обычным Select - работает, как ожидается. Фильтрация происходит, но пункты меню сохраняют выделение