### PR TITLE
fix(cdn-icon): added color icon support

### DIFF
--- a/.changeset/shaggy-cheetahs-warn.md
+++ b/.changeset/shaggy-cheetahs-warn.md
@@ -1,5 +1,5 @@
 ---
-"@alfalab/core-components-cdn-icon": minor
+"@alfalab/core-components-cdn-icon": patch
 ---
 
-fix(cdn-icon): added color icon support
+Исправлено отображение цветных иконок

--- a/.changeset/shaggy-cheetahs-warn.md
+++ b/.changeset/shaggy-cheetahs-warn.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-cdn-icon": minor
+---
+
+fix(cdn-icon): added color icon support

--- a/packages/cdn-icon/src/Component.tsx
+++ b/packages/cdn-icon/src/Component.tsx
@@ -36,6 +36,8 @@ export const CDNIcon: React.FC<CDNIconProps> = ({
 }) => {
     const [icon, setIcon] = useState('');
 
+    const monoIcon = !name.includes('_color');
+
     useEffect(() => {
         const xhr = new XMLHttpRequest();
 
@@ -53,7 +55,7 @@ export const CDNIcon: React.FC<CDNIconProps> = ({
     return (
         <span
             style={{ color }}
-            className={cn(styles.component, className)}
+            className={cn(styles.component, className, { [styles.parentColor]: monoIcon })}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: icon }}
             data-test-id={dataTestId}

--- a/packages/cdn-icon/src/index.module.css
+++ b/packages/cdn-icon/src/index.module.css
@@ -6,6 +6,6 @@
 .component svg {
     fill: currentColor;
 }
-.component path {
+.component.parentColor path {
     fill: inherit;
 }

--- a/packages/cdn-icon/src/index.module.css
+++ b/packages/cdn-icon/src/index.module.css
@@ -6,6 +6,6 @@
 .component svg {
     fill: currentColor;
 }
-.component.parentColor path {
+.parentColor path {
     fill: inherit;
 }


### PR DESCRIPTION
# Опишите проблему
При name='flag_abkhazia_m_color' или любой другой цветной иконки с пометкой '_color' компонент возвращал черную иконку.

# Шаги для воспроизведения
1. `<CDNIcon name='flag_abkhazia_m_color' />`

# Ожидаемое поведение
При name='flag_abkhazia_m_color' или любой другой цветной иконки с пометкой '_color' компонент должен возвращать цветную иконку.

# Внешний вид

Ожидаемый  | Фактический
:---------------:|:--------------------
| <img width="377" alt="Screenshot 2023-08-04 at 10 12 20" src="https://github.com/core-ds/core-components/assets/131259332/8de17a50-3069-424a-80a0-2a5a8d498ff9"> | <img width="359" alt="Screenshot 2023-08-04 at 10 13 13" src="https://github.com/core-ds/core-components/assets/131259332/96c6c45e-e167-46fe-bf35-281cd27d681f"> |

