### PR TITLE
fix(select-options): fix show footer

### DIFF
--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -36,6 +36,7 @@ export const OptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
             open,
             header,
             footer,
+            showFooter,
             optionsListWidth,
             nativeScrollbar: nativeScrollbarProp,
             flatOptions = [],
@@ -123,7 +124,7 @@ export const OptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
 
                 {nativeScrollbar ? renderWithNativeScrollbar() : renderWithCustomScrollbar()}
 
-                {footer && (
+                {showFooter && footer && (
                     <div
                         className={cn(styles.optionsListFooter, {
                             [styles.withBorder]:

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -30,6 +30,7 @@ export const VirtualOptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
             visibleOptions = DEFAULT_VISIBLE_OPTIONS,
             header,
             footer,
+            showFooter,
             optionsListWidth,
             onScroll,
             nativeScrollbar: nativeScrollbarProp,
@@ -200,7 +201,7 @@ export const VirtualOptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
                     <div className={styles.emptyPlaceholder}>{emptyPlaceholder}</div>
                 )}
 
-                {footer && (
+                {showFooter && footer && (
                     <div
                         className={cn(styles.virtualOptionsListFooter, {
                             [styles.withBorder]:


### PR DESCRIPTION
# Опишите проблему
SelectMobile - при использовании пропа OptionsList при отрисовки options с помощью VirtualOptionsList появляется футер с кнопками, которого не должно быть

<img width="1207" alt="Screenshot 2023-05-16 at 10 43 43" src="https://github.com/core-ds/core-components/assets/131259332/ff297c90-4594-4cc0-ac1d-6d1d5afd555d">


# Шаги для воспроизведения
1. Перейти на страницу Оплату мобильной связи (/payments/mobile) в мобильном разрешении
2. Нажать на селект Выбор оператора

# Ожидаемое поведение
При нажатии на селект должен появится список доступных операторов без футер


# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
<img width="333" alt="Screenshot 2023-05-16 at 10 59 13" src="https://github.com/core-ds/core-components/assets/131259332/6bda41c8-edfd-410b-b8e4-4c6a403edabe">  | <img width="344" alt="Screenshot 2023-05-16 at 11 00 32" src="https://github.com/core-ds/core-components/assets/131259332/2904ceba-8f9f-4792-9851-1577e26b01ec"> 


# Дополнительная информация
Дополнительная информация
