### PR TITLE
fix(select): change visible options recalc login in virtual-options-list

### DIFF
--- a/.changeset/hot-waves-argue.md
+++ b/.changeset/hot-waves-argue.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-select": patch
+---
+
+Исправлен баг с пересчетом высоты в VirtualOptionsList

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -41,7 +41,7 @@ export const VirtualOptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
         const listRef = useRef<HTMLDivElement>(null);
         const parentRef = useRef<HTMLDivElement>(null);
         const scrollbarRef = useRef<HTMLDivElement>(null);
-        const [visibleOptionsInvalidateKey, setVisibleOptionsInvalidateKey] = useState(0);
+        const [visibleOptionsInvalidateKey, setVisibleOptionsInvalidateKey] = useState('');
         const prevHighlightedIndex = usePrevious(highlightedIndex) || -1;
 
         let [nativeScrollbar] = useMedia<boolean>([[true, '(max-width: 1023px)']], false);
@@ -97,11 +97,15 @@ export const VirtualOptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
                 /**
                  * react-virtual может несколько раз отрендерить список с одним элементом,
                  * поэтому нужно еще раз пересчитать высоту, когда список ВИДИМЫХ пунктов будет отрендерен полностью
-                 * Также, высоту нужно пересчитывать при изменении ОБЩЕГО кол-ва пунктов меню
+                 * Также, высоту нужно пересчитывать при изменении пунктов меню
                  */
-                rowVirtualizer.virtualItems.length > 1 ? flatOptions.length : 1,
+                rowVirtualizer.virtualItems
+                    .slice(0, Math.min(rowVirtualizer.virtualItems.length, visibleOptions + 1))
+                    .map((item) => flatOptions[item.index].key)
+                    .join('_'),
             );
-        }, [rowVirtualizer.virtualItems.length, flatOptions.length]);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [rowVirtualizer.virtualItems.length, flatOptions]);
 
         useVisibleOptions({
             visibleOptions,


### PR DESCRIPTION
До этого пересчет высоты происходил только при изменении кол-ва пунктов, теперь проверяем по ключам.

Не смог сейчас воспроизвести баг react-virtual, но помню была проблема в клике, поэтому предлагаю пока не трогать это от греха подальше


```
render(() => {
    const [value, setValue] = React.useState('');

    const options = value.length % 2 === 0
      ? [ { key: 'Neptunium', content: (<p style={{height: '42px'}}>Neptunium</p>) }]
      : [ { key: 'Plutonium', content: (<p style={{height: '228px'}}>Plutonium</p>) } ];

    const handleInput = (event) => {
        setValue(event.target.value);
    };

    return (
        <div style={{ width: 320 }}>
            <InputAutocompleteDesktop
                size='m'
                block={true}
                options={options}
                label='Инпут с автокомплитом'
                placeholder='Начните вводить название'
                onInput={handleInput}
                value={value}

                // Remove props below to fix bug
                OptionsList={VirtualOptionsList}
                optionsListWidth='field'
            />
        </div>
    );
});
```