### PR TITLE
fix: fix accessibility when entering code

### DIFF
--- a/packages/code-input/src/__snapshots__/component.test.tsx.snap
+++ b/packages/code-input/src/__snapshots__/component.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`CodeInput Display tests should display correctly 1`] = `
     class="component"
   >
     <div
+      aria-label="Введено 0 из 4 символов"
+      aria-live="polite"
       class=""
     >
       <input
@@ -47,6 +49,8 @@ exports[`CodeInput Display tests should display correctly with error 1`] = `
     class="component"
   >
     <div
+      aria-label="Введено 0 из 4 символов"
+      aria-live="polite"
       class="shake"
     >
       <input

--- a/packages/code-input/src/components/base-code-input/component.tsx
+++ b/packages/code-input/src/components/base-code-input/component.tsx
@@ -34,6 +34,7 @@ export const BaseCodeInput = forwardRef<CustomInputRef, BaseCodeInputProps>(
             initialValues = '',
             dataTestId,
             clearCodeOnError = true,
+            errorVisibleDuration = CODE_ERROR_HINT_VISIBLE_DURATION,
             onErrorAnimationEnd,
             onChange,
             onComplete,
@@ -243,7 +244,7 @@ export const BaseCodeInput = forwardRef<CustomInputRef, BaseCodeInputProps>(
                 }
 
                 onErrorAnimationEnd?.();
-            }, CODE_ERROR_HINT_VISIBLE_DURATION);
+            }, errorVisibleDuration);
         };
 
         useEffect(
@@ -292,7 +293,11 @@ export const BaseCodeInput = forwardRef<CustomInputRef, BaseCodeInputProps>(
                 data-test-id={dataTestId}
                 onAnimationEnd={handleErrorAnimationEnd}
             >
-                <div className={cn({ [styles.shake]: Boolean(error) })}>
+                <div
+                    className={cn({ [styles.shake]: Boolean(error) })}
+                    aria-label={`Введено ${values.length} из ${fields} символов`}
+                    aria-live='polite'
+                >
                     {/* eslint-disable react/no-array-index-key */}
                     {new Array(fields).fill('').map((_, index) => (
                         <Input

--- a/packages/code-input/src/typings.ts
+++ b/packages/code-input/src/typings.ts
@@ -53,6 +53,12 @@ export type BaseCodeInputProps = {
     onComplete?: (code: string) => void;
 
     /**
+     * Продолжительность отображения ошибки
+     * @default 300
+     */
+    errorVisibleDuration?: number;
+
+    /**
      * Основные стили компонента.
      */
     stylesInput?: { [key: string]: string };

--- a/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
@@ -22,6 +22,8 @@ exports[`Confirmation Snapshot tests should match snapshot 1`] = `
         class="component containerInput codeInput"
       >
         <div
+          aria-label="Введено 0 из 5 символов"
+          aria-live="polite"
           class=""
         >
           <input
@@ -103,6 +105,8 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_CHECKING st
         class="component containerInput codeInput"
       >
         <div
+          aria-label="Введено 0 из 5 символов"
+          aria-live="polite"
           class=""
         >
           <input
@@ -247,6 +251,8 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_ERROR state
         class="component containerInput codeInput"
       >
         <div
+          aria-label="Введено 0 из 5 символов"
+          aria-live="polite"
           class="shake"
         >
           <input
@@ -334,6 +340,8 @@ exports[`Confirmation Snapshot tests should match snapshot with CODE_SENDING sta
         class="component containerInput codeInput"
       >
         <div
+          aria-label="Введено 0 из 5 символов"
+          aria-live="polite"
           class=""
         >
           <input

--- a/packages/confirmation/src/components/base-confirmation/component.tsx
+++ b/packages/confirmation/src/components/base-confirmation/component.tsx
@@ -41,6 +41,7 @@ export const BaseConfirmation: FC<ConfirmationProps> = ({
     hideCountdownSection = false,
     breakpoint = 1024,
     initialScreenHintSlot,
+    errorVisibleDuration,
     ...restProps
 }) => {
     const [timeLeft, startTimer, stopTimer] = useCountdown(countdownDuration);
@@ -105,6 +106,7 @@ export const BaseConfirmation: FC<ConfirmationProps> = ({
         onChangeState,
         onChangeScreen,
         clearCodeOnError,
+        errorVisibleDuration,
         initialScreenHintSlot,
         onInputFinished: handleInputFinished,
         onSmsRetryClick: handleSmsRetry,

--- a/packages/confirmation/src/components/screens/initial/component.tsx
+++ b/packages/confirmation/src/components/screens/initial/component.tsx
@@ -36,6 +36,7 @@ export const Initial: FC<InitialProps> = ({ mobile }) => {
         clearCodeOnError,
         hideCountdownSection,
         initialScreenHintSlot,
+        errorVisibleDuration,
         onChangeState,
         onInputFinished,
         onChangeScreen,
@@ -177,6 +178,7 @@ export const Initial: FC<InitialProps> = ({ mobile }) => {
                 onComplete={handleInputComplete}
                 onChange={handleInputChange}
                 clearCodeOnError={clearCodeOnError}
+                errorVisibleDuration={errorVisibleDuration}
                 onErrorAnimationEnd={handleErrorAnimationEnd}
             />
             {!hideCountdownSection && (

--- a/packages/confirmation/src/docs/description.mdx
+++ b/packages/confirmation/src/docs/description.mdx
@@ -141,6 +141,7 @@ render(() => {
                         onSmsRetryClick={handleSmsRetryClick}
                         onTempBlockFinished={handleTempBlockFinished}
                         phone='+7 ··· ··· 07 24'
+                        errorVisibleDuration={750}
                     />
                 )}
             </div>

--- a/packages/confirmation/src/types.ts
+++ b/packages/confirmation/src/types.ts
@@ -122,6 +122,12 @@ export type ConfirmationProps = {
      * @default 1024
      */
     breakpoint?: number;
+
+    /**
+     * Продолжительность отображения ошибки
+     * @default 300
+     */
+    errorVisibleDuration?: number;
 };
 
 export type TConfirmationContext = Required<
@@ -149,6 +155,7 @@ export type TConfirmationContext = Required<
         | 'onTempBlockFinished'
         | 'clearCodeOnError'
         | 'initialScreenHintSlot'
+        | 'errorVisibleDuration'
     > & {
         timeLeft: number;
     } & {


### PR DESCRIPTION
При вводе кода возникали три проблемы ( запрос из АМ)
1. Скринридеры не успевают считывать ошибку. (необходимо увеличить время отображения ошибки на экране)
добавила новый пропс errorVisibleDuration - Продолжительность отображения ошибки ( по дефолту 300) , чтобы скринридер успел прочитать текст ошибки необходимо минимум 700
2. Озвучивать количество введенных и оставшихся символов. ( пр: введено 2 символа из 6 и тд) 
 пока получилось сделать так, что скринридер два раза озвучивает текс : 'введено 2 символа из 6, введено 2 символа из 6' 
3. Возможность не произносить скринридером эмодзи, переданные в title. ( как вариант прокидывать в title что-то типа \<span>Заголовок\<span aria-hidden="true">😊\</span>\</span>). Мне кажется ограничивать с нашей стороны скринридеры как-то неправильно

как тестировать ошибку: 
включить скринридер на устройстве -> зайти в нашу демку Confirmation -> выбрать в селекте Некорректный код -> ввести любой код (как результат скринридер должен успеть произнести "Код введён неверно")
как тестировать количество введенных и оставшихся символов: 
включить скринридер на устройстве -> зайти в нашу демку Confirmation -> ввести любой код (как результат скринридер должен произносить на каждый ввод символа "Введено N из NN символов")

устройства для тестирования:

Voice Over в iOS
TalkBack в Android
nvda в Windows