### PR TITLE
chore: typings resolver

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,7 @@ import json from '@rollup/plugin-json';
 import {
     coreComponentsRootPackageResolver,
     coreComponentsResolver,
+    packagesTypingResolver,
 } from './tools/rollup/core-components-resolver.mjs';
 import ignoreCss from './tools/rollup/ignore-css.mjs';
 import processCss from './tools/rollup/process-css.mjs';
@@ -105,7 +106,7 @@ const es5 = {
             format: 'cjs',
             interop: 'compat',
             dynamicImportInCjs: false,
-            plugins: [addCssImports({ currentPackageDir })],
+            plugins: [addCssImports({ currentPackageDir }), packagesTypingResolver()],
         },
     ],
     plugins: [
@@ -139,6 +140,7 @@ const modern = {
             plugins: [
                 addCssImports({ currentPackageDir }),
                 coreComponentsResolver({ importFrom: 'modern' }),
+                packagesTypingResolver(),
             ],
         },
     ],
@@ -172,7 +174,7 @@ const cssm = {
             format: 'cjs',
             interop: 'compat',
             dynamicImportInCjs: false,
-            plugins: [coreComponentsResolver({ importFrom: 'cssm' })],
+            plugins: [coreComponentsResolver({ importFrom: 'cssm' }), packagesTypingResolver()],
         },
     ],
     plugins: [
@@ -204,6 +206,7 @@ const esm = {
             plugins: [
                 addCssImports({ currentPackageDir }),
                 coreComponentsResolver({ importFrom: 'esm' }),
+                packagesTypingResolver(),
             ],
         },
     ],

--- a/tools/rollup/core-components-resolver.mjs
+++ b/tools/rollup/core-components-resolver.mjs
@@ -55,3 +55,27 @@ export const coreComponentsResolver = ({ importFrom }) => ({
         return bundles;
     },
 });
+
+/**
+ * Заменяет импорты типов в d.ts с packages/{packageName}/src/* на @alfalab/core-components-{packageName}/*
+ */
+export const packagesTypingResolver = () => ({
+    name: 'packages-typings-resolver',
+    generateBundle: (_, bundles) => {
+        Object.keys(bundles).forEach((bundleName) => {
+            if (bundleName.endsWith('.d.ts')) {
+                let source = bundles[bundleName].source;
+                if (source) {
+                    const re = /import\((['"])packages\/(.+)\/src(\/.*?)?(['"])\)/g;
+
+                    bundles[bundleName].source = source.replaceAll(
+                        re,
+                        'import($1@alfalab/core-components-$2$3$4)',
+                    );
+                }
+            }
+        });
+
+        return bundles;
+    },
+});


### PR DESCRIPTION
Решает проблему с типами, которые ссылаются на packages.

Заменяет импорт import("packages/toast/src).ToastProps --> import("@alfalab/core-components-toast).ToastProps