### PR TITLE
chore: disable hoistTransitiveImports

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -111,6 +111,7 @@ const es5 = {
             interop: 'compat',
             dynamicImportInCjs: false,
             plugins: [addCssImports({ currentPackageDir }), packagesTypingResolver()],
+            hoistTransitiveImports: false,
         },
     ],
     plugins: [
@@ -146,6 +147,7 @@ const modern = {
                 coreComponentsResolver({ importFrom: 'modern' }),
                 packagesTypingResolver(),
             ],
+            hoistTransitiveImports: false,
         },
     ],
     plugins: [
@@ -179,6 +181,7 @@ const cssm = {
             interop: 'compat',
             dynamicImportInCjs: false,
             plugins: [coreComponentsResolver({ importFrom: 'cssm' }), packagesTypingResolver()],
+            hoistTransitiveImports: false,
         },
     ],
     plugins: [
@@ -212,6 +215,7 @@ const esm = {
                 coreComponentsResolver({ importFrom: 'esm' }),
                 packagesTypingResolver(),
             ],
+            hoistTransitiveImports: false,
         },
     ],
     plugins: [


### PR DESCRIPTION
Отключаем транзитивные импорты, они не должны быть включены с preserveModules флагом (у нас вместо него multiInput плагин, но смысл тот же). https://rollupjs.org/configuration-options/#output-hoisttransitiveimports

Было:
![Screenshot from 2023-12-05 11-27-44](https://github.com/core-ds/core-components/assets/40845033/34e7621f-dd43-4f76-94d3-5a00d7af81b2)

Стало:
![Screenshot from 2023-12-05 11-25-56](https://github.com/core-ds/core-components/assets/40845033/d6e42df9-1f25-43ea-83ab-15467ac498f8)
