### PR TITLE
fix(intl-phone-input): fixed format phone

### DIFF
--- a/.changeset/hip-plants-deliver.md
+++ b/.changeset/hip-plants-deliver.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-intl-phone-input": patch
+---
+
+Исправлена ошибка, из-за которой при пустом значении defaultCountryIso2 неверно форматировались российские номера

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -236,7 +236,7 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
         const setCountryByDialCode = (inputValue: string) => {
             const country = getCountryByNumber(inputValue);
 
-            changePhone(addCountryCode(inputValue));
+            changePhone(addCountryCode(inputValue), country?.iso2);
             if (country) {
                 setCountryIso2(country.iso2);
                 handleCountryChange(country.iso2);


### PR DESCRIPTION
# Опишите проблему
При value='+79059495743' и defaultCountryIso2='' не форматируется российский номера телефона (пустое значение, так как может быть иностранный номер)

# Ожидаемое поведение
При таких входных параметрах номер телефона должен быть отформатирован


# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** + 7 905 949-57-43  ** | ** + 7 905 949 57 43     **|
