### PR TITLE
feat(pure-cell): add vertical align auto for Addon

### DIFF
--- a/.changeset/wicked-monkeys-eat.md
+++ b/.changeset/wicked-monkeys-eat.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pure-cell': patch
+---
+
+Добавлено значение auto для растягивания контента по всей высоте компонента Addon

--- a/packages/pure-cell/src/components/addon/component.tsx
+++ b/packages/pure-cell/src/components/addon/component.tsx
@@ -10,7 +10,7 @@ type Props = {
     /**
      * Вертикальное выравнивание
      */
-    verticalAlign?: 'top' | 'center' | 'bottom';
+    verticalAlign?: 'auto' | 'top' | 'center' | 'bottom';
 
     /**
      * Горизонтальные отступы

--- a/packages/pure-cell/src/components/addon/index.module.css
+++ b/packages/pure-cell/src/components/addon/index.module.css
@@ -21,6 +21,10 @@
         padding-left: var(--gap-m);
     }
 
+    &.auto {
+        align-self: auto;
+    }
+
     &.top {
         align-self: flex-start;
     }


### PR DESCRIPTION
# Опишите проблему
В компоненте PureCell.Addon по умолчанию verticalAlign = 'top'(lign-self: flex-start). При пробрасывании чалдов в Addon, они смыкаются и прижимаются к верху враппера, без возможности растянуть их на всю высоту враппера

# Шаги для воспроизведения
1. Перейти на страницу '...'
2. Нажать на кнопку '...'

# Ожидаемое поведение
Иметь возможность прокинуть проп для растягивания контента Addon на всю высоту контейнера

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10

## Смартфон (если данных нет оставте блок пустым):
 - Device: iPhone 6
 - OS: iOS 10
 - Browser: Chrome
 - Version: 65

# Дополнительная информация
Дополнительная информация
