### PR TITLE
fix: Underlay borderRadius и overflow параметр

### DIFF
--- a/.changeset/six-pillows-juggle.md
+++ b/.changeset/six-pillows-juggle.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-underlay': minor
+---
+
+Fix borderRadius property, added new overflow property

--- a/.changeset/six-pillows-juggle.md
+++ b/.changeset/six-pillows-juggle.md
@@ -2,4 +2,4 @@
 '@alfalab/core-components-underlay': minor
 ---
 
-Fix borderRadius property, added new overflow property
+Фикс параметра borderRadius, добавлен параметр overflow

--- a/packages/underlay/src/Component.tsx
+++ b/packages/underlay/src/Component.tsx
@@ -17,6 +17,7 @@ export const Underlay = forwardRef<HTMLDivElement, UnderlayProps>(
             className,
             padding,
             dataTestId,
+            overflow = true,
             ...restProps
         },
         ref,
@@ -44,6 +45,7 @@ export const Underlay = forwardRef<HTMLDivElement, UnderlayProps>(
                     borderColor && styles[`border-color-${borderColor}`],
                     borderSize && styles[`border-width-${borderSize}`],
                     shadow && styles[shadow],
+                    { [styles.overflowHide]: !overflow },
                     className,
                 )}
                 data-test-id={dataTestId}

