### PR TITLE
fix(input-autocomplete): changed onInput type

### DIFF
--- a/.changeset/rich-frogs-brake.md
+++ b/.changeset/rich-frogs-brake.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-international-phone-input': major
+---
+
+Тип onChange коллбэка заменен на (value: string) => void

--- a/.changeset/spicy-planets-rhyme.md
+++ b/.changeset/spicy-planets-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-input-autocomplete': major
+---
+
+Тип onInput коллбэка заменен на (value: string) => void

--- a/packages/input-autocomplete/src/Component.test.tsx
+++ b/packages/input-autocomplete/src/Component.test.tsx
@@ -31,9 +31,9 @@ const InputAutocompleteMobileWrapper = (props: Partial<InputAutocompleteMobilePr
         setOpen(Boolean(isOpen));
     };
 
-    const handleInput: InputAutocompleteMobileProps['onInput'] = (event, payload) => {
-        setValue(payload.value);
-        props?.onInput?.(event, payload);
+    const handleInput: InputAutocompleteMobileProps['onInput'] = (value) => {
+        setValue(value);
+        props?.onInput?.(value);
     };
 
     return (
@@ -343,7 +343,7 @@ describe('InputAutocompleteMobile', () => {
             fireEvent.change(input, { target: { value: '123' } });
             fireEvent.click(getByTestId(dataTestId + '-clear'));
 
-            expect(cb).toHaveBeenNthCalledWith(2, expect.any(Object), { value: '' });
+            expect(cb).toHaveBeenNthCalledWith(2, '');
         });
 
         it('should restore prev value when click close button ', () => {
@@ -357,7 +357,7 @@ describe('InputAutocompleteMobile', () => {
             fireEvent.change(input, { target: { value: '123' } });
             fireEvent.click(getByTestId(dataTestId + '-bottom-sheet-header-closer'));
 
-            expect(cb).toHaveBeenNthCalledWith(2, expect.any(Object), { value: '' });
+            expect(cb).toHaveBeenNthCalledWith(2, '');
         });
 
         it('should apply new value when click continue ', () => {
@@ -372,7 +372,7 @@ describe('InputAutocompleteMobile', () => {
             fireEvent.click(getByTestId(dataTestId + '-apply'));
 
             expect(cb).toBeCalledTimes(1);
-            expect(cb).toBeCalledWith(expect.any(Object), { value: '123' });
+            expect(cb).toBeCalledWith('123');
         });
     });
 

--- a/packages/input-autocomplete/src/autocomplete-field/Component.tsx
+++ b/packages/input-autocomplete/src/autocomplete-field/Component.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
+import { InputProps } from '@alfalab/core-components-input';
 import { InputDesktop as DefaultInput } from '@alfalab/core-components-input/desktop';
 import type { FieldProps } from '@alfalab/core-components-select/shared';
 
@@ -47,6 +48,8 @@ export const AutocompleteField = ({
         [onClick],
     );
 
+    const handleInput: InputProps['onChange'] = (_, payload) => onInput?.(payload.value);
+
     return (
         <Input
             dataTestId={dataTestId}
@@ -67,7 +70,7 @@ export const AutocompleteField = ({
             error={error}
             success={success}
             hint={hint}
-            onChange={onInput}
+            onChange={handleInput}
             onClick={inputDisabled ? undefined : handleClick}
             onFocus={inputDisabled ? undefined : onFocus}
             autoComplete='off'

--- a/packages/input-autocomplete/src/docs/Component.stories.tsx
+++ b/packages/input-autocomplete/src/docs/Component.stories.tsx
@@ -44,7 +44,7 @@ const renderComponent = (Component: any, props?: Partial<InputAutocompleteProps>
     ];
 
     const [value, setValue] = React.useState('');
-    const handleInput: InputAutocompleteProps['onInput'] = (_, { value }) => {
+    const handleInput: InputAutocompleteProps['onInput'] = (value) => {
         setValue(value);
     };
     const handleChange: InputAutocompleteProps['onChange'] = ({ selected }) => {

--- a/packages/input-autocomplete/src/docs/description.mdx
+++ b/packages/input-autocomplete/src/docs/description.mdx
@@ -31,9 +31,7 @@ render(() => {
     const matchOption = (option, inputValue) =>
         option.key.toLowerCase().includes((inputValue || '').toLowerCase());
 
-    const handleInput = (_, { value }) => {
-        setValue(value);
-    };
+    const handleInput = (newValue) => setValue(newValue);
 
     const handleChange = ({ selected, selectedMultiple }) => {
         if (multiple) {
@@ -205,9 +203,7 @@ render(() => {
     const [value, setValue] = React.useState('');
     const inputRef = React.useRef();
 
-    const handleInput = (_, { value }) => {
-        setValue(value);
-    };
+    const handleInput = (newValue) => setValue(newValue);
 
     const handleChange = ({ selected }) => {
         const value = selected ? selected.content : null;

--- a/packages/input-autocomplete/src/mobile/Component.mobile.tsx
+++ b/packages/input-autocomplete/src/mobile/Component.mobile.tsx
@@ -51,7 +51,7 @@ export const InputAutocompleteMobile = React.forwardRef(
         const searchInputRef = useRef<HTMLInputElement>(null);
         const targetRef = useRef<HTMLDivElement>(null);
 
-        const restorePrevValue = () => onInput?.(null, { value: frozenValue.current });
+        const restorePrevValue = () => onInput?.(frozenValue.current);
 
         const setModalVisibility = (isOpen: boolean) => {
             if (isOpen) {
@@ -140,7 +140,7 @@ export const InputAutocompleteMobile = React.forwardRef(
                         className: cn(styles.input, inputProps?.className),
                         clear,
                         ref: mergeRefs([searchInputRef, inputProps?.ref as Ref<HTMLInputElement>]),
-                        onChange: onInput,
+                        onChange: (_, payload) => onInput?.(payload.value),
                     },
                 }}
                 Search={Input}

--- a/packages/input-autocomplete/src/types.ts
+++ b/packages/input-autocomplete/src/types.ts
@@ -1,4 +1,4 @@
-import type { ChangeEvent, FC, RefAttributes } from 'react';
+import type { FC, RefAttributes } from 'react';
 
 import type { InputProps } from '@alfalab/core-components-input';
 import type {
@@ -39,7 +39,7 @@ export interface InputAutocompleteCommonProps
     /**
      * Обработчик ввода
      */
-    onInput?: (event: ChangeEvent<HTMLInputElement> | null, payload: { value: string }) => void;
+    onInput?: (value: string) => void;
 }
 
 type MobileProps = {

--- a/packages/international-phone-input/src/Component.test.tsx
+++ b/packages/international-phone-input/src/Component.test.tsx
@@ -31,9 +31,9 @@ describe('InternationalPhoneInput', () => {
     }: InternationalPhoneInputDesktopProps) => {
         const [value, setValue] = useState('');
 
-        const handleChange: InternationalPhoneInputDesktopProps['onChange'] = (e, payload) => {
-            onChange?.(e, payload);
-            setValue(payload.value);
+        const handleChange: InternationalPhoneInputDesktopProps['onChange'] = (phone) => {
+            onChange?.(phone);
+            setValue(phone);
         };
         return (
             <InternationalPhoneInputDesktop {...restProps} value={value} onChange={handleChange} />
@@ -66,7 +66,7 @@ describe('InternationalPhoneInput', () => {
 
         fireEvent.input(input, { target: { value: '+54' } });
 
-        expect(onChange).toHaveBeenCalledWith(expect.any(Object), { value: '+54' });
+        expect(onChange).toHaveBeenCalledWith('+54');
     });
 
     it('should call `onChange` callback after input was changed with dial code of country from NANP', async () => {
@@ -78,7 +78,7 @@ describe('InternationalPhoneInput', () => {
         fireEvent.input(input, { target: { value: '+1868' } });
 
         await waitFor(() => {
-            expect(onChange).toHaveBeenCalledWith(expect.any(Object), { value: '+1868' });
+            expect(onChange).toHaveBeenCalledWith('+1868');
         });
     });
 
@@ -89,7 +89,7 @@ describe('InternationalPhoneInput', () => {
         const input = screen.getByDisplayValue('');
         fireEvent.input(input, { target: { value: '+74957888878' } });
 
-        expect(onChange).toHaveBeenCalledWith(expect.any(Object), { value: '+7 495 788 88 78' });
+        expect(onChange).toHaveBeenCalledWith('+7 495 788 88 78');
     });
 
     it('should have passed country flag icon', () => {
@@ -193,7 +193,7 @@ describe('InternationalPhoneInput', () => {
         await userEvent.type(input, '{backspace}');
 
         await waitFor(() => {
-            expect(onChange).toHaveBeenCalledWith(expect.any(Object), { value: '' });
+            expect(onChange).toHaveBeenCalledWith('');
         });
     });
 
@@ -274,7 +274,7 @@ describe('InternationalPhoneInput', () => {
         fireEvent.click(clearButton);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledWith(null, { value: '' });
+            expect(onChange).toBeCalledWith('');
         });
     });
 
@@ -289,9 +289,9 @@ describe('InternationalPhoneInput', () => {
                     <InternationalPhoneInputDesktop
                         value={value}
                         onCountryChange={onCountryChange}
-                        onChange={(e, p) => {
-                            setValue(p.value);
-                            onChange(e, p);
+                        onChange={(phone) => {
+                            setValue(phone);
+                            onChange(phone);
                         }}
                     />
                     <button
@@ -311,9 +311,7 @@ describe('InternationalPhoneInput', () => {
         fireEvent.click(btn);
 
         await waitFor(async () => {
-            expect(onChange).toHaveBeenCalledWith(expect.any(Object), {
-                value: '+7 949 123 45 67',
-            });
+            expect(onChange).toHaveBeenCalledWith('+7 949 123 45 67');
             expect(onCountryChange).toHaveBeenCalledWith(
                 expect.objectContaining({
                     iso2: 'ru',
@@ -339,7 +337,7 @@ describe('InternationalPhoneInput', () => {
             await userEvent.type(input, '{backspace}');
         }
 
-        expect(onChange).toHaveBeenCalledWith(expect.any(Object), { value: '+7' });
+        expect(onChange).toHaveBeenCalledWith('+7');
     });
 
     it('should be remove chars in selection', async () => {
@@ -361,7 +359,7 @@ describe('InternationalPhoneInput', () => {
         });
 
         await waitFor(() => {
-            expect(onChange).toBeCalledWith(expect.any(Object), { value: '+7 983 123 67' });
+            expect(onChange).toBeCalledWith('+7 983 123 67');
         });
     });
 

--- a/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
+++ b/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
@@ -77,17 +77,17 @@ export const BaseInternationalPhoneInput = forwardRef<
 
         const maskRef = useMaskito({ options: maskOptions });
 
-        const changeNumber = (e: ChangeEvent<HTMLInputElement> | null, phone: string) => {
-            onChange?.(e, { value: phone });
+        const changeNumber = (phone: string) => {
+            onChange?.(phone);
         };
 
-        const updatePhoneData = (phone: string, e: ChangeEvent<HTMLInputElement> | null) => {
+        const updatePhoneData = (phone: string) => {
             const { nextCountry, nextPhone } = getPhoneData(phone, countriesData, defaultIso2);
 
             if (nextCountry !== country) {
                 handleCountryChange?.(nextCountry);
             }
-            changeNumber(e, nextPhone);
+            changeNumber(nextPhone);
         };
 
         const handleSelectCountry = ({ selected }: BaseSelectChangePayload) => {
@@ -96,7 +96,7 @@ export const BaseInternationalPhoneInput = forwardRef<
             handleCountryChange?.(nextCountry);
 
             if (nextCountry) {
-                changeNumber(null, `+${nextCountry.dialCode}`);
+                changeNumber(`+${nextCountry.dialCode}`);
             }
 
             requestAnimationFrame(() => inputRef.current?.focus());
@@ -108,12 +108,11 @@ export const BaseInternationalPhoneInput = forwardRef<
                     typeof payload === 'string' ? payload : payload.selected?.key || '',
                     maskOptions,
                 ),
-                null,
             );
         };
 
         const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
-            updatePhoneData(e.target.value, e);
+            updatePhoneData(e.target.value);
         };
 
         const handleClear = (event: MouseEvent<HTMLButtonElement>) => {
@@ -121,7 +120,7 @@ export const BaseInternationalPhoneInput = forwardRef<
 
             const countryCode = country?.countryCode || '';
 
-            changeNumber(null, clearableCountryCode ? '' : `+${countryCode}`);
+            changeNumber(clearableCountryCode ? '' : `+${countryCode}`);
         };
 
         useEffect(() => {
@@ -129,7 +128,7 @@ export const BaseInternationalPhoneInput = forwardRef<
                 const newValue = maskitoTransform(value, maskOptions);
 
                 if (value !== newValue) {
-                    updatePhoneData(newValue, null);
+                    updatePhoneData(newValue);
                 }
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -169,7 +168,7 @@ export const BaseInternationalPhoneInput = forwardRef<
                 options={filteredOptions}
                 value={value}
                 onChange={handleOptionSelect}
-                onInput={(event, { value: phone }) => updatePhoneData(phone, event)}
+                onInput={(phone) => updatePhoneData(phone)}
                 inputProps={{
                     ...inputProps,
                     onClear: handleClear,

--- a/packages/international-phone-input/src/docs/Component.stories.tsx
+++ b/packages/international-phone-input/src/docs/Component.stories.tsx
@@ -27,9 +27,7 @@ export const international_phone_input: Story = {
     render: () => {
         const [value, setValue] = useState('');
 
-        const handleChange: InternationalPhoneInputProps['onChange'] = (e, { value: phone }) => {
-            setValue(phone);
-        };
+        const handleChange: InternationalPhoneInputProps['onChange'] = (phone) => setValue(phone);
 
         return (
             <div style={{ width: '320px' }}>

--- a/packages/international-phone-input/src/docs/description.mdx
+++ b/packages/international-phone-input/src/docs/description.mdx
@@ -18,9 +18,7 @@ render(() => {
     const [clearableCountryCode, setClearableCountryCode] = React.useState(false);
     const [autocomplete, setAutocomplete] = React.useState(false);
 
-    const handleChange = (e, { value: phone }) => {
-        setValue(phone);
-    };
+    const handleChange = (phone) => setValue(phone);
 
     return (
         <div style={{ width: document.body.clientWidth < 450 ? '100%' : 320 }}>
@@ -67,9 +65,7 @@ render(() => {
     const [value, setValue] = React.useState('');
     const [selectedCountry, setSelectedCountry] = React.useState();
 
-    const handleChange = (e, { value: phone }) => {
-        setValue(phone);
-    };
+    const handleChange = (phone) => setValue(phone);
 
     return (
         <div style={{ width: document.body.clientWidth < 450 ? '100%' : 320 }}>

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ElementType, FC } from 'react';
+import type { ElementType, FC } from 'react';
 import { FocusEvent } from 'react';
 
 import type { InputProps } from '@alfalab/core-components-input';
@@ -71,7 +71,7 @@ type CommonPhoneInputProps = {
     /**
      *  Обработчик изменения номера
      */
-    onChange?: (e: ChangeEvent<HTMLInputElement> | null, { value }: { value: string }) => void;
+    onChange?: (phone: string) => void;
 
     /**
      * Обработчик блюра поля

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -267,9 +267,9 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
             }
         };
 
-        const handleInputChange: InputAutocompleteDesktopProps['onInput'] = (_, payload) => {
-            setCountryByDialCodeWithLengthCheck(payload.value);
-            changePhone(addCountryCode(payload.value));
+        const handleInputChange: InputAutocompleteDesktopProps['onInput'] = (newValue) => {
+            setCountryByDialCodeWithLengthCheck(newValue);
+            changePhone(addCountryCode(newValue));
         };
 
         const handleSelectChange: Required<SelectProps>['onChange'] = ({ selected }) => {


### PR DESCRIPTION
**Что сделано**

Изменен тип onInput коллбэка с `(event: ChangeEvent | null, payload: {value:string}) => void` на `(value: string) => void`

**Зачем**

Возникают проблемы с event === null

Разработчики часто завязываются именно на первый аргумент коллбэков, игнорируют второй

И если event пришел null, то непонятно какой из этого вывод должен сделать разработчик

Отсюда вытекает подобный код:
```jsx
const handleChange = (event) => {
 if (event) {
  const { value } = event.target
  // do something with value
 }
}
```
но это совершенно не равнозначно коду (особенно в случае input-autocomplete)
```jsx
const handleChange = (_, { value }) => {
  // do something with value
}
```
что само собой порождает ошибки