### PR TITLE
fix(side-panel): component ref scroll on mobile version

### DIFF
--- a/.changeset/tricky-eggs-study.md
+++ b/.changeset/tricky-eggs-study.md
@@ -1,0 +1,9 @@
+---
+'@alfalab/core-components-base-modal': patch
+'@alfalab/core-components-bottom-sheet': patch
+'@alfalab/core-components-modal': patch
+'@alfalab/core-components-navigation-bar': patch
+'@alfalab/core-components-side-panel': patch
+---
+
+- Изменена нода с overflow: auto в SidePanelMobile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
     - name: Install dependencies
       run: yarn
 
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
     - name: Run lint
       run: yarn lint
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -23,6 +23,10 @@ jobs:
         - name: Checkout LFS objects
           run: git lfs checkout
 
+        - uses: actions/setup-node@v3
+          with:
+            node-version: 16
+
         - name: Install dependencies
           run: yarn
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Install dependencies
         run: yarn --pure-lockfile
 

--- a/packages/base-modal/src/Component.tsx
+++ b/packages/base-modal/src/Component.tsx
@@ -181,6 +181,7 @@ export type BaseModalProps = {
 
 export type BaseModalContext = {
     parentRef: React.RefObject<HTMLDivElement>;
+    componentRef: React.RefObject<HTMLDivElement>;
     hasFooter?: boolean;
     hasHeader?: boolean;
     hasScroll?: boolean;
@@ -197,6 +198,7 @@ export type BaseModalContext = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BaseModalContext = React.createContext<BaseModalContext>({
     parentRef: { current: null },
+    componentRef: { current: null },
     hasFooter: false,
     hasHeader: false,
     hasScroll: false,
@@ -469,6 +471,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
         const contextValue = useMemo<BaseModalContext>(
             () => ({
                 parentRef: wrapperRef,
+                componentRef: componentNodeRef,
                 hasHeader,
                 hasFooter,
                 hasScroll,

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -315,7 +315,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
             ...(titleIsReactElement
                 ? { children: title }
                 : { title: title ? title?.toString() : undefined }),
-            parentRef: scrollableContainer,
+            scrollableParentRef: scrollableContainer,
             className: headerClassName,
             addonClassName,
             closerClassName,

--- a/packages/modal/src/components/header/Component.tsx
+++ b/packages/modal/src/components/header/Component.tsx
@@ -33,7 +33,7 @@ export const Header: FC<HeaderProps> = ({
     return (
         <NavigationBar
             {...restProps}
-            parentRef={parentRef}
+            scrollableParentRef={parentRef}
             hasCloser={hasCloser}
             sticky={sticky}
             view={view}

--- a/packages/navigation-bar/src/Component.tsx
+++ b/packages/navigation-bar/src/Component.tsx
@@ -35,7 +35,7 @@ export const NavigationBar: FC<NavigationBarProps> = ({
     closerIcon,
     onClose,
     view,
-    parentRef,
+    scrollableParentRef,
     sticky,
     onBack,
 }) => {
@@ -58,7 +58,7 @@ export const NavigationBar: FC<NavigationBarProps> = ({
     const headerPaddingTop = mainLinePaddingTopRef.current;
 
     useEffect(() => {
-        const parent = parentRef?.current;
+        const parent = scrollableParentRef?.current;
 
         const handleScroll = (ev: Event) => {
             const divElement = ev.target as HTMLDivElement;
@@ -75,7 +75,7 @@ export const NavigationBar: FC<NavigationBarProps> = ({
         }
 
         return () => parent?.removeEventListener('scroll', handleScroll);
-    }, [parentRef, withAnimation]);
+    }, [scrollableParentRef, withAnimation]);
 
     const renderBackButton = () => {
         let textOpacity = 1;

--- a/packages/navigation-bar/src/types.ts
+++ b/packages/navigation-bar/src/types.ts
@@ -124,9 +124,9 @@ export type NavigationBarProps = {
     view: 'desktop' | 'mobile';
 
     /**
-     * Ссылка на родительскую ноду.
+     * Ссылка на родительскую ноду overflow: auto
      */
-    parentRef?: React.RefObject<HTMLDivElement>;
+    scrollableParentRef?: React.RefObject<HTMLDivElement>;
 };
 
 export type ContentParams = {

--- a/packages/side-panel/src/Component.mobile.tsx
+++ b/packages/side-panel/src/Component.mobile.tsx
@@ -35,7 +35,7 @@ const SidePanelMobileComponent = forwardRef<HTMLDivElement, SidePanelMobileProps
                 }}
                 className={cn(className, styles.component)}
             >
-                {children}
+                <div className={styles.mobileContent}>{children}</div>
             </BaseModal>
         );
 

--- a/packages/side-panel/src/components/header/Component.tsx
+++ b/packages/side-panel/src/components/header/Component.tsx
@@ -21,7 +21,7 @@ export const Header: FC<HeaderProps> = ({
     hasCloser = true,
     ...restProps
 }) => {
-    const { setHasHeader, headerHighlighted, parentRef, onClose } = useContext(ModalContext);
+    const { setHasHeader, headerHighlighted, onClose, componentRef } = useContext(ModalContext);
     const { size = 's', view = 'desktop' } = useContext(ResponsiveContext) || {};
 
     useEffect(() => {
@@ -33,7 +33,7 @@ export const Header: FC<HeaderProps> = ({
     return (
         <NavigationBar
             {...restProps}
-            parentRef={parentRef}
+            scrollableParentRef={componentRef}
             view={view}
             sticky={sticky}
             title={title}

--- a/packages/side-panel/src/mobile.module.css
+++ b/packages/side-panel/src/mobile.module.css
@@ -1,6 +1,18 @@
 @import './vars.css';
 
 .component {
+    position: fixed;
+    top: 0;
     flex: 1;
+    height: 100%;
     width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.mobileContent {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    flex: 1;
 }


### PR DESCRIPTION
# Опишите проблему
В мобильной версии сайд панели не используется обертка в виде Drawer, где проставляется owerflow: auto; для BaseModal и получается что при попытке скролить через рефу componentRef ничего не происходит, потому-что скрол ставится на враппере. 

