### PR TITLE
fix(button): added blur animation

### DIFF
--- a/packages/button/src/components/base-button/index.module.css
+++ b/packages/button/src/components/base-button/index.module.css
@@ -1,6 +1,12 @@
 @import '../../../../themes/src/default.css';
 @import '../../vars.css';
 
+@property --button-backdrop-filter {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 80;
+}
+
 .component {
     position: relative;
     display: inline-flex;
@@ -41,7 +47,9 @@
 .secondary,
 .accent[disabled],
 .primary[disabled] {
-    backdrop-filter: blur(80px);
+    transform: translate3d(0, 0, 0);
+    backdrop-filter: blur(calc(var(--button-backdrop-filter, 80) * 1px));
+    animation: backdrop-filter-animation 100ms linear;
 }
 
 .focused {
@@ -295,4 +303,14 @@
 
 .rounded {
     border-radius: var(--border-radius-pill);
+}
+
+@keyframes backdrop-filter-animation {
+    from {
+        --button-backdrop-filter: 0;
+    }
+
+    to {
+        --button-backdrop-filter: 80;
+    }
 }

--- a/packages/tag/src/components/base-tag/index.module.css
+++ b/packages/tag/src/components/base-tag/index.module.css
@@ -1,5 +1,11 @@
 @import '../../vars.css';
 
+@property --tag-backdrop-filter {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 80;
+}
+
 .component {
     display: inline-flex;
     justify-content: center;
@@ -189,5 +195,17 @@
 
 .outlined.checked[disabled],
 .filled {
-    backdrop-filter: blur(80px);
+    transform: translate3d(0, 0, 0);
+    backdrop-filter: blur(calc(var(--tag-backdrop-filter, 80) * 1px));
+    animation: backdrop-filter-animation 100ms linear;
+}
+
+@keyframes backdrop-filter-animation {
+    from {
+        --tag-backdrop-filter: 0;
+    }
+
+    to {
+        --tag-backdrop-filter: 80;
+    }
 }


### PR DESCRIPTION
Решаем проблему с задержкой появления кнопок с блюром в сайд-панели, шторке и т.п. Пытаемся сделать это анимацией.

backdrop-filter не анимируется, пришлось делать анимацию через css-переменную.
Использую объявление css-custom-properties через @property, а не :root, потому что нам нужна локальная переменная + переменные, объявленные через :root, не анимируются.

Для браузеров, которые не поддерживают @property, сделал fallback на 80px  