### PR TITLE
feat(tag): make onClick method params required

### DIFF
--- a/.changeset/nervous-cows-fetch.md
+++ b/.changeset/nervous-cows-fetch.md
@@ -1,5 +1,5 @@
 ---
-'@alfalab/core-components-tag': patch
+'@alfalab/core-components-tag': minor
 ---
 
-Параметры `event` и `payload` в пропе `onClick` стали обязательными
+Параметры `event` и `payload` в пропе `onClick` передаются всегда

--- a/.changeset/nervous-cows-fetch.md
+++ b/.changeset/nervous-cows-fetch.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tag': patch
+---
+
+Параметры `event` и `payload` в пропе `onClick` стали обязательными

--- a/packages/tag/src/Component.tsx
+++ b/packages/tag/src/Component.tsx
@@ -55,8 +55,8 @@ export type TagProps = Omit<NativeProps, 'onClick'> & {
      * Обработчик нажатия
      */
     onClick?: (
-        event?: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        payload?: {
+        event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        payload: {
             checked: boolean;
             name?: string;
         },


### PR DESCRIPTION
# Опишите проблему
В пропе onClick у компонента Tag параметры event и payload являются необязательными. В то время как в компоненте CheckboxGroup в пропе onChange они же являются обязательными. Не получается использовать один и тот же обработчик клика для CheckboxGround и Tag. 

# Ожидаемое поведение
Иметь возможность использовать один хэндлер и для CheckboxGround, и для Tag

# Внешний вид
 - не изменено
