### PR TITLE
feat: set margin left 0 when title is false

### DIFF
--- a/.changeset/rude-eels-guess.md
+++ b/.changeset/rude-eels-guess.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-tabs": patch
+---
+
+Убран margin-left у rightAddons, если title передали пустую строку

--- a/packages/tabs/src/components/primary-tablist/index.module.css
+++ b/packages/tabs/src/components/primary-tablist/index.module.css
@@ -188,3 +188,6 @@
     align-items: center;
     margin-left: var(--gap-xs);
 }
+.rightAddonsMarginZero {
+    margin-left: 0;
+}

--- a/packages/tabs/src/components/tabs/__snapshots__/Component.test.tsx.snap
+++ b/packages/tabs/src/components/tabs/__snapshots__/Component.test.tsx.snap
@@ -210,7 +210,9 @@ exports[`Tabs Snapshots tests should match snapshot 3`] = `
             >
               Таб 1
             </span>
-            <span>
+            <span
+              class=""
+            >
               addon
             </span>
           </button>

--- a/packages/tabs/src/components/title/Component.tsx
+++ b/packages/tabs/src/components/title/Component.tsx
@@ -45,7 +45,15 @@ export const Title = forwardRef<HTMLButtonElement, Props>(
             >
                 <span className={cn(styles.content, { [styles.focused]: focused })}>{title}</span>
 
-                {rightAddons && <span className={styles.rightAddons}>{rightAddons}</span>}
+                {rightAddons && (
+                    <span
+                        className={cn(styles.rightAddons, {
+                            [styles.rightAddonsMarginZero]: !title,
+                        })}
+                    >
+                        {rightAddons}
+                    </span>
+                )}
             </button>
         ),
 );


### PR DESCRIPTION
# Опишите проблему
Если передать пустой title в tabs и оставить только rightAddon, появляется лишний отступ

# Шаги для воспроизведения
1. Перейти на страницу счета с комбо картой
2. посмотреть на комбо табы

# Ожидаемое поведение
Отступа нет
