### PR TITLE
feat(select): update downshift version

### DIFF
--- a/.changeset/selfish-mails-impress.md
+++ b/.changeset/selfish-mails-impress.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': minor
+---
+
+Обновлена зависимость downshift до 8.3.1

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "classnames": "^2.3.1",
         "compute-scroll-into-view": "^3.1.0",
         "date-fns": "^2.16.1",
-        "downshift": "^8.2.2",
+        "downshift": "^8.3.1",
         "element-closest": "^3.0.2",
         "intersection-observer": "^0.12.0",
         "libphonenumber-js": "^1.10.30",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -33,7 +33,7 @@
         "@juggle/resize-observer": "^3.3.1",
         "compute-scroll-into-view": "^3.1.0",
         "classnames": "^2.3.1",
-        "downshift": "^8.2.2",
+        "downshift": "^8.3.1",
         "intersection-observer": "^0.12.0",
         "react-merge-refs": "^1.1.0",
         "react-virtual": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9497,10 +9497,10 @@ dotgitignore@^2.1.0:
     find-up "^3.0.0"
     minimatch "^3.0.4"
 
-downshift@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-8.2.2.tgz#bc4bf0024ad9b70bf2c493b58cca9c652fb1d555"
-  integrity sha512-UmJHlNTzmFN3i427Hh9f1OXMnkhgSB/J+urC9ywabvwuftm0nB0/Utsb89OtDq+2UqyScQV4Ro7EM2PEV80N5w==
+downshift@^8.2.2, downshift@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-8.3.1.tgz#a820e3a500f0f2a0784a55bac48ffaa7e11141b5"
+  integrity sha512-djPzjGfTSEjOsfmlur4onCV3Mtd6oGI+eOQIBNwoS7oEYTjPrxk6n+sJLmndT/KKwHvUyBSh3AFb64eHIFifTQ==
   dependencies:
     "@babel/runtime" "^7.22.15"
     compute-scroll-into-view "^3.0.3"


### PR DESCRIPTION
Проблема:
 - В downshift@8.2.4 (у нас указана ^8.2.2) внесли изменение  https://github.com/downshift-js/downshift/pull/1558, которое ломает controlled мобильный селект, он перестает открываться. Из-за того, что мы используем caret (^) в указании версии,  во всех новых проектах будет установлена последняя 8.x.x версия(8.3.1 на сегодняшний день)

Что сделано:
 - Удален костыль для 18 реакта, который возникал из-за сайд эффектов в редьюсере
 - menuRef перевешены на обертки модальных сущностей. Внутри downshift есть проверка на то, где произошел клик эвент, если за пределами элемента в menuRef, то селект закрывается. Раньше это также решалось костылем в редьюсере (см.  case useCombobox.stateChangeTypes.InputBlur), который перестал работать в последних версиях downshift
 - Для controlled open добавлен useEffect, который будет менять внутреннее состояние EnhancedReducer внутри useCombobox.  При изменении только пропа openProp оно не меняется и из-за этого появляются баги с открытием/закрытием селекта

Бетка 44.7.0-beta.1