### PR TITLE
fix(steps): make checkIsStepCustom's return value nullable

### DIFF
--- a/.changeset/clean-carrots-judge.md
+++ b/.changeset/clean-carrots-judge.md
@@ -1,5 +1,5 @@
 ---
-"@alfalab/core-components-steps": patch
+"@alfalab/core-components-steps": minor
 ---
 
 fix(steps): make checkIsStepCustom's return value nullable

--- a/.changeset/clean-carrots-judge.md
+++ b/.changeset/clean-carrots-judge.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-steps": patch
+---
+
+fix(steps): make checkIsStepCustom's return value nullable

--- a/packages/steps/src/Component.tsx
+++ b/packages/steps/src/Component.tsx
@@ -89,9 +89,9 @@ export type StepsProps = {
     /**
      * Кастомный метод для установки кастомного индикатора шага
      * @param stepNumber - номер шага
-     * @return Объект StepIndicatorProps { className, content, iconColor }
+     * @return Объект StepIndicatorProps { className, content, iconColor } или null
      */
-    checkIsStepCustom?: (stepNumber: number) => StepIndicatorProps;
+    checkIsStepCustom?: (stepNumber: number) => StepIndicatorProps | null;
 
     /**
      * Обработчик клика на шаг

--- a/packages/steps/src/components/step/Component.tsx
+++ b/packages/steps/src/components/step/Component.tsx
@@ -69,7 +69,7 @@ export type StepProps = {
     /**
      * Свойства кастомного индикатора текущего шага
      */
-    customStepIndicator?: StepIndicatorProps;
+    customStepIndicator?: StepIndicatorProps | null;
 
     /**
      * Управление ориентацией компонента


### PR DESCRIPTION
Добавлена возможность возвращать null для функции checkIsStepCustom, так как это необходимо для применения кастомной иконки к конкретному шагу, иначе иконка будет применяться ко всем шагам.
