### PR TITLE
feat(side-panel): add scrollableNodeRef

### DIFF
--- a/.changeset/pink-masks-invite.md
+++ b/.changeset/pink-masks-invite.md
@@ -1,0 +1,6 @@
+---
+"@alfalab/core-components-drawer": minor
+"@alfalab/core-components-side-panel": minor
+---
+
+feat(side-panel): Добавлен проп scrollableNodeRef для получения контейнера со скроллом

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -21,6 +21,7 @@
         "@alfalab/core-components-base-modal": "^5.1.3",
         "@alfalab/core-components-scrollbar": "^2.1.5",
         "classnames": "^2.3.1",
+        "react-merge-refs": "^1.1.0",
         "tslib": "^2.4.0"
     }
 }

--- a/packages/drawer/src/Component.tsx
+++ b/packages/drawer/src/Component.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useMemo } from 'react';
+import React, { forwardRef, MutableRefObject, useMemo } from 'react';
+import mergeRefs from 'react-merge-refs';
 import { CSSTransition } from 'react-transition-group';
 import { TransitionProps } from 'react-transition-group/Transition';
 import cn from 'classnames';
@@ -27,6 +28,11 @@ export type DrawerProps = Omit<BaseModalProps, 'container'> & {
      * Пропсы кастомного скроллбара.
      */
     scrollbarProps?: Partial<Omit<ScrollbarProps, 'children'>>;
+
+    /**
+     * Реф для контейнера со скроллом.
+     */
+    scrollableNodeRef?: MutableRefObject<HTMLDivElement>;
 
     /**
      * Пропсы для анимации контента (CSSTransition)
@@ -73,6 +79,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
             nativeScrollbar = true,
             placement = 'right',
             scrollbarProps,
+            scrollableNodeRef,
             ...restProps
         },
         ref,
@@ -109,7 +116,16 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
 
         const renderWithCustomScrollbar = () => (
             <Scrollbar
-                {...scrollbarProps}
+                {...{
+                    ...scrollbarProps,
+                    scrollableNodeProps: {
+                        ...scrollbarProps?.scrollableNodeProps,
+                        ref: mergeRefs([
+                            scrollableNodeRef ?? null,
+                            scrollbarProps?.scrollableNodeProps?.ref ?? null,
+                        ]),
+                    },
+                }}
                 className={cn(styles.simplebar, scrollbarProps?.className)}
             >
                 {children}
@@ -128,6 +144,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
                 })}
                 transitionProps={transitionProps}
                 backdropProps={{ ...backdropProps, ...restProps.backdropProps }}
+                componentRef={nativeScrollbar ? scrollableNodeRef : undefined}
             >
                 <CSSTransition
                     {...{ ...contentProps, ...contentTransitionProps }}

--- a/packages/side-panel/src/Component.desktop.tsx
+++ b/packages/side-panel/src/Component.desktop.tsx
@@ -1,4 +1,11 @@
-import React, { cloneElement, forwardRef, isValidElement, useContext, useRef } from 'react';
+import React, {
+    cloneElement,
+    forwardRef,
+    isValidElement,
+    MutableRefObject,
+    useContext,
+    useRef,
+} from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
@@ -30,6 +37,11 @@ export type SidePanelDesktopProps = BaseModalProps &
          * @default false
          */
         hasCloser?: boolean;
+
+        /**
+         * Реф для контейнера со скроллом.
+         */
+        scrollableNodeRef?: MutableRefObject<HTMLDivElement>;
     };
 
 const SidePanelDesktopComponent = forwardRef<HTMLDivElement, SidePanelDesktopProps>(
@@ -42,6 +54,7 @@ const SidePanelDesktopComponent = forwardRef<HTMLDivElement, SidePanelDesktopPro
             contentTransitionProps = {},
             backdropProps,
             placement = 'right',
+            scrollableNodeRef,
             ...restProps
         },
         ref,
@@ -84,6 +97,7 @@ const SidePanelDesktopComponent = forwardRef<HTMLDivElement, SidePanelDesktopPro
                     },
                     ...contentTransitionProps,
                 }}
+                scrollableNodeRef={scrollableNodeRef}
             >
                 {React.Children.map(children, (child) =>
                     isValidElement(child) ? cloneElement(child, { size }) : child,

--- a/packages/side-panel/src/Component.mobile.tsx
+++ b/packages/side-panel/src/Component.mobile.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef, MutableRefObject, useContext } from 'react';
 import cn from 'classnames';
 
 import { BaseModal, BaseModalProps } from '@alfalab/core-components-base-modal';
@@ -17,12 +17,17 @@ export type SidePanelMobileProps = BaseModalProps & {
      * @default false
      */
     hasCloser?: boolean;
+
+    /**
+     * Реф для контейнера со скроллом.
+     */
+    scrollableNodeRef?: MutableRefObject<HTMLDivElement>;
 };
 
 const contextValue = { size: 's', view: 'mobile' } as const;
 
 const SidePanelMobileComponent = forwardRef<HTMLDivElement, SidePanelMobileProps>(
-    ({ children, className, transitionProps, ...restProps }, ref) => {
+    ({ children, className, transitionProps, scrollableNodeRef, ...restProps }, ref) => {
         const responsiveContext = useContext(ResponsiveContext);
 
         const renderContent = () => (
@@ -35,6 +40,7 @@ const SidePanelMobileComponent = forwardRef<HTMLDivElement, SidePanelMobileProps
                 }}
                 className={cn(className, styles.component)}
                 scrollHandler='content'
+                componentRef={scrollableNodeRef}
             >
                 <div className={styles.mobileContent}>{children}</div>
             </BaseModal>

--- a/packages/side-panel/src/typings.ts
+++ b/packages/side-panel/src/typings.ts
@@ -3,4 +3,5 @@ export type View = 'desktop' | 'mobile';
 export type TResponsiveModalContext = {
     view: View;
     size: 's';
+    scrollableRef?: React.RefObject<HTMLDivElement>;
 } | null;


### PR DESCRIPTION
Всем привет, а можете подсказать в десктопной версии `SidePanel` используется Drawer, который использует кастомный скролл бар по-умолчанию, а мобильная версия сайд панели использует напрямую BaseModal, в логике использования я подписываюсь на скролл в сайд панеле и сейчас получается, что если мне использовать десктопную версию, то рефу можно прокинуть таким образом `scrollbarProps={{ scrollableNodeProps: { ref: scrollableRef } }}`, но для мобильной версии так не работает, там приходится делать так

```
componentRef={scrollableRef}
nativeScrollbar={true}
```

а вобще целевой вариант - это переходить на кастомный скролл? Пока что видится, что такой возможности у нас нет, если хочется использовать подписки на скролл, пока придется наверное юзать нативный скроллбар (так как могут быть ситуации, что в десктопной версии пользователь может сузить браузер и получить мобильную версию сайд панели и тогда эта логика со скроллом поломается, у нас бандлы отдаются по юзер агенту и по нему определяется дестопная версия или нет)

Может будет возможность как-то пофиксить, чтобы можно было одними и теми же пропсами передавать рефу для кролла, или для мобильной версии может тоже будет переход на кастомный скролл бар?