### PR TITLE
feat(bottom-sheet): Fix type of magneticAreas prop in bottom-sheet co…

### DIFF
--- a/.changeset/mighty-months-shout.md
+++ b/.changeset/mighty-months-shout.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-bottom-sheet': minor
+---
+
+Fixed magneticAreas type

--- a/packages/bottom-sheet/src/types.ts
+++ b/packages/bottom-sheet/src/types.ts
@@ -229,7 +229,7 @@ export type BottomSheetProps = {
      * По-умолчанию -[0, window.innerHeight - '24px']
      * массив должен состоять минимум из 2 элементов
      */
-    magneticAreas?: number[];
+    magneticAreas?: (number | string)[];
 
     /**
      * Индекс точки из magneticAreas, к которому нужно примагнититься при первом открытии шторки.

--- a/packages/bottom-sheet/src/types.ts
+++ b/packages/bottom-sheet/src/types.ts
@@ -229,7 +229,7 @@ export type BottomSheetProps = {
      * По-умолчанию -[0, window.innerHeight - '24px']
      * массив должен состоять минимум из 2 элементов
      */
-    magneticAreas?: (number | string)[];
+    magneticAreas?: Array<number | string>;
 
     /**
      * Индекс точки из magneticAreas, к которому нужно примагнититься при первом открытии шторки.


### PR DESCRIPTION
# Опишите проблему
Тип `number[]` не сходится с описанием пропа `magneticAreas` ( и с логикой работы, этот проп умеет преобразовывать проценты в числа относительно размера экрана )

# Ожидаемое поведение
Принимаемый тип должен быть `(string|number)[]`
