### PR TITLE
fix(side-panel): fixed footer and header overlaps

### DIFF
--- a/.changeset/warm-feet-eat.md
+++ b/.changeset/warm-feet-eat.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-side-panel': patch
+---
+
+Исправлена ошибка, из-за которой контент с z-index, отличным от auto, наезжал на sticky footer и header  
+

--- a/packages/side-panel/src/components/content/index.module.css
+++ b/packages/side-panel/src/components/content/index.module.css
@@ -1,8 +1,10 @@
 @import '../../vars.css';
 
 .content {
+    position: relative;
     box-sizing: border-box;
     width: 100%;
+    z-index: 0;
 
     &.withHeader {
         padding-top: 0;


### PR DESCRIPTION
Пример:

```javascript
function Example() {
    const [open, setOpen] = React.useState(false);
    return (
      <div>
        <SidePanelDesktop open={open} onClose={() => setOpen(false)}>
            <SidePanelDesktop.Header sticky title='title'/>
            
            <SidePanelDesktop.Content>
                <Plate
                  view='negative'
                  title='Компонент плашки'
                  leftAddons={<Badge view='icon' iconColor='negative' content={<AlertCircleMIcon />} />}
                />
                 <div style={{height: 1000}}/>
                 <Select options={[{key: '123123'}]}/>
            </SidePanelDesktop.Content>
                
            <SidePanelDesktop.Footer sticky>
                Footer
            </SidePanelDesktop.Footer>
          </SidePanelDesktop>
          
          <Button onClick={() => setOpen(true)}>
              Нажми на меня
          </Button>
      </div>
    );
}
render(
    <Example />
)
```