### PR TITLE
fix(intl-phone-input): change insert rule

### DIFF
--- a/.changeset/gentle-students-rescue.md
+++ b/.changeset/gentle-students-rescue.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-intl-phone-input": patch
+---
+
+fix(intl-phone-input): исправлена вставка в пустое поле номера без "+"

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -427,6 +427,7 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
                 text,
                 selectionStart || 0,
                 selectionEnd || 0,
+                ruNumberPriority && countryIso2 === 'ru',
             );
             const targetCountry = getCountryByNumber(preparedNumber);
             const maxPhoneLength =

--- a/packages/intl-phone-input/src/utils/preparePasteData.test.ts
+++ b/packages/intl-phone-input/src/utils/preparePasteData.test.ts
@@ -6,9 +6,14 @@ describe('preparePasteData', () => {
         expect(preparePasteData('', '89491234567', 0, 0)).toEqual('+79491234567');
     });
 
-    it('should return number with +7 when paste number doesn\'t start with "7" or "8" in empty field', () => {
-        expect(preparePasteData('', '6491234567', 0, 0)).toEqual('+76491234567');
-        expect(preparePasteData('', '9491234567', 0, 0)).toEqual('+79491234567');
+    it('should return number with + when paste number doesn\'t start with "7" or "8" in empty field', () => {
+        expect(preparePasteData('', '6491234567', 0, 0)).toEqual('+6491234567');
+        expect(preparePasteData('', '9491234567', 0, 0)).toEqual('+9491234567');
+    });
+
+    it('should return number with +7 when paste number doesn\'t start with "7" or "8" in empty field with ruNumberPriority', () => {
+        expect(preparePasteData('', '6491234567', 0, 0, true)).toEqual('+76491234567');
+        expect(preparePasteData('', '9491234567', 0, 0, true)).toEqual('+79491234567');
     });
 
     it('should return number when paste number start with "+" in empty field', () => {
@@ -16,7 +21,7 @@ describe('preparePasteData', () => {
     });
 
     it('should return number when paste number with letters in empty field', () => {
-        expect(preparePasteData('', '123aaa456', 0, 0)).toEqual('+7123456');
+        expect(preparePasteData('', '123aaa456', 0, 0)).toEqual('+123456');
     });
 
     it('should return number when paste number in field with "+"', () => {

--- a/packages/intl-phone-input/src/utils/preparePasteData.ts
+++ b/packages/intl-phone-input/src/utils/preparePasteData.ts
@@ -9,6 +9,7 @@ export function preparePasteData(
     phoneFromBuffer: string,
     selectionStart?: number,
     selectionEnd?: number,
+    ruNumberPriority?: boolean,
 ) {
     const trimNuber = phoneFromBuffer.trim();
     const cutNumberWithPlus = trimNuber.replace(/[^+\d]/g, '');
@@ -43,9 +44,12 @@ export function preparePasteData(
             // вставка номера начинающегося с "7" или "8" в пустое поле
         } else if (isRuNumberInBuffer) {
             resultNumber = `+7${cutNumber.substring(1)}`;
-            // вставка номера начинающегося НЕ с "7", "8", "+" в пустое поле
-        } else {
+            // вставка номера начинающегося НЕ с "7", "8", "+" в пустое поле с российским флагом
+        } else if (ruNumberPriority) {
             resultNumber = `+7${cutNumber}`;
+            // вставка номера начинающегося НЕ с "7", "8", "+" в пустое поле без российского флага
+        } else {
+            resultNumber = `+${cutNumber}`;
         }
     }
 


### PR DESCRIPTION
Немного изменилась спека, теперь в поле без ру флага при вставке значения без + не нужно подставлять 7 https://www.figma.com/file/cdNnkh2QdxuvYLrBm4cubM/branch/pxLATDZssLAEKvbtCMeQdP/Web-%3A%3A-Core-Default-Components?node-id=65619%3A78962&t=bMoPLGqVd5nsD40K-0