### PR TITLE
fix(select-with-tags): wrong visible elements

### DIFF
--- a/.changeset/thin-ravens-collect.md
+++ b/.changeset/thin-ravens-collect.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-select-with-tags": patch
+---
+
+Исправлен баг с некорректным расчетом видимых тэгов

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -82,7 +82,7 @@ export const TagList: FC<FieldProps & FormControlProps & TagListOwnProps> = ({
         setShowMoreEnabled(isPopoverOpen);
     }, [isPopoverOpen]);
 
-    useLayoutEffect_SAFE_FOR_SSR(() => {
+    useEffect(() => {
         setVisibleElements(selectedMultiple.length);
         setShowMoreEnabled(false);
     }, [selectedMultiple]);


### PR DESCRIPTION
Исправил баг, из-за которого пересчет кол-ва видимых тэгов срабатывал до построения DOM'а и выдавал неправильный результат. 
Теперь сначала будет срабатывать useEffect, изменяться DOM и только потом будет useLayoutEffect с пересчетом