### PR TITLE
fix(button): fix dark theme button loader color

### DIFF
--- a/.changeset/twelve-walls-cover.md
+++ b/.changeset/twelve-walls-cover.md
@@ -1,0 +1,6 @@
+---
+"@alfalab/core-components-button": patch
+"@alfalab/core-components-themes": patch
+---
+
+Исправлен цвет лоадера в mobile, click, intranet темах

--- a/packages/button/src/default.module.css
+++ b/packages/button/src/default.module.css
@@ -62,6 +62,7 @@
 
     /* loader */
     --button-spinner-static-color: var(--color-static-graphic-light);
+    --button-spinner-static-primary-color: var(--color-static-graphic-light);
     --button-spinner-default-color: var(--color-light-graphic-primary);
 }
 
@@ -105,7 +106,7 @@
     }
 
     & > .loader {
-        color: var(--button-spinner-static-color);
+        color: var(--button-spinner-static-primary-color);
     }
 }
 

--- a/packages/themes/src/mixins/button/click.css
+++ b/packages/themes/src/mixins/button/click.css
@@ -8,5 +8,5 @@
     --button-primary-color: var(--color-light-text-primary-inverted);
 
     /* loader */
-    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
+    --button-spinner-static-primary-color: var(--color-light-graphic-primary-inverted);
 }

--- a/packages/themes/src/mixins/button/click.css
+++ b/packages/themes/src/mixins/button/click.css
@@ -6,4 +6,7 @@
     --button-primary-disabled-bg-color: var(--color-light-bg-secondary-inverted);
     --button-primary-disabled-color: var(--color-light-text-tertiary-inverted);
     --button-primary-color: var(--color-light-text-primary-inverted);
+
+    /* loader */
+    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
 }

--- a/packages/themes/src/mixins/button/intranet.css
+++ b/packages/themes/src/mixins/button/intranet.css
@@ -63,5 +63,5 @@
     --button-inverted-primary-color: var(--color-light-text-primary);
 
     /* loader */
-    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
+    --button-spinner-static-primary-color: var(--color-light-graphic-primary-inverted);
 }

--- a/packages/themes/src/mixins/button/intranet.css
+++ b/packages/themes/src/mixins/button/intranet.css
@@ -61,4 +61,7 @@
     --button-inverted-primary-disabled-bg-color: var(--color-light-bg-secondary);
     --button-inverted-primary-disabled-color: var(--color-light-text-tertiary);
     --button-inverted-primary-color: var(--color-light-text-primary);
+
+    /* loader */
+    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
 }

--- a/packages/themes/src/mixins/button/mobile.css
+++ b/packages/themes/src/mixins/button/mobile.css
@@ -63,5 +63,5 @@
     --button-inverted-primary-color: var(--color-light-text-primary);
 
     /* loader */
-    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
+    --button-spinner-static-primary-color: var(--color-light-graphic-primary-inverted);
 }

--- a/packages/themes/src/mixins/button/mobile.css
+++ b/packages/themes/src/mixins/button/mobile.css
@@ -61,4 +61,7 @@
     --button-inverted-primary-disabled-bg-color: var(--color-light-bg-secondary);
     --button-inverted-primary-disabled-color: var(--color-light-text-tertiary);
     --button-inverted-primary-color: var(--color-light-text-primary);
+
+    /* loader */
+    --button-spinner-static-color: var(--color-light-graphic-primary-inverted);
 }


### PR DESCRIPTION
# Опишите проблему
Лоадер в компоненте Button типа primary в темных темах mobile, click, intranet сливался с белым цветом самой кнопки.

# Внешний вид

Было:
<img width="776" alt="Screenshot 2023-02-20 at 12 20 36" src="https://user-images.githubusercontent.com/56126128/220084007-f3c8099d-2efb-4391-a9ad-4a08fbf07cf5.png">

Стало:
<img width="264" alt="Screenshot 2023-02-20 at 14 39 54" src="https://user-images.githubusercontent.com/56126128/220084038-d48c16bf-62c0-4698-af49-fc6fded049da.png">


