### PR TITLE
fix(icon-view): fixed CDNIcon size

### DIFF
--- a/.changeset/spotty-jokes-reply.md
+++ b/.changeset/spotty-jokes-reply.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-cdn-icon': patch
+'@alfalab/core-components-icon-view': patch
+---
+
+CDNIcon теперь занимает всю ширину и высоту IconView

--- a/packages/cdn-icon/src/Component.tsx
+++ b/packages/cdn-icon/src/Component.tsx
@@ -57,10 +57,10 @@ export const CDNIcon: React.FC<CDNIconProps> = ({
         xhr.open('GET', `${baseUrl}/${name}.svg`);
         xhr.send();
         xhr.onload = function onload() {
+            setLoadingStatus(LoadingStatus.SUCCESS);
             const svg = xhr.response;
 
             if (svg.startsWith('<svg')) {
-                setLoadingStatus(LoadingStatus.SUCCESS);
                 setIcon(svg);
             }
         };
@@ -75,7 +75,9 @@ export const CDNIcon: React.FC<CDNIconProps> = ({
     return (
         <span
             style={{ color }}
-            className={cn(styles.component, className, { [styles.parentColor]: monoIcon })}
+            className={cn('cc-cdn-icon', styles.component, className, {
+                [styles.parentColor]: monoIcon,
+            })}
             data-test-id={dataTestId}
             {...(loadingStatus === LoadingStatus.FAILURE
                 ? { children: fallback }

--- a/packages/icon-view/src/components/base-shape/index.module.css
+++ b/packages/icon-view/src/components/base-shape/index.module.css
@@ -53,7 +53,8 @@
     left: 50%;
     transform: translate(-50%, -50%);
 
-    & svg {
+    & svg,
+    :global(.cc-cdn-icon) {
         width: 100%;
         height: 100%;
     }


### PR DESCRIPTION
[Пример](https://core-ds.github.io/core-components/fix_cdn_icon_full_width_8dfc113889aa84ab936c5fef3c8d46dc0ce92c37/?path=/docs/sandbox--docs/code=render(()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%20%20%20%20%3CSpace%20direction%3D'horizontal'%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%5B'128'%2C%20'80'%2C%20'64'%2C%20'48'%2C%20'40'%2C%20'32'%2C%20'24'%2C%20'20'%5D.map((size)%20%3D%3E%20(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CSuperEllipse%20size%3D%7Bsize%7D%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CCDNIcon%20name%3D'glyph_debt_m'%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FSuperEllipse%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20))%7D%0A%20%20%20%20%20%20%20%20%3C%2FSpace%3E%0A%20%20%20%20)%3B%0A%7D)%3B) - 
```jsx
render(() => {
    return (
        <Space direction='horizontal'>
            {['128', '80', '64', '48', '40', '32', '24', '20'].map((size) => (
                <SuperEllipse size={size}>
                    <CDNIcon name='glyph_debt_m' />
                </SuperEllipse>
            ))}
        </Space>
    );
});
```