### PR TITLE
fix(textarea): fixed error with vertical scrollbar and autosize

### DIFF
--- a/.changeset/kind-wombats-guess.md
+++ b/.changeset/kind-wombats-guess.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-textarea': patch
+---
+
+Исправлена ошибка, из-за которой появлялся вертикальный скролл при autosize=true

--- a/packages/textarea/src/Component.tsx
+++ b/packages/textarea/src/Component.tsx
@@ -149,6 +149,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             colorStyles[colors].textarea,
             styles[size],
             {
+                [styles.overflowHidden]: autosize && !maxRows,
                 [styles.customScrollbar]: !nativeScrollbar,
                 [styles.hasInnerLabel]: hasInnerLabel,
                 [colorStyles[colors].hasInnerLabel]: hasInnerLabel,

--- a/packages/textarea/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Component.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Textarea Snapshots tests should match snapshot 1`] = `
         >
           <textarea
             autocomplete="on"
-            class="textarea textarea s filled"
+            class="textarea textarea s overflowHidden filled"
             rows="1"
           >
             value
@@ -44,7 +44,7 @@ exports[`Textarea Snapshots tests should match snapshot with custom counter 1`] 
         >
           <textarea
             autocomplete="on"
-            class="textarea textarea s filled"
+            class="textarea textarea s overflowHidden filled"
             rows="1"
           >
             value
@@ -77,7 +77,7 @@ exports[`Textarea Snapshots tests should match snapshot with custom scrollbar 1`
         >
           <textarea
             autocomplete="on"
-            class="textarea textarea s customScrollbar filled"
+            class="textarea textarea s overflowHidden customScrollbar filled"
             rows="1"
           >
             value
@@ -105,7 +105,7 @@ exports[`Textarea Snapshots tests should match snapshot with default counter 1`]
         >
           <textarea
             autocomplete="on"
-            class="textarea textarea s filled"
+            class="textarea textarea s overflowHidden filled"
             rows="1"
           >
             value

--- a/packages/textarea/src/index.module.css
+++ b/packages/textarea/src/index.module.css
@@ -62,6 +62,10 @@
     height: inherit;
 }
 
+.overflowHidden.overflowHidden {
+    overflow: hidden;
+}
+
 .customScrollbar {
     @mixin custom-scrollbar;
 }


### PR DESCRIPTION
[Было](https://core-ds.github.io/core-components/master/?path=/docs/sandbox--docs/code=function%20Example()%20%7B%0A%20%20%20%20const%20%5Bcount%2C%20setCount%5D%20%3D%20React.useState(0)%3B%0A%20%20%20%20return%20(%0A%20%20%20%20%20%20%20%20%3Cdiv%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3CTextarea%20value%3D%7B%60%20Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit%2C%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%20Nibh%20mauris%20cursus%20mattis%20molestie%20a.%20Fringilla%20phasellus%20faucibus%20scelerisque%20eleifend%20donec.%20Viverra%20tellus%20in%20hac%20habitasse%20platea%20dictumst%20vestibulum.%20Velit%20laoreet%20id%20donec%20ultrices.%20Pulvinar%20sapien%20et%20ligula%20ullamcorper%20malesuada%20proin%20libero%20nunc.%20Suspendisse%20sed%20nisi%20lacus%20sed%20viverra%20tellus%20in%20hac.%20Netus%20et%20malesuada%20fames%20ac%20turpis%20egestas%20sed.%20Sagittis%20purus%20sit%20amet%20volutpat.%20Magna%20ac%20placerat%20vestibulum%20lectus.%20Venenatis%20cras%20sed%20felis%20eget.%20Faucibus%20purus%20in%20massa%20tempor%20nec%20feugiat%20nisl%20pretium.%20Scelerisque%20varius%20morbi%20enim%20nunc%20faucibus%20a%20pellentesque%20sit.%20Scelerisque%20viverra%20mauris%20in%20aliquam%20sem.%20Elit%20eget%20gravida%20cum%20sociis%20natoque%20penatibus%20et.%20A%20erat%20nam%20at%20lectus%20urna%20duis%20convallis%20convallis.%0A%0AUllamcorper%20eget%20nulla%20facilisi%20etiam%20dignissim%20diam%20quis%20enim.%20Vestibulum%20mattis%20ullamcorper%20velit%20sed%20ullamcorper%20morbi%20tincidunt.%20Leo%20vel%20orci%20porta%20non%20pulvinar.%20Enim%20ut%20sem%20viverra%20aliquet%20eget%20sit%20amet%20tellus.%20Tempus%20urna%20et%20pharetra%20pharetra%20massa%20massa.%20Arcu%20vitae%20elementum%20curabitur%20vitae%20nunc%20sed%20velit%20dignissim.%20Lectus%20quam%20id%20leo%20in%20vitae%20turpis%20massa.%20Amet%20est%20placerat%20in%20egestas%20erat%20imperdiet%20sed%20euismod%20nisi.%20Rhoncus%20est%20pellentesque%20elit%20ullamcorper%20dignissim%20cras%20tincidunt.%20Adipiscing%20diam%20donec%20adipiscing%20tristique%20risus%20nec%20feugiat%20in.%0A%0AAliquam%20purus%20sit%20amet%20luctus%20venenatis%20lectus%20magna.%20Suspendisse%20faucibus%20interdum%20posuere%20lorem%20ipsum%20dolor%20sit%20amet%20consectetur.%20Sagittis%20vitae%20et%20leo%20duis.%20Ac%20orci%20phasellus%20egestas%20tellus.%20Risus%20pretium%20quam%20vulputate%20dignissim.%20Arcu%20dui%20vivamus%20arcu%20felis%20bibendum%20ut%20tristique.%20Vulputate%20enim%20nulla%20aliquet%20porttitor%20lacus%20luctus.%20Enim%20tortor%20at%20auctor%20urna.%20Non%20pulvinar%20neque%20laoreet%20suspendisse%20interdum.%20Donec%20ac%20odio%20tempor%20orci%20dapibus%20ultrices.%20Netus%20et%20malesuada%20fames%20ac%20turpis%20egestas%20maecenas.%60%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%0A%20%20%20%20)%3B%0A%7D%0Arender(%0A%20%20%20%20%3CExample%20%2F%3E%0A))