### PR TITLE
chore: include correct css-vars for selected theme

### DIFF
--- a/.storybook/addons/theme-switcher/utils.js
+++ b/.storybook/addons/theme-switcher/utils.js
@@ -2,6 +2,7 @@ import { getMobileFrames, getOrCreateStyleTag } from '../utils';
 import { MODE_COLORS_TAG_ID } from '../mode-switcher/utils';
 
 import bluetintColors from '!!postcss-loader!../../../packages/vars/src/colors-bluetint.css';
+import bluetintShadows from '!!postcss-loader!../../../packages/vars/src/shadows-bluetint.css';
 
 import click from '!!postcss-loader!./themes/click.css';
 import mobile from '!!postcss-loader!./themes/mobile.css';
@@ -34,16 +35,16 @@ export function setThemeStylesInMobileFrame(theme) {
     });
 }
 
-export function getThemeStyles(theme) {
+export function getThemeStyles(selectedTheme) {
     const bluetintThemes = ['mobile', 'intranet', 'click'];
+    const bluetintVars = [bluetintColors, bluetintShadows].join('\n');
+
     return [
-        themes[theme],
-        bluetintThemes.some((x) => x.includes(theme)) ? bluetintColors : '',
+        themes[selectedTheme],
+        bluetintThemes.some((theme) => theme.includes(selectedTheme)) ? bluetintVars : '',
     ].join('\n');
 }
 
 export function setThemeStyles(theme, doc) {
-    const themeStyles = getThemeStyles(theme);
-
-    getOrCreateStyleTag(THEME_TAG_ID, MODE_COLORS_TAG_ID, doc).innerHTML = themeStyles;
+    getOrCreateStyleTag(THEME_TAG_ID, MODE_COLORS_TAG_ID, doc).innerHTML = getThemeStyles(theme);
 }

--- a/.storybook/addons/theme-switcher/utils.js
+++ b/.storybook/addons/theme-switcher/utils.js
@@ -41,7 +41,7 @@ export function getThemeStyles(selectedTheme) {
 
     return [
         themes[selectedTheme],
-        bluetintThemes.some((theme) => theme.includes(selectedTheme)) ? bluetintVars : '',
+        bluetintThemes.some((theme) => theme === selectedTheme) ? bluetintVars : '',
     ].join('\n');
 }
 

--- a/packages/input/src/__image_snapshots__/input-screenshots-main-props-site-theme-2-snap.png
+++ b/packages/input/src/__image_snapshots__/input-screenshots-main-props-site-theme-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd22762007f79e933765b6c9758c7ecb5021251a91dce67998052a89dcef0151
-size 444264
+oid sha256:4d81be22dea77b3b5eb44e935951ca4cfb2da3e09c188f07ddbb0156c00c7405
+size 471432

--- a/packages/input/src/__image_snapshots__/input-screenshots-main-props-site-theme-2-snap.png
+++ b/packages/input/src/__image_snapshots__/input-screenshots-main-props-site-theme-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d81be22dea77b3b5eb44e935951ca4cfb2da3e09c188f07ddbb0156c00c7405
-size 471432
+oid sha256:dd22762007f79e933765b6c9758c7ecb5021251a91dce67998052a89dcef0151
+size 444264

--- a/packages/select/src/__image_snapshots__/select-interactions-tests-click-open-select-select-one-item-2-snap.png
+++ b/packages/select/src/__image_snapshots__/select-interactions-tests-click-open-select-select-one-item-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0d9f590e5e14ff03e38fcb2ace98764e12aa9b684925f09b88dfe323ca2df7c
-size 13916
+oid sha256:f7ba2adccb04be69cfc21d6faa734fbd92db6d6c815e357c89fc42ee424b8595
+size 13508

--- a/packages/select/src/__image_snapshots__/select-interactions-tests-click-open-select-select-one-item-4-snap.png
+++ b/packages/select/src/__image_snapshots__/select-interactions-tests-click-open-select-select-one-item-4-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:832c7c197ae8b6261e37cbb155c763032fa24529c6bef5da7beb21ec18a1b5ac
-size 14054
+oid sha256:e2f518a741f9250079fe2ea0244ea22d24ea69ad641a1180af5f62bf36ac7dbb
+size 13751

--- a/packages/select/src/__image_snapshots__/select-multiple-click-snap.png
+++ b/packages/select/src/__image_snapshots__/select-multiple-click-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd2ab3a75d91110b5d77d4116157e141bc02f459f0f0d89330bdf939fcd8e599
-size 19064
+oid sha256:e26d067d840332cd6691edfaa4257986fdbe2df418702188360dc9bcd02f3028
+size 18862

--- a/packages/select/src/__image_snapshots__/select-optgroup-click-snap.png
+++ b/packages/select/src/__image_snapshots__/select-optgroup-click-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51f3f477ba4ea21f3b2a012548c4ff714ebf5809cdc4fba3428086bea760eced
-size 16319
+oid sha256:338c4e4a87bb206f037947e026fc1516e626996d25ac3f271a8597345b9e5193
+size 16029


### PR DESCRIPTION
При переключении темы в сторибук не подтягивались токены теней (блютинт). Пофиксил.

