### PR TITLE
fix(modal): fixed footer and header overlaps

### DIFF
--- a/.changeset/slimy-mirrors-melt.md
+++ b/.changeset/slimy-mirrors-melt.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-modal': patch
+---
+
+Исправлена ошибка, из-за которой контент с z-index, отличным от auto, наезжал на sticky footer и header

--- a/packages/modal/src/components/content/index.module.css
+++ b/packages/modal/src/components/content/index.module.css
@@ -1,8 +1,10 @@
 @import '../../vars.css';
 
 .content {
+    position: relative;
     box-sizing: border-box;
     width: 100%;
+    z-index: 0;
 
     &.withHeader {
         padding-top: 0;


### PR DESCRIPTION
Пример:

```javascript
function Example() {
    const [open, setOpen] = React.useState(false);
    return (
        <div>
            <ModalDesktop open={open} onClose={() => setOpen(false)}>
            <ModalDesktop.Header sticky title='title'/>
            
            <ModalDesktop.Content>
                <Plate
                  view='negative'
                  title='Компонент плашки'
                  leftAddons={<Badge view='icon' iconColor='negative' content={<AlertCircleMIcon />} />}
                />
                 <div style={{height: 1000}}/>
              </ModalDesktop.Content>
                
              <ModalDesktop.Footer sticky>
                  Footer
              </ModalDesktop.Footer>
            </ModalDesktop>
            <Button onClick={() => setOpen(true)}>
                Нажми на меня
            </Button>
        </div>
    );
}
render(
    <Example />
)
```