### PR TITLE
feat: Initial visible height and magnetic areas in bottom-sheet

### DIFF
--- a/.changeset/spotty-lions-check.md
+++ b/.changeset/spotty-lions-check.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-bottom-sheet': major
+'@alfalab/core-components-backdrop': minor
+'@alfalab/core-components-base-modal': minor
+'@alfalab/core-components-navigation-bar': minor
+---
+
+Добавлены возможности выбора изначальной видимой высоты и высот зависания(примагничивания) для bottom-sheet

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "react-focus-lock": "^2.9.3",
         "react-merge-refs": "^1.1.0",
         "react-popper": "^2.3.0",
-        "react-swipeable": "^5.5.1",
+        "react-swipeable": "^7.0.0",
         "react-textarea-autosize": "^8.3.4",
         "react-transition-group": "^4.4.5",
         "react-virtual": "^2.3.2",

--- a/packages/backdrop/src/Component.tsx
+++ b/packages/backdrop/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, ReactNode } from 'react';
+import React, { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { CSSTransitionClassNames } from 'react-transition-group/CSSTransition';
 import { TransitionProps } from 'react-transition-group/Transition';
@@ -43,6 +43,11 @@ export type BackdropProps = Partial<TransitionProps> & {
      * Дочерние элементы.
      */
     children?: ReactNode;
+
+    /**
+     * Дополнительные стили backdrop
+     */
+    style?: CSSProperties
 };
 
 export const Backdrop: React.FC<BackdropProps> = ({

--- a/packages/base-modal/src/Component.tsx
+++ b/packages/base-modal/src/Component.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, {
+    CSSProperties,
     FC,
     forwardRef,
     KeyboardEvent,
@@ -124,6 +125,11 @@ export type BaseModalProps = {
     wrapperClassName?: string;
 
     /**
+     * Дополнительные стили для обертки (Modal)
+     */
+    wrapperStyle?: CSSProperties;
+
+    /**
      * Обработчик скролла контента
      */
     scrollHandler?: 'wrapper' | 'content' | MutableRefObject<HTMLDivElement | null>;
@@ -232,6 +238,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
             className,
             contentClassName,
             wrapperClassName,
+            wrapperStyle = {},
             onBackdropClick,
             onClose,
             onEscapeKeyDown,
@@ -516,6 +523,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
                                         open={open}
                                         style={{
                                             zIndex: computedZIndex,
+                                            ...backdropProps?.style
                                         }}
                                     />
                                 )}
@@ -533,6 +541,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
                                     data-test-id={dataTestId}
                                     style={{
                                         zIndex: computedZIndex,
+                                        ...wrapperStyle
                                     }}
                                 >
                                     <CSSTransition

--- a/packages/bottom-sheet/package.json
+++ b/packages/bottom-sheet/package.json
@@ -26,7 +26,7 @@
         "classnames": "^2.3.1",
         "react-div-100vh": "^0.7.0",
         "react-merge-refs": "^1.1.0",
-        "react-swipeable": "^5.5.1",
+        "react-swipeable": "^7.0.0",
         "react-transition-group": "^4.4.5",
         "tslib": "^2.4.0"
     }

--- a/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
+++ b/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
   style="padding-right: 0px; overflow: hidden;"
 >
   <div />
+  <div />
   <div
     alfa-portal-container=""
   >
@@ -17,7 +18,7 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
       data-focus-lock-disabled="false"
     >
       <div
-        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100;"
+        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100; pointer-events: auto;"
       >
         <div
           aria-hidden="true"
@@ -27,27 +28,28 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
       <div
         class="wrapper"
         role="dialog"
-        style="z-index: 100;"
+        style="z-index: 100; pointer-events: auto;"
         tabindex="0"
       >
         <div
-          class="component modal appear appearActive"
+          class="component modal disabledPointerEvents appear appearActive"
         >
           <div
             class="content"
           >
             <div
+              class="disabledPointerEvents"
               style="max-height: 744px;"
             >
               <div
-                class="component withTransition"
+                class="component enabledPointerEvents withTransition"
                 style="max-height: 744px;"
               >
                 <div
-                  class="scrollableContainer"
+                  class="scrollableContainer enabledPointerEvents"
                 >
                   <div
-                    class="marker"
+                    class="marker disabledPointerEvents"
                   />
                   <div
                     class="header headerWrapper hasContent"
@@ -106,7 +108,7 @@ exports[`Bottom sheet Snapshots tests should match snapshot with action button 1
       data-focus-lock-disabled="false"
     >
       <div
-        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100;"
+        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100; pointer-events: auto;"
       >
         <div
           aria-hidden="true"
@@ -116,27 +118,28 @@ exports[`Bottom sheet Snapshots tests should match snapshot with action button 1
       <div
         class="wrapper"
         role="dialog"
-        style="z-index: 100;"
+        style="z-index: 100; pointer-events: auto;"
         tabindex="0"
       >
         <div
-          class="component modal appear appearActive"
+          class="component modal disabledPointerEvents appear appearActive"
         >
           <div
             class="content"
           >
             <div
+              class="disabledPointerEvents"
               style="max-height: 744px;"
             >
               <div
-                class="component withTransition"
+                class="component enabledPointerEvents withTransition"
                 style="max-height: 744px;"
               >
                 <div
-                  class="scrollableContainer"
+                  class="scrollableContainer enabledPointerEvents"
                 >
                   <div
-                    class="marker"
+                    class="marker disabledPointerEvents"
                   />
                   <div
                     class="header headerWrapper hasContent"

--- a/packages/bottom-sheet/src/component.test.tsx
+++ b/packages/bottom-sheet/src/component.test.tsx
@@ -1,5 +1,11 @@
-import React, { useState, forwardRef } from 'react';
-import { fireEvent, render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import React, { useState, forwardRef, useRef } from 'react';
+import {
+    fireEvent,
+    render,
+    renderHook,
+    waitFor,
+    waitForElementToBeRemoved
+} from '@testing-library/react';
 
 import { act } from 'react-dom/test-utils';
 import { BottomSheet, BottomSheetProps, CLOSE_OFFSET } from '.';
@@ -33,6 +39,7 @@ const BottomSheetWrapper = forwardRef<HTMLDivElement, Partial<BottomSheetProps>>
 const dataTestId = 'test-id';
 
 let getBoundingClientRect: () => DOMRect;
+let sheetContainerRef: React.RefObject<HTMLDivElement>;
 
 const mockGetBoundingClientRect = (height: number) => {
     if (!getBoundingClientRect) {
@@ -52,6 +59,16 @@ const mockGetBoundingClientRect = (height: number) => {
     });
 };
 
+const mockElementsFromPoint = () => {
+    const element = renderHook(() => useRef<HTMLDivElement>(null));
+    const spyFunc = () => [element.result.current.current];
+
+    Object.defineProperty(document, 'elementsFromPoint', {
+        value: spyFunc,
+    });
+    sheetContainerRef = element.result.current;
+}
+
 const clearGetBoundingClientRect = () => {
     HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
 };
@@ -59,6 +76,7 @@ const clearGetBoundingClientRect = () => {
 describe('Bottom sheet', () => {
     beforeAll(() => {
         mockGetBoundingClientRect(100);
+        mockElementsFromPoint();
     });
 
     afterAll(() => {
@@ -218,6 +236,7 @@ describe('Bottom sheet', () => {
                 <BottomSheetWrapper
                     dataTestId={dataTestId}
                     className={className}
+                    sheetContainerRef={sheetContainerRef}
                     transitionProps={{
                         timeout: 0,
                         onEntered,
@@ -267,6 +286,7 @@ describe('Bottom sheet', () => {
                 <BottomSheetWrapper
                     dataTestId={dataTestId}
                     className={className}
+                    sheetContainerRef={sheetContainerRef}
                     transitionProps={{
                         timeout: 0,
                         onEntered,
@@ -309,6 +329,7 @@ describe('Bottom sheet', () => {
                 <BottomSheetWrapper
                     dataTestId={dataTestId}
                     className={className}
+                    sheetContainerRef={sheetContainerRef}
                     transitionProps={{
                         timeout: 0,
                         onEntered,

--- a/packages/bottom-sheet/src/component.test.tsx
+++ b/packages/bottom-sheet/src/component.test.tsx
@@ -253,12 +253,15 @@ describe('Bottom sheet', () => {
             const initial = { x: left + 10, y: top + 10 };
 
             let swipeDelta = 20;
-
-            fireEvent.touchStart(swipeableBottomSheet, {
-                touches: [{ clientX: initial.x, clientY: initial.y }],
+            fireEvent.touchMove(swipeableBottomSheet, {
+                touches: [
+                    { clientX: initial.x, clientY: initial.y },
+                ],
             });
             fireEvent.touchMove(swipeableBottomSheet, {
-                touches: [{ clientX: initial.x, clientY: initial.y + swipeDelta }],
+                touches: [
+                    { clientX: initial.x, clientY: initial.y + swipeDelta },
+                ],
             });
 
             expect(getComputedStyle(swipeableBottomSheet).transform).toBe(

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -413,6 +413,8 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         };
 
         const getBackdropOpacity = (offset: number): number => {
+            if (hideOverlay) return (open && offset === 0) ? 1 : 0;
+
             const containerHeight = modalRef?.current?.getBoundingClientRect()?.height ?? 0;
 
             if (containerHeight === 0) return MIN_BACKDROP_OPACITY;
@@ -731,7 +733,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         useEffect(() => {
             setWithTransition(true);
             setSheetOffset(0);
-            setBackdropOpacity(1);
+            setBackdropOpacity(hideOverlay ? (open ? 1 : 0) : 1);
             if (open) {
                 // Ждем, пока появится шторка, иначе не отработает анимация
                 setTimeout(handleChangeVisibleHeight);
@@ -764,7 +766,6 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                     opacity: backdropOpacity,
                     handlers: swipeable ? backdropSwipeablehandlers : false,
                     opacityTimeout: TIMEOUT,
-                    invisible: hideOverlay,
                     style: {
                         pointerEvents: hideOverlay ? 'none' : 'auto',
                     },

--- a/packages/bottom-sheet/src/components/footer/Component.tsx
+++ b/packages/bottom-sheet/src/components/footer/Component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useContext, useEffect } from 'react';
+import React, { ReactNode, useContext, useEffect } from 'react';
 import cn from 'classnames';
 
 import { BaseModalContext } from '@alfalab/core-components-base-modal';
@@ -22,7 +22,7 @@ export type FooterProps = {
     className?: string;
 };
 
-export const Footer: FC<FooterProps> = ({ children, className, sticky }) => {
+export const Footer = React.forwardRef<HTMLDivElement, FooterProps>(({ children, className, sticky }, ref) => {
     const { footerHighlighted, setHasFooter } = useContext(BaseModalContext);
 
     useEffect(() => {
@@ -31,6 +31,7 @@ export const Footer: FC<FooterProps> = ({ children, className, sticky }) => {
 
     return (
         <div
+            ref={ref}
             className={cn(styles.footer, className, {
                 [styles.sticky]: sticky,
                 [styles.highlighted]: footerHighlighted && sticky,
@@ -39,4 +40,4 @@ export const Footer: FC<FooterProps> = ({ children, className, sticky }) => {
             {children}
         </div>
     );
-};
+});

--- a/packages/bottom-sheet/src/components/swipeable-backdrop/Component.tsx
+++ b/packages/bottom-sheet/src/components/swipeable-backdrop/Component.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { SwipeableHandlers } from 'react-swipeable/types';
+import { SwipeableHandlers } from 'react-swipeable';
 
 import { Backdrop, BackdropProps } from '@alfalab/core-components-backdrop';
 

--- a/packages/bottom-sheet/src/components/swipeable-backdrop/Component.tsx
+++ b/packages/bottom-sheet/src/components/swipeable-backdrop/Component.tsx
@@ -31,7 +31,7 @@ export const SwipeableBackdrop: FC<SwipeableBackdropProps> = ({
         {...handlers}
         style={{
             opacity,
-            transition: opacity === 1 ? `opacity ${opacityTimeout}ms ease-in-out` : '',
+            transition: `opacity ${opacityTimeout}ms ease-in-out`,
             position: 'relative',
             ...style,
         }}

--- a/packages/bottom-sheet/src/docs/Component.stories.mdx
+++ b/packages/bottom-sheet/src/docs/Component.stories.mdx
@@ -90,10 +90,12 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
                     stickyFooter={boolean('stickyFooter', true)}
                     initialHeight={select('initialHeight', ['default', 'full'], 'default')}
                     visibleHeight={text('visibleHeight')}
+                    maximumVisibleHeight={text('maximumVisibleHeight')}
                     hideOverlay={hideOverlay}
+                    allowScrollOnNonFullVisible={boolean('allowScrollOnNonFullVisible', false)}
                     hideHeader={boolean('hideHeader', false)}
                     disableOverlayClick={boolean('disableOverlayClick', false)}
-                    magneticAreas={text('magneticAreas', '20, 100px, 25%, 50%').split(',').map((item) => item.trim())}
+                    magneticAreas={text('magneticAreas', '20, 100, 25%, 50%').split(',').map((item) => item.trim())}
                     magneticThresholdUp={text('magneticThresholdUp', '20px')}
                     magneticThresholdDown={text('magneticThresholdDown', '50%')}
                     onMagnetic={(index) => console.log(index === -1 ? 'Отмагнитились' : `Примагнитились к magneticAreas[${index}]`)}

--- a/packages/bottom-sheet/src/docs/Component.stories.mdx
+++ b/packages/bottom-sheet/src/docs/Component.stories.mdx
@@ -29,6 +29,7 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
         }, []);
         const [textContent, setTextContent] = React.useState('');
         const renderActionButton = boolean('renderActionButton', true);
+        const hideOverlay = boolean('hideOverlay', false);
         return (
             <div>
                 <Button
@@ -51,6 +52,20 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
                 >
                     Окрыть шторку с длинным контентом
                 </Button>
+                {
+                    hideOverlay &&
+                    <>
+                        <Button
+                            onClick={() => {
+                                alert('Клик сработал!');
+                            }}
+                            style={{ margin: '15px' }}
+                            id='button-3'
+                        >
+                            Проверить клик
+                        </Button>
+                    </>
+                }
                 <BottomSheet
                     key={textContent}
                     open={open}
@@ -64,6 +79,7 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
                     }
                     onClose={handleClose}
                     swipeable={boolean('swipeable', true)}
+                    hideScrollbar={boolean('hideScrollbar', false)}
                     titleAlign={select('titleAlign', ['center', 'left'], 'center')}
                     trimTitle={boolean('trimTitle', false)}
                     stickyHeader={boolean('stickyHeader', false)}
@@ -73,9 +89,13 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
                     rightAddons={select('rightAddons', [true, false], false)}
                     stickyFooter={boolean('stickyFooter', true)}
                     initialHeight={select('initialHeight', ['default', 'full'], 'default')}
-                    hideOverlay={boolean('hideOverlay', false)}
+                    visibleHeight={text('visibleHeight')}
+                    hideOverlay={hideOverlay}
                     hideHeader={boolean('hideHeader', false)}
                     disableOverlayClick={boolean('disableOverlayClick', false)}
+                    magneticAreas={text('magneticAreas', '20, 100px, 25%, 50%').split(',').map((item) => item.trim())}
+                    stickyThreshold={text('stickyThreshold', '20px')}
+                    onMagnetic={(index) => console.log(`Примагнитились к magneticAreas[${index}]`)}
                     backgroundColor={select('backgroundColor', BACKGROUND, undefined)}
                 >
                     <div style={{ whiteSpace: 'pre-wrap' }}>{textContent}</div>

--- a/packages/bottom-sheet/src/docs/Component.stories.mdx
+++ b/packages/bottom-sheet/src/docs/Component.stories.mdx
@@ -94,8 +94,9 @@ export const BACKGROUND = ['primary', 'secondary', undefined];
                     hideHeader={boolean('hideHeader', false)}
                     disableOverlayClick={boolean('disableOverlayClick', false)}
                     magneticAreas={text('magneticAreas', '20, 100px, 25%, 50%').split(',').map((item) => item.trim())}
-                    stickyThreshold={text('stickyThreshold', '20px')}
-                    onMagnetic={(index) => console.log(`Примагнитились к magneticAreas[${index}]`)}
+                    magneticThresholdUp={text('magneticThresholdUp', '20px')}
+                    magneticThresholdDown={text('magneticThresholdDown', '50%')}
+                    onMagnetic={(index) => console.log(index === -1 ? 'Отмагнитились' : `Примагнитились к magneticAreas[${index}]`)}
                     backgroundColor={select('backgroundColor', BACKGROUND, undefined)}
                 >
                     <div style={{ whiteSpace: 'pre-wrap' }}>{textContent}</div>

--- a/packages/bottom-sheet/src/docs/description.mdx
+++ b/packages/bottom-sheet/src/docs/description.mdx
@@ -183,6 +183,8 @@ const MECHANICS_SETTINGS = [
     { label: 'Скрыть скроллбар внутри bottom-sheet', name: 'hideScrollbar' },
     { label: 'Магнитные области - 20px, 50%', name: 'magAreas' },
     { label: 'Изначально заданная высота 50%', name: 'initialVisibleHeight' },
+    { label: 'Максимальная видимая высота 60%', name: 'maximumVisibleHeight' },
+    { label: 'Разрешить скролл при не полном открытии шторы', name: 'allowScrollOnNonFullVisible' },
 ];
 
 render(() => {
@@ -366,10 +368,12 @@ render(() => {
                 hideOverlay={mechanics['hideOverlay']}
                 hideScrollbar={mechanics['hideScrollbar']}
                 visibleHeight={mechanics['initialVisibleHeight'] ? '50%' : undefined}
-                magneticAreas={mechanics['magAreas'] ? ['40px', '50%'] : []}
+                magneticAreas={mechanics['magAreas'] ? [40, '50%'] : []}
                 stickyFooter={footerSettings.sticky}
                 swipeable={mechanics.swipeable || mechanics['magAreas']}
                 initialHeight={mechanics.adaptive ? 'default' : 'full'}
+                allowScrollOnNonFullVisible={mechanics.allowScrollOnNonFullVisible}
+                maximumVisibleHeight={mechanics.maximumVisibleHeight ? '60%' : undefined}
                 actionButton={
                     showFooter ? (
                         <div

--- a/packages/bottom-sheet/src/docs/description.mdx
+++ b/packages/bottom-sheet/src/docs/description.mdx
@@ -179,6 +179,10 @@ const FOOTER_SETTINGS = [
 const MECHANICS_SETTINGS = [
     { label: 'Высота подстраивается под размер контента', name: 'adaptive' },
     { label: 'Разрешить закрывать свайпом', name: 'swipeable' },
+    { label: 'Скрыть оверлей', name: 'hideOverlay' },
+    { label: 'Скрыть скроллбар внутри bottom-sheet', name: 'hideScrollbar' },
+    { label: 'Магнитные области - 20px, 50%', name: 'magAreas' },
+    { label: 'Изначально заданная высота 50%', name: 'initialVisibleHeight' },
 ];
 
 render(() => {
@@ -359,8 +363,12 @@ render(() => {
                         ? 'Почему банк проверяет мои операции?'
                         : undefined
                 }
+                hideOverlay={mechanics['hideOverlay']}
+                hideScrollbar={mechanics['hideScrollbar']}
+                visibleHeight={mechanics['initialVisibleHeight'] ? '50%' : undefined}
+                magneticAreas={mechanics['magAreas'] ? ['40px', '50%'] : []}
                 stickyFooter={footerSettings.sticky}
-                swipeable={mechanics.swipeable}
+                swipeable={mechanics.swipeable || mechanics['magAreas']}
                 initialHeight={mechanics.adaptive ? 'default' : 'full'}
                 actionButton={
                     showFooter ? (

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -13,6 +13,14 @@
     max-width: 600px;
 }
 
+.disabledPointerEvents {
+    pointer-events: none;
+}
+
+.enabledPointerEvents {
+    pointer-events: all;
+}
+
 .component {
     overflow: hidden;
     position: relative;
@@ -35,6 +43,15 @@
     position: relative;
     height: 100%;
     background-color: inherit;
+}
+
+.withoutScrollbar {
+    scrollbar-width: none;
+}
+.withoutScrollbar::-webkit-scrollbar {
+    display:none;
+    width: 0 !important;
+    background: transparent;
 }
 
 .marker {

--- a/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
       data-focus-lock-disabled="false"
     >
       <div
-        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100;"
+        style="opacity: 1; transition: opacity 300ms ease-in-out; position: relative; z-index: 100; pointer-events: auto;"
       >
         <div
           aria-hidden="true"
@@ -107,27 +107,28 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
       <div
         class="wrapper"
         role="dialog"
-        style="z-index: 100;"
+        style="z-index: 100; pointer-events: auto;"
         tabindex="0"
       >
         <div
-          class="component modal appear appearActive"
+          class="component modal disabledPointerEvents appear appearActive"
         >
           <div
             class="content"
           >
             <div
+              class="disabledPointerEvents"
               style="height: 744px; max-height: 744px;"
             >
               <div
-                class="component sheet withTransition"
+                class="component enabledPointerEvents sheet withTransition"
                 style="height: 744px; max-height: 744px;"
               >
                 <div
-                  class="scrollableContainer sheetContainer"
+                  class="scrollableContainer enabledPointerEvents sheetContainer"
                 >
                   <div
-                    class="marker"
+                    class="marker disabledPointerEvents"
                   />
                   <div
                     class="header headerWrapper sticky"

--- a/packages/navigation-bar/src/Component.tsx
+++ b/packages/navigation-bar/src/Component.tsx
@@ -30,7 +30,9 @@ export const NavigationBar: FC<NavigationBarProps> = ({
     titleSize = 'default',
     subtitle,
     hasCloser,
+    closerRef,
     hasBackButton,
+    backButtonRef,
     backButtonClassName,
     dataTestId,
     imageUrl,
@@ -124,6 +126,7 @@ export const NavigationBar: FC<NavigationBarProps> = ({
         return (
             <div className={cn(styles.addon, backButtonClassName)}>
                 <BackArrowAddon
+                    ref={backButtonRef}
                     textOpacity={textOpacity}
                     view={view}
                     onClick={onBack}
@@ -163,6 +166,7 @@ export const NavigationBar: FC<NavigationBarProps> = ({
     const renderCloser = () => (
         <div className={cn(styles.addon, styles.closer, closerClassName)}>
             <Closer
+                ref={closerRef}
                 view={view}
                 icon={closerIcon}
                 dataTestId={getDataTestId(dataTestId, 'closer')}

--- a/packages/navigation-bar/src/components/back-arrow-addon/Component.tsx
+++ b/packages/navigation-bar/src/components/back-arrow-addon/Component.tsx
@@ -35,18 +35,19 @@ export interface BackArrowAddonProps extends React.HTMLAttributes<HTMLButtonElem
     onClick?: () => void;
 }
 
-export const BackArrowAddon: React.FC<BackArrowAddonProps> = ({
+export const BackArrowAddon = React.forwardRef<HTMLButtonElement, BackArrowAddonProps>(({
     text = 'Назад',
     onClick,
     className,
     textOpacity = 1,
     view,
     ...htmlAttributes
-}) => {
+}, ref) => {
     const Icon = view === 'desktop' ? ArrowLeftMediumMIcon : ArrowLeftMIcon;
 
     return (
         <Button
+            ref={ref}
             view='ghost'
             size={view === 'mobile' ? 'xxs' : 's'}
             onClick={onClick}
@@ -79,4 +80,4 @@ export const BackArrowAddon: React.FC<BackArrowAddonProps> = ({
             </div>
         </Button>
     );
-};
+});

--- a/packages/navigation-bar/src/components/closer/Component.tsx
+++ b/packages/navigation-bar/src/components/closer/Component.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, ElementType, FC } from 'react';
+import React, { ButtonHTMLAttributes, ElementType } from 'react';
 import cn from 'classnames';
 
 import { IconButton } from '@alfalab/core-components-icon-button';
@@ -47,7 +47,7 @@ export interface CloserProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     ) => void;
 }
 
-export const Closer: FC<CloserProps> = ({
+export const Closer = React.forwardRef<HTMLButtonElement, CloserProps>(({
     view,
     className,
     sticky,
@@ -55,7 +55,7 @@ export const Closer: FC<CloserProps> = ({
     dataTestId,
     onClose,
     ...restProps
-}) => {
+}, ref) => {
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         onClose?.(event, 'closerClick');
     };
@@ -67,6 +67,7 @@ export const Closer: FC<CloserProps> = ({
             })}
         >
             <IconButton
+                ref={ref}
                 size={view === 'desktop' ? 's' : 'xs'}
                 className={cn(styles.button, { [styles.mobile]: view === 'mobile' })}
                 aria-label='закрыть'
@@ -77,4 +78,4 @@ export const Closer: FC<CloserProps> = ({
             />
         </div>
     );
-};
+});

--- a/packages/navigation-bar/src/types.ts
+++ b/packages/navigation-bar/src/types.ts
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, {ReactNode, RefObject} from 'react';
 
 import type { CloserProps } from './components/closer';
 
@@ -54,9 +54,19 @@ export type NavigationBarProps = {
     hasCloser?: boolean;
 
     /**
+     * Ref крестика
+     */
+    closerRef?: RefObject<HTMLButtonElement>;
+
+    /**
      * Наличие кнопки "Назад"
      */
     hasBackButton?: boolean;
+
+    /**
+     * Ref кнопки назад
+     */
+    backButtonRef?: RefObject<HTMLButtonElement>;
 
     /**
      * Дополнительный класс для правого аддона

--- a/yarn.lock
+++ b/yarn.lock
@@ -21924,6 +21924,11 @@ react-swipeable@^5.5.1:
   dependencies:
     prop-types "^15.6.2"
 
+react-swipeable@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-7.0.0.tgz#7a12570ee435d35ac700511de338384aa78d12cd"
+  integrity sha512-NI7KGfQ6gwNFN0Hor3vytYW3iRfMMaivGEuxcADOOfBCx/kqwXE8IfHFxEcxSUkxCYf38COLKYd9EMYZghqaUA==
+
 react-textarea-autosize@^8.3.4:
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz#270a343de7ad350534141b02c9cb78903e553524"


### PR DESCRIPTION
# Опишите проблему
1. Нет возможности выбора высоты в которой будет задерживаться bottom-sheet при закрытии/открытии
2. Нет возможности задать изначальную высоту bottom-sheet
3. Нет возможности задать максимальную высоту bottom-shhet
4. Нет возможности включить скролл внутри шторки в заданной видимой высоте
5. Нет возможности игнорировать свайп при евентах на внутренних элементах
6. Оверлей перехватывает все mouse эвенты, что не позволяет кликать по элементам на странице под bottom-sheet
7. Нет возможности скрыть скроллбар внутри bottom-sheet при помощи параметра

# Ожидаемое поведение
1. При заданных областях `magneticAreas` `bottom-sheet` должен:
  - Задерживаться (притягиваться) при свайпе вниз к самому ближайшему значению
  - Отмагничиваться если свайп был наверх и дальность до самой верхней `magneticArea` больше `magneticThresholdUp`
	- При заданной `magneticThresholdDown` игнорируется притягивание к самой верхней `magneticArea`
  - При свайпе в самый низ, притягиваться к самой нижней точке
  - Запустить коллбек `onMagnetic` индексом из массива `magneticAreas` (если мы отмагнитились от максимлаьной либо минимальной области, отдает -1 вместо идекса)
2. Если `visibleHeight` меняется, то должна меняться видимая высота `bottom-sheet` относительно высоты окна
3. Если `maximumVisibleHeight` задана, то штора не поднимается выше этого значения. Также если заданы mageticAreas, это значение добавляется в конец, для примагничивания к ней
4. Если задана `allowScrollOnNonFullVisible`, тогда будет работать скролл внутри шторы, даже если она открыта не на максимальной высоте
5. При заданном массиве рефов внутри параметра `ignoreSwipeRefs`, скролл по ним не приводит к сдвигу шторы
6. Если `transparentBackdropClick` - истина, клик/ховер и любые другие действия на странице (которые ниже по `z-index` чем `bottom-sheet` и эго контейнер) не должны быть заблокированы
7. Параметры `magneticAreas`, `magneticThresholdUp`, `magneticThresholdDown` можно задать в 2 форматах: `пиксели(number) - 10`, `процент(string) - 10%`


# Чек лист
- [x] Тесты
- [x] Документация


# Тестовый стенд

## Десктоп:
 - OS: MacOS
 - Browser: Safari
 - Version: 16.3

 - OS: MacOS
 - Browser: Chrome
 - Version: 100.0.4896.75

## Смартфон:
 - Device: iPhone 14 Pro
 - OS: iOS 16.3
 - Browser: Safari
 - Version: 16

# Дополнительная информация
Дополнительная информация