### PR TITLE
feat(tab): add forwardRef to Tab component

### DIFF
--- a/.changeset/eighty-pears-attack.md
+++ b/.changeset/eighty-pears-attack.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tabs': patch
+---
+
+Tab обернут в forwardRef

--- a/packages/tabs/src/components/tab/Component.tsx
+++ b/packages/tabs/src/components/tab/Component.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import cn from 'classnames';
 
 import { TabProps } from '../../typings';
 
 import styles from './index.module.css';
 
-export const Tab = ({ children, hidden, className, disabled, dataTestId }: TabProps) =>
+export const Tab = forwardRef<HTMLDivElement, TabProps>(({ children, hidden, className, disabled, dataTestId }, ref) =>
     children ? (
         <div
+            ref={ref}
             className={cn(
                 styles.component,
                 {
@@ -22,4 +23,4 @@ export const Tab = ({ children, hidden, className, disabled, dataTestId }: TabPr
         >
             {children}
         </div>
-    ) : null;
+    ) : null);


### PR DESCRIPTION
# Опишите проблему
Необходимо прокинуть ref в Tab, чтобы иметь возможность привязать к нему тултип или другой компонент, к которому можно указать anchor 

# Шаги для воспроизведения
1. Создать ref
1. Обернуть Tabs в Tooltip
2. Указать пропсы в Tooltip: 
getPortalContainer={ () => refTab.current }
anchor={ refTab.current } 
3. в Tab передать ref: <Tab id={'tab-1'} title={'tab-1'} ref={refTab} />

# Ожидаемое поведение
Тултип появится возле таба, которому был передан ref

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым)

## Смартфон (если данных нет оставте блок пустым)

# Дополнительная информация
Дополнительная информация
