### PR TITLE
fix(bottom-sheet): fixed footer overlaps

### DIFF
--- a/.changeset/calm-bulldogs-mix.md
+++ b/.changeset/calm-bulldogs-mix.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-bottom-sheet': patch
+---
+
+Исправлена ошибка, из-за которой контент с z-index, отличным от auto, наезжал на sticky footer  
+

--- a/packages/bottom-sheet/src/components/footer/index.module.css
+++ b/packages/bottom-sheet/src/components/footer/index.module.css
@@ -13,6 +13,7 @@
 .sticky {
     position: sticky;
     bottom: 0;
+    z-index: 1;
 }
 
 .highlighted {

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -49,6 +49,8 @@
 }
 
 .content {
+    position: relative;
+    z-index: 0;
     display: flex;
     flex-direction: column;
     flex: 1;


### PR DESCRIPTION
Пример:
```
function Example() {
    const [open, setOpen] = React.useState(false);
    return (
        <div>
            <BottomSheet hasCloser onClose={() => setOpen(false)} open={open} actionButton={
              <div>
                <Button view='primary'>Применить</Button>
              </div>
            }>
            <div style={{height: 1000}}/>
                <Plate
                  view='negative'
                  title='Компонент плашки'
                  leftAddons={<Badge view='icon' iconColor='negative' content={<AlertCircleMIcon />} />}
                />
            </BottomSheet>
            <Button onClick={() => setOpen(true)}>
                Нажми на меня
            </Button>
        </div>
    );
}
render(
    <Example />
)
```