--- a/packages/underlay/src/docs/Component.stories.mdx
+++ b/packages/underlay/src/docs/Component.stories.mdx
@@ -85,12 +85,13 @@ export const SHADOW = [
 <Story name='Underlay'>
     {React.createElement(() => {
         const paddingSizes = ['3xs', '2xs', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl', '4xl'];
-        const borderRadius = select('borderRadius', ['m', 'xl', 'xxl'], 'm');
+        const borderRadius = select('borderRadius', ['m', 'l', 'xl', 'xxl'], 'm');
         const borderSize = select('borderSize', ['1', '2', '4'], '2');
         const paddingTop = select('padding.top', paddingSizes, 'm');
         const paddingRight = select('padding.right', paddingSizes, 'm');
         const paddingBottom = select('padding.bottom', paddingSizes, 'm');
         const paddingLeft = select('padding.left', paddingSizes, 'm');
+        const overflow = select('overflow', ['true', 'false'], 'false');
         return (
             <Underlay
                 borderRadius={borderRadius}
@@ -98,6 +99,7 @@ export const SHADOW = [
                 shadow={select('shadow', SHADOW, 'shadow-l')}
                 backgroundColor={select('backgroundColor', BACKGROUND, 'positive-muted')}
                 borderColor={select('borderColor', BORDER_COLOR, 'graphic-positive')}
+                overflow={overflow === 'true'}
                 padding={{
                     top: paddingTop,
                     right: paddingRight,

--- a/packages/underlay/src/docs/Component.stories.mdx
+++ b/packages/underlay/src/docs/Component.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Markdown } from '@storybook/addon-docs';
-import { select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { ComponentHeader, Tabs } from 'storybook/blocks';
 
 import { Underlay } from '@alfalab/core-components-underlay';
@@ -91,7 +91,7 @@ export const SHADOW = [
         const paddingRight = select('padding.right', paddingSizes, 'm');
         const paddingBottom = select('padding.bottom', paddingSizes, 'm');
         const paddingLeft = select('padding.left', paddingSizes, 'm');
-        const overflow = select('overflow', ['true', 'false'], 'false');
+        const overflow = boolean('overflow', true);
         return (
             <Underlay
                 borderRadius={borderRadius}
@@ -99,7 +99,7 @@ export const SHADOW = [
                 shadow={select('shadow', SHADOW, 'shadow-l')}
                 backgroundColor={select('backgroundColor', BACKGROUND, 'positive-muted')}
                 borderColor={select('borderColor', BORDER_COLOR, 'graphic-positive')}
-                overflow={overflow === 'true'}
+                overflow={overflow}
                 padding={{
                     top: paddingTop,
                     right: paddingRight,

--- a/packages/underlay/src/docs/description.mdx
+++ b/packages/underlay/src/docs/description.mdx
@@ -1,6 +1,6 @@
 ## Примеры
 
-Настраиваются: цвет фона, тень, радиус скругления, величина отступов, цвет и толщина обводки. 
+Настраиваются: цвет фона, тень, радиус скругления, величина отступов, цвет и толщина обводки.
 При необходимости, можно сделать компонент кликабельным.
 
 ```jsx live
@@ -13,10 +13,10 @@ render(() => {
         border: '1px dashed rgb(55, 120, 251)',
         boxSizing: 'border-box',
     }
-    
+
     const handleClick = () => {
       alert('Клик!')
-    } 
+    }
 
     const css = `
         div[data-test-id='test1'] {
@@ -24,16 +24,16 @@ render(() => {
             width: 320px;
             height: 200px;
         }
-        
+
         div[data-test-id='test2'] {
             background-image: url(./images/underlay.png);
-            background-repeat: no-repeat;            
+            background-repeat: no-repeat;
         }
     `;
 
     return (
     <Container>
-        <Underlay 
+        <Underlay
             onClick={handleClick}
             borderSize={1}
             borderRadius='xl'
@@ -43,6 +43,7 @@ render(() => {
                 bottom: 'm',
                 right: 'm'
             }}
+            overflow={false}
             backgroundColor='positive-muted'
             borderColor='graphic-positive'
             dataTestId='test1'
@@ -51,7 +52,7 @@ render(() => {
         </Underlay>
         <style>{css}</style>
         <Gap size='l'/>
-        <Underlay 
+        <Underlay
             padding='m'
             dataTestId='test2'
             >

--- a/packages/underlay/src/index.module.css
+++ b/packages/underlay/src/index.module.css
@@ -5,6 +5,10 @@
     box-sizing: border-box;
 }
 
+.overflow-hide {
+    overflow: hidden;
+}
+
 @mixin bg-class-list;
 
 @each $size in 3xs, 2xs, xs, s, m, l, xl, 2xl, 3xl, 4xl {
@@ -58,7 +62,7 @@
     }
 }
 
-@each $radius in m, xl, xxl {
+@each $radius in m, l, xl, xxl {
     .border-radius-$(radius) {
         border-radius: var(--border-radius-$(radius));
     }

--- a/packages/underlay/src/index.module.css
+++ b/packages/underlay/src/index.module.css
@@ -5,7 +5,7 @@
     box-sizing: border-box;
 }
 
-.overflow-hide {
+.overflowHide {
     overflow: hidden;
 }
 

--- a/packages/underlay/src/types.ts
+++ b/packages/underlay/src/types.ts
@@ -39,11 +39,10 @@ export type UnderlayProps = React.HTMLAttributes<HTMLDivElement> & {
      */
     borderColor?: BorderColorType;
 
-    /*
-    * Настройка выступа за границы underlay
-    * true - разрешен
-    * false - запрещен
-    * */
+    /**
+    * Настройка выступа за границы (true - разрешен)
+    * default: true
+    */
     overflow?: boolean;
 
     /**

--- a/packages/underlay/src/types.ts
+++ b/packages/underlay/src/types.ts
@@ -40,9 +40,9 @@ export type UnderlayProps = React.HTMLAttributes<HTMLDivElement> & {
     borderColor?: BorderColorType;
 
     /**
-    * Настройка выступа за границы (true - разрешен)
-    * default: true
-    */
+     * Настройка выступа за границы (true - разрешен)
+     * default: true
+     */
     overflow?: boolean;
 
     /**

--- a/packages/underlay/src/types.ts
+++ b/packages/underlay/src/types.ts
@@ -40,7 +40,7 @@ export type UnderlayProps = React.HTMLAttributes<HTMLDivElement> & {
     borderColor?: BorderColorType;
 
     /**
-     * Настройка выступа за границы (true - разрешен)
+     * Настройка переполнения (true - разрешена)
      * default: true
      */
     overflow?: boolean;

--- a/packages/underlay/src/types.ts
+++ b/packages/underlay/src/types.ts
@@ -11,7 +11,7 @@ type PaddingType = {
     left?: PaddingSize;
 };
 
-type BorderRadiusType = 'm' | 'l' | 'xxl';
+type BorderRadiusType = 'm' | 'l' | 'xl' | 'xxl';
 
 export type UnderlayProps = React.HTMLAttributes<HTMLDivElement> & {
     /**
@@ -38,6 +38,13 @@ export type UnderlayProps = React.HTMLAttributes<HTMLDivElement> & {
      * Цвет бордера
      */
     borderColor?: BorderColorType;
+
+    /*
+    * Настройка выступа за границы underlay
+    * true - разрешен
+    * false - запрещен
+    * */
+    overflow?: boolean;
 
     /**
      * Тень


### PR DESCRIPTION
# Опишите проблему
- При использовании параметра `borderRadius` равного `xl` - ошибка типа, но компонент выставляет вырный бордерРадиус
- При использовании `borderRadius` равного `l` - скругления не появляетсяются
- Нет возможности настроить overflow без использования классов


# Чек лист
- [x] Тесты
- [x] Документация

# Тестовый стенд

## Десктоп:
 - OS: MacOS
 - Browser: Safari
 - Version: 16.4
