### PR TITLE
Add ref to tab

### DIFF
--- a/.changeset/eighty-pears-attack.md
+++ b/.changeset/eighty-pears-attack.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tabs': patch
+---
+
+Прокинул ref в Tab, чтобы иметь возможность отображать подсказки, например для Tooltip или Popover

--- a/packages/gallery/src/component.test.tsx
+++ b/packages/gallery/src/component.test.tsx
@@ -283,7 +283,7 @@ describe('Gallery', () => {
 
             await waitFor(
                 () => expect(getByText('Открыть в полноэкранном режиме')).toBeInTheDocument(),
-                { timeout: 2000 },
+                { timeout: 4000 },
             );
 
             fireEvent.mouseOver(downloadButton);

--- a/packages/input-autocomplete/src/Component.test.tsx
+++ b/packages/input-autocomplete/src/Component.test.tsx
@@ -213,7 +213,9 @@ describe('InputAutocompleteMobile', () => {
             const option = await findByText(options[0].content);
 
             fireEvent.click(option);
-            await waitFor(() => expect(onExited).toBeCalled());
+            await waitFor(() => expect(onExited).toBeCalled(), {
+                timeout: 4000,
+            });
             await userEvent.tab();
 
             expect(onBlur).toBeCalled();

--- a/packages/tabs/src/components/primary-tablist/Component.collapsible.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.collapsible.tsx
@@ -49,17 +49,27 @@ export const CollapsiblePrimaryTabList = ({
 
     const collapsedOptions = useMemo(
         () =>
-            tablistTitles.reduce<PickerButtonDesktopProps['options']>((options, title) => {
-                if (title.collapsed) {
-                    options.push({
-                        key: title.title,
-                        value: title.id,
-                        content: <Title {...title} styles={styles} isOption={true} />,
-                    });
-                }
+            tablistTitles.reduce<PickerButtonDesktopProps['options']>(
+                (options, { ref, ...title }) => {
+                    if (title.collapsed) {
+                        options.push({
+                            key: title.title,
+                            value: title.id,
+                            content: (
+                                <Title
+                                    {...title}
+                                    ref={ref as React.Ref<HTMLButtonElement>}
+                                    styles={styles}
+                                    isOption={true}
+                                />
+                            ),
+                        });
+                    }
 
-                return options;
-            }, []),
+                    return options;
+                },
+                [],
+            ),
         [tablistTitles],
     );
 

--- a/packages/tabs/src/components/primary-tablist/Component.collapsible.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.collapsible.tsx
@@ -86,7 +86,7 @@ export const CollapsiblePrimaryTabList = ({
                 [styles.fullWidthScroll]: fullWidthScroll,
             })}
         >
-            {tablistTitles.map(({ dataTestId: _, ...restTitleProps }, index) => (
+            {tablistTitles.map(({ dataTestId: _, ref: __, ...restTitleProps }, index) => (
                 <KeyboardFocusable key={restTitleProps.id}>
                     {(ref, focused) => (
                         <Title

--- a/packages/tabs/src/components/primary-tablist/Component.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.tsx
@@ -59,7 +59,7 @@ export const PrimaryTabList = ({
                 [styles.fullWidthScroll]: fullWidthScroll,
             })}
         >
-            {titles.map(({ dataTestId: _, ...restTitleProps }, index) => (
+            {titles.map(({ dataTestId: _, ref: __, ...restTitleProps }, index) => (
                 <KeyboardFocusable key={restTitleProps.id}>
                     {(ref, focused) => (
                         <Title

--- a/packages/tabs/src/components/tab/Component.tsx
+++ b/packages/tabs/src/components/tab/Component.tsx
@@ -1,25 +1,28 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import cn from 'classnames';
 
 import { TabProps } from '../../typings';
 
 import styles from './index.module.css';
 
-export const Tab = ({ children, hidden, className, disabled, dataTestId }: TabProps) =>
-    children ? (
-        <div
-            className={cn(
-                styles.component,
-                {
-                    [styles.hidden]: hidden,
-                },
-                className,
-            )}
-            hidden={hidden}
-            role='tabpanel'
-            tabIndex={disabled ? -1 : 0}
-            data-test-id={dataTestId}
-        >
-            {children}
-        </div>
-    ) : null;
+export const Tab = forwardRef<HTMLDivElement, TabProps>(
+    ({ children, hidden, className, disabled, dataTestId }, ref) =>
+        children ? (
+            <div
+                ref={ref}
+                className={cn(
+                    styles.component,
+                    {
+                        [styles.hidden]: hidden,
+                    },
+                    className,
+                )}
+                hidden={hidden}
+                role='tabpanel'
+                tabIndex={disabled ? -1 : 0}
+                data-test-id={dataTestId}
+            >
+                {children}
+            </div>
+        ) : null,
+);

--- a/packages/tabs/src/components/tabs/Component.tsx
+++ b/packages/tabs/src/components/tabs/Component.tsx
@@ -32,6 +32,7 @@ export const Tabs = ({
                 toggleClassName,
                 dataTestId: toggleTestId,
             },
+            ref,
         }) => ({
             title,
             id,
@@ -40,6 +41,7 @@ export const Tabs = ({
             hidden,
             toggleClassName,
             dataTestId: toggleTestId,
+            ref,
         }),
     );
 

--- a/packages/tabs/src/hooks/use-tabs.tsx
+++ b/packages/tabs/src/hooks/use-tabs.tsx
@@ -1,4 +1,13 @@
-import { KeyboardEvent, MouseEvent, MutableRefObject, useCallback, useRef, useState } from 'react';
+import {
+    KeyboardEvent,
+    MouseEvent,
+    MutableRefObject,
+    Ref,
+    useCallback,
+    useRef,
+    useState,
+} from 'react';
+import mergeRefs from 'react-merge-refs';
 
 import { getDataTestId } from '@alfalab/core-components-shared';
 
@@ -100,9 +109,21 @@ export function useTabs({ titles = [], selectedId, onChange }: UseTabsProps) {
         [focusTab],
     );
 
-    const getTabListItemProps = (index: number, outerRef?: MutableRefObject<HTMLElement>) => {
+    const getTabListItemProps = (index: number, keyboardRef?: MutableRefObject<HTMLElement>) => {
         const item = titles[index];
         const itemSelected = item.id === selectedId;
+
+        const refs: Array<Ref<HTMLElement>> = [
+            (node: HTMLButtonElement) => {
+                // eslint-disable-next-line no-param-reassign
+                if (keyboardRef) keyboardRef.current = node;
+                handleItemRef(node, item, index);
+            },
+        ];
+
+        if (item.ref) {
+            refs.push(item.ref);
+        }
 
         return {
             role: 'tab',
@@ -111,11 +132,7 @@ export function useTabs({ titles = [], selectedId, onChange }: UseTabsProps) {
             selected: itemSelected,
             'data-test-id': getDataTestId(item.dataTestId, 'toggle'),
             disabled: item.disabled,
-            ref: (node: HTMLButtonElement) => {
-                // eslint-disable-next-line no-param-reassign
-                if (outerRef) outerRef.current = node;
-                handleItemRef(node, item, index);
-            },
+            ref: mergeRefs(refs),
             onKeyDown: handleKeyDown,
             onClick: (event?: MouseEvent) => handleItemClick(event as MouseEvent, item),
         };

--- a/packages/tabs/src/typings.ts
+++ b/packages/tabs/src/typings.ts
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, ReactElement, ReactNode } from 'react';
+import { FC, FunctionComponentElement, MouseEvent, ReactNode, Ref } from 'react';
 
 import { TagProps } from '@alfalab/core-components-tag';
 
@@ -63,7 +63,7 @@ export type TabsProps = {
     /**
      * Компоненты табов
      */
-    children: Array<ReactElement<TabProps>>;
+    children: Array<FunctionComponentElement<TabProps>>;
 
     /**
      * Компонент заголовков табов
@@ -147,6 +147,11 @@ export type TabProps = {
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
+
+    /**
+     * Реф на компонент таба
+     */
+    ref?: Ref<HTMLDivElement>;
 };
 
 export type TabListTitle = {
@@ -159,6 +164,7 @@ export type TabListTitle = {
     selected?: boolean;
     collapsed?: boolean;
     dataTestId?: string;
+    ref?: Ref<HTMLDivElement>;
 };
 
 export type TabListProps = Pick<


### PR DESCRIPTION
# Опишите проблему
При указании в Tooltip или в Popover пропс anchor со ссылкой на Tab, таб не отображался или anchor принимал значение контейнера, вокруг которого был обернут компонент Tooltip или в Popover

# Шаги для воспроизведения
```
const PaymentTabsBlock = () => {
    const [anchor, setAnchor] = useState<HTMLElement | null>(null);

    return (
        <Tooltip
            content={
                <Typography.Text>Подсказка</Typography.Text>
            }
            position={ 'right-start' }
            anchor={ anchor }
            open={ true }
        >
            <Tabs>
                <Tab key={ '1' } id={ '1' } title='1' />
                <Tab key={ '2' } id={ '2' } title={ '2' } />
                <Tab ref={ setAnchor } key={ '3' } id={ '3' } title='3' />
            </Tabs>
        </Tooltip>
    );
};
```

# Ожидаемое поведение
При рендере должна отобразиться подсказка возле таба, которому передали ref

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставьте блок пустым)

## Смартфон (если данных нет оставьте блок пустым):

# Дополнительная информация
Падали, то успешно проходили 2 теста, добавление задержки поправило ошибку