### PR TITLE
feat(amount-input): add codeFormat prop

### DIFF
--- a/.changeset/wet-rice-accept.md
+++ b/.changeset/wet-rice-accept.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-amount-input': minor
+---
+
+Добавлен проп codeFormat: 'letter' | 'symbolic'

--- a/packages/amount-input/src/Component.test.tsx
+++ b/packages/amount-input/src/Component.test.tsx
@@ -92,6 +92,21 @@ describe('AmountInput', () => {
         expect(input.placeholder).toBe(`0${THINSP}%`);
     });
 
+    it('should use currency suffix with codeFormat=letter', () => {
+        const input = renderAmountInput(null, 'RUR', { codeFormat: 'letter' });
+        expect(input.placeholder).toBe(`0${THINSP}RUR`);
+    });
+
+    it('should use currency suffix with codeFormat=symbolic', () => {
+        const input = renderAmountInput(null, 'RUR', { codeFormat: 'symbolic' });
+        expect(input.placeholder).toBe(`0${THINSP}₽`);
+    });
+
+    it('should use currency suffix without codeFormat', () => {
+        const input = renderAmountInput(null, 'RUR');
+        expect(input.placeholder).toBe(`0${THINSP}₽`);
+    });
+
     it('should allow to clean suffix when currency empty', () => {
         const input = renderAmountInput(null, null, { suffix: '' });
         expect(input.placeholder).toBe(`0${THINSP}`);

--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -4,9 +4,9 @@ import cn from 'classnames';
 import { Input, InputProps } from '@alfalab/core-components-input';
 import { withSuffix } from '@alfalab/core-components-with-suffix';
 import { CurrencyCodes } from '@alfalab/data';
-import { formatAmount, getCurrencySymbol, THINSP } from '@alfalab/utils';
+import { formatAmount, THINSP } from '@alfalab/utils';
 
-import { getAmountValueFromStr, getFormattedValue } from './utils';
+import { getAmountValueFromStr, getCurrencyCodeWithFormat, getFormattedValue } from './utils';
 
 import defaultColors from './default.module.css';
 import styles from './index.module.css';
@@ -23,6 +23,11 @@ export type AmountInputProps = Omit<InputProps, 'value' | 'onChange' | 'type'> &
      * Значение null - значит не установлено
      */
     value?: string | number | null;
+
+    /**
+     * Формат отображения кода валюты
+     */
+    codeFormat?: 'letter' | 'symbolic';
 
     /**
      * default - не отображаем копейки, если их значение 0
@@ -104,8 +109,9 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
             minority = 100,
             currency = 'RUR',
             suffix = currency,
+            codeFormat = 'symbolic',
             placeholder = `0\u2009${
-                suffix === currency ? getCurrencySymbol(currency) || '' : suffix
+                suffix === currency ? getCurrencyCodeWithFormat(currency, codeFormat) || '' : suffix
             }`,
             integersOnly = false,
             positiveOnly = true,
@@ -144,7 +150,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
         const [inputValue, setInputValue] = useState<string>(() => getFormattedAmount(value));
 
         const [majorPart, minorPart] = inputValue.split(',');
-        const currencySymbol = getCurrencySymbol(currency);
+        const currencyCode = getCurrencyCodeWithFormat(currency, codeFormat);
 
         useEffect(() => {
             const currentAmountValue = getAmountValueFromStr(inputValue, minority);
@@ -283,7 +289,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
                             <span className={colorStyles[colors].minorPartAndCurrency}>
                                 {minorPart !== undefined && `,${minorPart}`}
                                 {THINSP}
-                                {suffix === currency ? currencySymbol : suffix}
+                                {suffix === currency ? currencyCode : suffix}
                             </span>
                         </Fragment>
                     }

--- a/packages/amount-input/src/utils/index.ts
+++ b/packages/amount-input/src/utils/index.ts
@@ -4,7 +4,9 @@
  */
 
 import { CurrencyCodes } from '@alfalab/data';
-import { formatAmount } from '@alfalab/utils';
+import { formatAmount, getCurrencySymbol } from '@alfalab/utils';
+
+import { AmountInputProps } from '../Component';
 
 /**
  * Форматирует введенное значение
@@ -54,4 +56,15 @@ export function getAmountValueFromStr(str: string, minority: number) {
     }
 
     return Math.round(Number(str.replace(',', '.').replace(/[^0-9.-]/g, '')) * minority);
+}
+
+export function getCurrencyCodeWithFormat(
+    currency: CurrencyCodes,
+    codeFormat: AmountInputProps['codeFormat'],
+) {
+    if (!currency) {
+        return '';
+    }
+
+    return codeFormat === 'symbolic' ? getCurrencySymbol(currency) : currency;
 }


### PR DESCRIPTION
Необходима возможность выводить мнемонику валюты, а не только символы