### PR TITLE
feat(calendar): allow import CalendarMonthOnlyView and CalendarMonthO…

### DIFF
--- a/packages/calendar/src/components/calendar-mobile/Component.tsx
+++ b/packages/calendar/src/components/calendar-mobile/Component.tsx
@@ -71,7 +71,7 @@ export type CalendarMobileProps = CalendarDesktopProps & {
     allowSelectionFromEmptyRange?: boolean;
 };
 
-const CalendarMonthOnlyView = ({
+export const CalendarMonthOnlyView = ({
     value,
     defaultView,
     month: monthTimestamp,
@@ -230,6 +230,20 @@ const CalendarMonthOnlyView = ({
     );
 };
 
+export const CalendarMonthOnlyViewHeader = () => (
+    <table className={styles.dayNames}>
+        <thead>
+            <tr>
+                {WEEKDAYS.map((dayName) => (
+                    <th className={styles.dayName} key={dayName}>
+                        {dayName}
+                    </th>
+                ))}
+            </tr>
+        </thead>
+    </table>
+);
+
 export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
     (
         {
@@ -263,20 +277,7 @@ export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
             if (onChange) onChange();
         };
 
-        const renderDayNames = () =>
-            monthOnlyView ? (
-                <table className={styles.dayNames}>
-                    <thead>
-                        <tr>
-                            {WEEKDAYS.map((dayName) => (
-                                <th className={styles.dayName} key={dayName}>
-                                    {dayName}
-                                </th>
-                            ))}
-                        </tr>
-                    </thead>
-                </table>
-            ) : null;
+        const renderDayNames = () => (monthOnlyView ? <CalendarMonthOnlyViewHeader /> : null);
 
         const renderContent = () => {
             const commonProps = {

--- a/packages/calendar/src/docs/description.mdx
+++ b/packages/calendar/src/docs/description.mdx
@@ -590,6 +590,30 @@ render(() => {
 });
 ```
 
+## Mobile Month Only View
+
+Представляет из себя контент мобильного month-only календаря
+
+```jsx live mobileOnly
+render(() => {
+    const [value, setValue] = React.useState();
+
+    return (
+        <CalendarMonthOnlyView
+             responsive
+             value={value}
+             onChange={setValue}
+        />
+    );
+});
+```
+
+#### Дни недели
+
+```jsx live mobileOnly
+render(() => (<CalendarMonthOnlyViewHeader />));
+```
+
 ## Слоты
 
 В каждую дату можно передать дополнительный контент, расположив его под числом.


### PR DESCRIPTION
# Опишите проблему
Нет возможности использовать контент мобильного календаря без дефолтной модалки

# Чек лист
- [x] Документация

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10

## Смартфон (если данных нет оставте блок пустым):
 - Device: iPhone 14 Pro
 - OS: iOS 17
 - Browser: Safari

