### PR TITLE
Feat/pure cell different clickable areas

### DIFF
--- a/.changeset/fast-cheetahs-eat.md
+++ b/.changeset/fast-cheetahs-eat.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-themes": patch
+---
+
+- Добавлены css переменные --pure-cell-clickable-area-hover-opacity и --pure-cell-clickable-area-active-opacity для PureCell темы click 

--- a/.changeset/khaki-bees-do.md
+++ b/.changeset/khaki-bees-do.md
@@ -1,8 +1,8 @@
 ---
-"@alfalab/core-components-pure-cell": patch
+"@alfalab/core-components-pure-cell": minor
 ---
 
-Добавлена пропс onClick для компонента PureCell.Graphics
-Добавлена пропс onClick для компонента PureCell.Main
-Добавлена пропс onClick для компонента PureCell.Addon
-Кликабельные области PureCell изолированы в плане всплытия событий (click, hover, active)
+- Добавлен пропс onClick для компонента PureCell.Graphics
+- Добавлен пропс onClick для компонента PureCell.Main
+- Добавлен пропс onClick для компонента PureCell.Addon
+- Кликабельные области PureCell изолированы в плане всплытия событий (click, hover, active)

--- a/.changeset/khaki-bees-do.md
+++ b/.changeset/khaki-bees-do.md
@@ -1,0 +1,8 @@
+---
+"@alfalab/core-components-pure-cell": patch
+---
+
+Добавлена пропс onClick для компонента PureCell.Graphics
+Добавлена пропс onClick для компонента PureCell.Main
+Добавлена пропс onClick для компонента PureCell.Addon
+Кликабельные области PureCell изолированы в плане всплытия событий (click, hover, active)

--- a/packages/pure-cell/src/component.test.tsx
+++ b/packages/pure-cell/src/component.test.tsx
@@ -310,4 +310,101 @@ describe('PureCell', () => {
             expect(link.parentElement).toBe(valueTypography);
         });
     });
+
+    describe('PureCell.Main', () => {
+        it('should call cb function if it has `onClick` prop ', () => {
+            const cb = jest.fn();
+            const cellCb = jest.fn();
+
+            render(
+                <PureCell onClick={cellCb}>
+                    <PureCell.Graphics dataTestId='cell-pure' onClick={cb}>
+                        <StarMIcon />
+                    </PureCell.Graphics>
+                </PureCell>,
+            );
+
+            fireEvent.click(screen.getByTestId('cell-pure-graphics'));
+
+            expect(cb).toBeCalledTimes(1);
+            expect(cellCb).toBeCalledTimes(0);
+            expect(screen.getByTestId('cell-pure-graphics').tagName).toBe('BUTTON');
+        });
+    });
+
+    describe('PureCell.Graphics', () => {
+        it('should call cb function if it has `onClick` prop ', () => {
+            const cb = jest.fn();
+            const cellCb = jest.fn();
+
+            render(
+                <PureCell onClick={cellCb}>
+                    <PureCell.Content>
+                        <PureCell.Main dataTestId='cell-pure' onClick={cb}>
+                            <PureCell.Text titleColor='primary' view='component-primary'>
+                                Title
+                            </PureCell.Text>
+                            <PureCell.Text titleColor='secondary' view='primary-small'>
+                                Label
+                            </PureCell.Text>
+                        </PureCell.Main>
+                    </PureCell.Content>
+                </PureCell>,
+            );
+
+            fireEvent.click(screen.getByTestId('cell-pure-main'));
+
+            expect(cb).toBeCalledTimes(1);
+            expect(cellCb).toBeCalledTimes(0);
+            expect(screen.getByTestId('cell-pure-main').tagName).toBe('BUTTON');
+        });
+    });
+
+    describe('PureCell.Addon', () => {
+        it('should call cb function if it has `onClick` prop ', () => {
+            const cb = jest.fn();
+            const cellCb = jest.fn();
+
+            render(
+                <PureCell onClick={cellCb}>
+                    <PureCell.Content>
+                        <PureCell.Addon dataTestId='cell-pure' onClick={cb}>
+                            <StarMIcon />
+                        </PureCell.Addon>
+                    </PureCell.Content>
+                </PureCell>,
+            );
+
+            fireEvent.click(screen.getByTestId('cell-pure-addon'));
+
+            expect(cb).toBeCalledTimes(1);
+            expect(cellCb).toBeCalledTimes(0);
+            expect(screen.getByTestId('cell-pure-addon').tagName).toBe('BUTTON');
+        });
+    });
+
+    describe('PureCell.FooterButton', () => {
+        it('should call cb function if it has `onClick` prop ', () => {
+            const cb = jest.fn();
+            const cellCb = jest.fn();
+
+            render(
+                <PureCell onClick={cellCb}>
+                    <PureCell.Content>
+                        <PureCell.Footer>
+                            <PureCell.FooterButton dataTestId='cell-pure' onClick={cb}>
+                                Button
+                            </PureCell.FooterButton>
+                        </PureCell.Footer>
+                    </PureCell.Content>
+                </PureCell>,
+            );
+
+            fireEvent.click(screen.getByTestId('cell-pure-button'));
+
+            expect(cb).toBeCalledTimes(1);
+            expect(cellCb).toBeCalledTimes(0);
+            expect(screen.getByTestId('cell-pure-button').tagName).toBe('BUTTON');
+        });
+    });
 });

--- a/packages/pure-cell/src/component.tsx
+++ b/packages/pure-cell/src/component.tsx
@@ -123,14 +123,13 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
     ) => {
         const cellRef = useRef<HTMLDivElement>(null);
         const [focused] = useFocus(cellRef, 'keyboard');
-        const [hoverState, setHoverState] = useState(false);
-        const [activeState, setActiveState] = useState(false);
+        const [hoverState, setHoverState] = useState<boolean>(false);
+        const [activeState, setActiveState] = useState<boolean>(false);
 
         const setHover = () => setHoverState(true);
         const unsetHover = () => setHoverState(false);
-        const setActive = () => {
-            setActiveState(true);
-        };
+        const setActive = () => setActiveState(true);
+
         const unsetActive = () => setActiveState(false);
 
         const mouseEvents = {

--- a/packages/pure-cell/src/component.tsx
+++ b/packages/pure-cell/src/component.tsx
@@ -6,6 +6,7 @@ import React, {
     forwardRef,
     HTMLAttributes,
     useRef,
+    useState,
 } from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
@@ -34,6 +35,8 @@ export type PureCellContext = {
     /** Направление */
     direction?: 'horizontal' | 'vertical';
     dataTestId?: string;
+    setMainHover?: () => void;
+    unsetMainHover?: () => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -120,11 +123,37 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
     ) => {
         const cellRef = useRef<HTMLDivElement>(null);
         const [focused] = useFocus(cellRef, 'keyboard');
+        const [hoverState, setHoverState] = useState(false);
+        const [activeState, setActiveState] = useState(false);
+
+        const setHover = () => setHoverState(true);
+        const unsetHover = () => setHoverState(false);
+        const setActive = () => {
+            setActiveState(true);
+        };
+        const unsetActive = () => setActiveState(false);
+
+        const mouseEvents = {
+            onMouseEnter: setHover,
+            onMouseLeave: unsetHover,
+            onMouseDown: setActive,
+            onMouseUp: unsetActive,
+        };
+
         const addClasses = {
             [styles.component]: true,
             [styles.focused]: focused,
             [styles[direction]]: true,
             [styles[horizontalPadding]]: true,
+            [styles.hover]: hoverState,
+            [styles.active]: activeState,
+        };
+
+        const contextState: PureCellContext = {
+            direction,
+            dataTestId,
+            setMainHover: setHover,
+            unsetMainHover: unsetHover,
         };
 
         if (typeof verticalPadding === 'string') {
@@ -151,8 +180,9 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
                     className={cn(styles.link, addClasses, className)}
                     data-test-id={dataTestId}
                     onClick={onClick}
+                    {...mouseEvents}
                 >
-                    <PureCellContext.Provider value={{ direction, dataTestId }}>
+                    <PureCellContext.Provider value={contextState}>
                         {children}
                     </PureCellContext.Provider>
                 </Component>
@@ -167,8 +197,9 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
                     className={cn(styles.button, addClasses, className)}
                     data-test-id={dataTestId}
                     onClick={onClick}
+                    {...mouseEvents}
                 >
-                    <PureCellContext.Provider value={{ direction, dataTestId }}>
+                    <PureCellContext.Provider value={contextState}>
                         {children}
                     </PureCellContext.Provider>
                 </Component>
@@ -183,9 +214,7 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
                 className={cn(addClasses, className)}
                 data-test-id={dataTestId}
             >
-                <PureCellContext.Provider value={{ direction, dataTestId }}>
-                    {children}
-                </PureCellContext.Provider>
+                <PureCellContext.Provider value={contextState}>{children}</PureCellContext.Provider>
             </Component>
         );
     },

--- a/packages/pure-cell/src/components/addon/component.tsx
+++ b/packages/pure-cell/src/components/addon/component.tsx
@@ -29,6 +29,11 @@ type Props = {
      * Используется модификатор -addon
      */
     dataTestId?: string;
+
+    /**
+     * Клик по контенту аддона.
+     */
+    onClick?: () => void;
 };
 
 export const Addon: React.FC<Props> = ({
@@ -36,15 +41,39 @@ export const Addon: React.FC<Props> = ({
     verticalAlign = 'top',
     addonPadding = 'default',
     dataTestId,
+    onClick,
 }) => {
     const pureCellContext = useContext(PureCellContext);
 
+    const Component = onClick ? 'button' : 'section';
+
+    const events = onClick
+        ? {
+              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+                  onClick();
+              },
+              onMouseEnter: () => {
+                  pureCellContext.unsetMainHover?.();
+              },
+              onMouseLeave: () => {
+                  pureCellContext.setMainHover?.();
+              },
+              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+              },
+          }
+        : {};
+
     return (
-        <section
-            className={cn(styles.component, styles[addonPadding], styles[verticalAlign])}
+        <Component
+            className={cn(styles.component, styles[addonPadding], styles[verticalAlign], {
+                [styles.button]: onClick,
+            })}
             data-test-id={getDataTestId(dataTestId || pureCellContext.dataTestId, 'addon')}
+            {...events}
         >
             {children}
-        </section>
+        </Component>
     );
 };

--- a/packages/pure-cell/src/components/addon/component.tsx
+++ b/packages/pure-cell/src/components/addon/component.tsx
@@ -36,6 +36,11 @@ type Props = {
     onClick?: () => void;
 };
 
+const ADDON_COMPONENT: Record<string, keyof Pick<React.ReactHTML, 'button' | 'section'>> = {
+    button: 'button',
+    section: 'section',
+};
+
 export const Addon: React.FC<Props> = ({
     children,
     verticalAlign = 'top',
@@ -45,25 +50,23 @@ export const Addon: React.FC<Props> = ({
 }) => {
     const pureCellContext = useContext(PureCellContext);
 
-    const Component = onClick ? 'button' : 'section';
+    const Component = onClick ? ADDON_COMPONENT.button : ADDON_COMPONENT.section;
 
-    const events = onClick
-        ? {
-              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-                  onClick();
-              },
-              onMouseEnter: () => {
-                  pureCellContext.unsetMainHover?.();
-              },
-              onMouseLeave: () => {
-                  pureCellContext.setMainHover?.();
-              },
-              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-              },
-          }
-        : {};
+    const onMouseEvents = {
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            onClick?.();
+        },
+        onMouseEnter: () => {
+            pureCellContext.unsetMainHover?.();
+        },
+        onMouseLeave: () => {
+            pureCellContext.setMainHover?.();
+        },
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+        },
+    };
 
     return (
         <Component
@@ -71,7 +74,7 @@ export const Addon: React.FC<Props> = ({
                 [styles.button]: onClick,
             })}
             data-test-id={getDataTestId(dataTestId || pureCellContext.dataTestId, 'addon')}
-            {...events}
+            {...(onClick && onMouseEvents)}
         >
             {children}
         </Component>

--- a/packages/pure-cell/src/components/addon/index.module.css
+++ b/packages/pure-cell/src/components/addon/index.module.css
@@ -1,4 +1,4 @@
-@import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .component {
     display: flex;

--- a/packages/pure-cell/src/components/addon/index.module.css
+++ b/packages/pure-cell/src/components/addon/index.module.css
@@ -37,3 +37,17 @@
         align-self: flex-end;
     }
 }
+
+.button {
+    @mixin button-reset;
+    padding: 0;
+    transition: opacity 0.15s ease-in-out;
+
+    &:hover {
+        opacity: 0.8;
+    }
+
+    &:active {
+        opacity: 0.6;
+    }
+}

--- a/packages/pure-cell/src/components/addon/index.module.css
+++ b/packages/pure-cell/src/components/addon/index.module.css
@@ -44,10 +44,10 @@
     transition: opacity 0.15s ease-in-out;
 
     &:hover {
-        opacity: 0.8;
+        opacity: var(--pure-cell-clickable-area-hover-opacity);
     }
 
     &:active {
-        opacity: 0.6;
+        opacity: var(--pure-cell-clickable-area-active-opacity);
     }
 }

--- a/packages/pure-cell/src/components/footer-button/component.tsx
+++ b/packages/pure-cell/src/components/footer-button/component.tsx
@@ -18,55 +18,34 @@ type ComponentProps = Omit<ButtonProps, 'dataTestId'> & {
 type FooterButtonProps = ComponentProps &
     Partial<AnchorHTMLAttributes<HTMLAnchorElement> | ButtonHTMLAttributes<HTMLButtonElement>>;
 
+type FooterButtonMouseEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent> &
+    React.MouseEvent<HTMLButtonElement, MouseEvent>;
+
+type FooterButtonMouseEventHandler =
+    | React.MouseEventHandler<HTMLAnchorElement>
+    | React.MouseEventHandler<HTMLButtonElement>;
+
 export const FooterButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, FooterButtonProps>(
     ({ children, dataTestId, onClick, onMouseDown, onMouseEnter, onMouseLeave, ...props }, ref) => {
         const pureCellContext = useContext(PureCellContext);
 
-        const handleClick = (
-            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
-                React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        ) => {
+        const handleClick = (e: FooterButtonMouseEvent) => {
             e.stopPropagation();
-            (
-                onClick as
-                    | React.MouseEventHandler<HTMLAnchorElement>
-                    | React.MouseEventHandler<HTMLButtonElement>
-            )?.(e);
+            (onClick as FooterButtonMouseEventHandler)?.(e);
         };
 
-        const handleMouseEnter = (
-            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
-                React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        ) => {
-            (
-                onMouseEnter as
-                    | React.MouseEventHandler<HTMLAnchorElement>
-                    | React.MouseEventHandler<HTMLButtonElement>
-            )?.(e);
+        const handleMouseEnter = (e: FooterButtonMouseEvent) => {
+            (onMouseEnter as FooterButtonMouseEventHandler)?.(e);
             pureCellContext.unsetMainHover?.();
         };
 
-        const handleMouseLeave = (
-            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
-                React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        ) => {
-            (
-                onMouseLeave as
-                    | React.MouseEventHandler<HTMLAnchorElement>
-                    | React.MouseEventHandler<HTMLButtonElement>
-            )?.(e);
+        const handleMouseLeave = (e: FooterButtonMouseEvent) => {
+            (onMouseLeave as FooterButtonMouseEventHandler)?.(e);
             pureCellContext.setMainHover?.();
         };
 
-        const handleMouseDown = (
-            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
-                React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        ) => {
-            (
-                onMouseDown as
-                    | React.MouseEventHandler<HTMLAnchorElement>
-                    | React.MouseEventHandler<HTMLButtonElement>
-            )?.(e);
+        const handleMouseDown = (e: FooterButtonMouseEvent) => {
+            (onMouseDown as FooterButtonMouseEventHandler)?.(e);
             e.stopPropagation();
         };
 

--- a/packages/pure-cell/src/components/footer-button/component.tsx
+++ b/packages/pure-cell/src/components/footer-button/component.tsx
@@ -19,8 +19,56 @@ type FooterButtonProps = ComponentProps &
     Partial<AnchorHTMLAttributes<HTMLAnchorElement> | ButtonHTMLAttributes<HTMLButtonElement>>;
 
 export const FooterButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, FooterButtonProps>(
-    ({ children, dataTestId, ...props }, ref) => {
+    ({ children, dataTestId, onClick, onMouseDown, onMouseEnter, onMouseLeave, ...props }, ref) => {
         const pureCellContext = useContext(PureCellContext);
+
+        const handleClick = (
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
+                React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        ) => {
+            e.stopPropagation();
+            (
+                onClick as
+                    | React.MouseEventHandler<HTMLAnchorElement>
+                    | React.MouseEventHandler<HTMLButtonElement>
+            )?.(e);
+        };
+
+        const handleMouseEnter = (
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
+                React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        ) => {
+            (
+                onMouseEnter as
+                    | React.MouseEventHandler<HTMLAnchorElement>
+                    | React.MouseEventHandler<HTMLButtonElement>
+            )?.(e);
+            pureCellContext.unsetMainHover?.();
+        };
+
+        const handleMouseLeave = (
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
+                React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        ) => {
+            (
+                onMouseLeave as
+                    | React.MouseEventHandler<HTMLAnchorElement>
+                    | React.MouseEventHandler<HTMLButtonElement>
+            )?.(e);
+            pureCellContext.setMainHover?.();
+        };
+
+        const handleMouseDown = (
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent> &
+                React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        ) => {
+            (
+                onMouseDown as
+                    | React.MouseEventHandler<HTMLAnchorElement>
+                    | React.MouseEventHandler<HTMLButtonElement>
+            )?.(e);
+            e.stopPropagation();
+        };
 
         return (
             <Button
@@ -29,6 +77,10 @@ export const FooterButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Fo
                 dataTestId={getDataTestId(dataTestId || pureCellContext.dataTestId, 'button')}
                 className={styles.component}
                 ref={ref}
+                onClick={handleClick}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                onMouseDown={handleMouseDown}
             >
                 {children}
             </Button>

--- a/packages/pure-cell/src/components/graphics/component.tsx
+++ b/packages/pure-cell/src/components/graphics/component.tsx
@@ -29,6 +29,11 @@ export type Props = {
      * Отступ от графики
      */
     graphicPadding?: 'airy' | 'default' | 'compact' | 'tiny' | 'none';
+
+    /**
+     * Клик по контенту графики.
+     */
+    onClick?: () => void;
 };
 
 export const Graphics: React.FC<Props> = ({
@@ -36,22 +41,45 @@ export const Graphics: React.FC<Props> = ({
     dataTestId,
     verticalAlign = 'top',
     graphicPadding,
+    onClick,
 }) => {
     const pureCellContext = useContext(PureCellContext);
 
+    const Component = onClick ? 'button' : 'section';
+
     const defaultGraphicPadding = pureCellContext.direction === 'horizontal' ? 'airy' : 'default';
 
+    const events = onClick
+        ? {
+              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+                  onClick();
+              },
+              onMouseEnter: () => {
+                  pureCellContext.unsetMainHover?.();
+              },
+              onMouseLeave: () => {
+                  pureCellContext.setMainHover?.();
+              },
+              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+              },
+          }
+        : {};
+
     return (
-        <section
+        <Component
             className={cn(
                 styles.component,
                 styles[verticalAlign],
                 styles[pureCellContext.direction || 'horizontal'],
                 styles[graphicPadding || defaultGraphicPadding],
+                { [styles.button]: onClick },
             )}
             data-test-id={getDataTestId(dataTestId || pureCellContext.dataTestId, 'graphics')}
+            {...events}
         >
             {children}
-        </section>
+        </Component>
     );
 };

--- a/packages/pure-cell/src/components/graphics/component.tsx
+++ b/packages/pure-cell/src/components/graphics/component.tsx
@@ -36,6 +36,11 @@ export type Props = {
     onClick?: () => void;
 };
 
+const GRAPHICS_COMPONENT: Record<string, keyof Pick<React.ReactHTML, 'button' | 'section'>> = {
+    button: 'button',
+    section: 'section',
+};
+
 export const Graphics: React.FC<Props> = ({
     children,
     dataTestId,
@@ -45,27 +50,25 @@ export const Graphics: React.FC<Props> = ({
 }) => {
     const pureCellContext = useContext(PureCellContext);
 
-    const Component = onClick ? 'button' : 'section';
+    const Component = onClick ? GRAPHICS_COMPONENT.button : GRAPHICS_COMPONENT.section;
 
     const defaultGraphicPadding = pureCellContext.direction === 'horizontal' ? 'airy' : 'default';
 
-    const events = onClick
-        ? {
-              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-                  onClick();
-              },
-              onMouseEnter: () => {
-                  pureCellContext.unsetMainHover?.();
-              },
-              onMouseLeave: () => {
-                  pureCellContext.setMainHover?.();
-              },
-              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-              },
-          }
-        : {};
+    const onMouseEvents = {
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            onClick?.();
+        },
+        onMouseEnter: () => {
+            pureCellContext.unsetMainHover?.();
+        },
+        onMouseLeave: () => {
+            pureCellContext.setMainHover?.();
+        },
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+        },
+    };
 
     return (
         <Component
@@ -77,7 +80,7 @@ export const Graphics: React.FC<Props> = ({
                 { [styles.button]: onClick },
             )}
             data-test-id={getDataTestId(dataTestId || pureCellContext.dataTestId, 'graphics')}
-            {...events}
+            {...(onClick && onMouseEvents)}
         >
             {children}
         </Component>

--- a/packages/pure-cell/src/components/graphics/index.module.css
+++ b/packages/pure-cell/src/components/graphics/index.module.css
@@ -59,3 +59,18 @@
         margin-bottom: var(--gap-2xs);
     }
 }
+
+.button {
+    @mixin button-reset;
+    padding: 0;
+    transition: opacity 0.15s ease-in-out;
+    min-width: auto;
+
+    &:hover {
+        opacity: 0.8;
+    }
+
+    &:active {
+        opacity: 0.6;
+    }
+}

--- a/packages/pure-cell/src/components/graphics/index.module.css
+++ b/packages/pure-cell/src/components/graphics/index.module.css
@@ -67,10 +67,10 @@
     min-width: auto;
 
     &:hover {
-        opacity: 0.8;
+        opacity: var(--pure-cell-clickable-area-hover-opacity);
     }
 
     &:active {
-        opacity: 0.6;
+        opacity: var(--pure-cell-clickable-area-active-opacity);
     }
 }

--- a/packages/pure-cell/src/components/graphics/index.module.css
+++ b/packages/pure-cell/src/components/graphics/index.module.css
@@ -1,4 +1,4 @@
-@import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .component {
     display: inline-flex;

--- a/packages/pure-cell/src/components/main/component.tsx
+++ b/packages/pure-cell/src/components/main/component.tsx
@@ -29,24 +29,56 @@ type Props = {
      * Используется модификатор -main
      */
     dataTestId?: string;
+
+    /**
+     * Клик по контенту.
+     */
+    onClick?: () => void;
 };
 
-export const Main: React.FC<Props> = ({ children, isReverse, className, dataTestId }) => {
-    const { direction = 'horizontal', dataTestId: contextDataTestId } = useContext(PureCellContext);
+export const Main: React.FC<Props> = ({ children, isReverse, className, dataTestId, onClick }) => {
+    const {
+        direction = 'horizontal',
+        dataTestId: contextDataTestId,
+        setMainHover,
+        unsetMainHover,
+    } = useContext(PureCellContext);
+
+    const Component = onClick ? 'button' : 'section';
+
+    const events = onClick
+        ? {
+              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+                  onClick();
+              },
+              onMouseEnter: () => {
+                  unsetMainHover?.();
+              },
+              onMouseLeave: () => {
+                  setMainHover?.();
+              },
+              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+              },
+          }
+        : {};
 
     return (
-        <div
+        <Component
             className={cn(
                 styles.component,
                 styles[direction],
                 {
                     [styles.reverse]: isReverse,
                 },
+                { [styles.button]: onClick },
                 className,
             )}
             data-test-id={getDataTestId(dataTestId || contextDataTestId, 'main')}
+            {...events}
         >
             {children}
-        </div>
+        </Component>
     );
 };

--- a/packages/pure-cell/src/components/main/component.tsx
+++ b/packages/pure-cell/src/components/main/component.tsx
@@ -36,6 +36,11 @@ type Props = {
     onClick?: () => void;
 };
 
+const MAIN_COMPONENT: Record<string, keyof Pick<React.ReactHTML, 'button' | 'section'>> = {
+    button: 'button',
+    section: 'section',
+};
+
 export const Main: React.FC<Props> = ({ children, isReverse, className, dataTestId, onClick }) => {
     const {
         direction = 'horizontal',
@@ -44,25 +49,23 @@ export const Main: React.FC<Props> = ({ children, isReverse, className, dataTest
         unsetMainHover,
     } = useContext(PureCellContext);
 
-    const Component = onClick ? 'button' : 'section';
+    const Component = onClick ? MAIN_COMPONENT.button : MAIN_COMPONENT.section;
 
-    const events = onClick
-        ? {
-              onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-                  onClick();
-              },
-              onMouseEnter: () => {
-                  unsetMainHover?.();
-              },
-              onMouseLeave: () => {
-                  setMainHover?.();
-              },
-              onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.stopPropagation();
-              },
-          }
-        : {};
+    const onMouseEvents = {
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            onClick?.();
+        },
+        onMouseEnter: () => {
+            unsetMainHover?.();
+        },
+        onMouseLeave: () => {
+            setMainHover?.();
+        },
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+        },
+    };
 
     return (
         <Component
@@ -76,7 +79,7 @@ export const Main: React.FC<Props> = ({ children, isReverse, className, dataTest
                 className,
             )}
             data-test-id={getDataTestId(dataTestId || contextDataTestId, 'main')}
-            {...events}
+            {...(onClick && onMouseEvents)}
         >
             {children}
         </Component>

--- a/packages/pure-cell/src/components/main/index.module.css
+++ b/packages/pure-cell/src/components/main/index.module.css
@@ -28,11 +28,11 @@
         min-width: auto;
 
         &:hover {
-            opacity: 0.8;
+            opacity: var(--pure-cell-clickable-area-hover-opacity);
         }
 
         &:active {
-            opacity: 0.6;
+            opacity: var(--pure-cell-clickable-area-active-opacity);
         }
     }
 }

--- a/packages/pure-cell/src/components/main/index.module.css
+++ b/packages/pure-cell/src/components/main/index.module.css
@@ -1,4 +1,4 @@
-@import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .component {
     display: flex;

--- a/packages/pure-cell/src/components/main/index.module.css
+++ b/packages/pure-cell/src/components/main/index.module.css
@@ -20,4 +20,19 @@
     &.reverse {
         flex-direction: column-reverse;
     }
+
+    &.button {
+        @mixin button-reset;
+        padding: 0;
+        transition: opacity 0.15s ease-in-out;
+        min-width: auto;
+
+        &:hover {
+            opacity: 0.8;
+        }
+
+        &:active {
+            opacity: 0.6;
+        }
+    }
 }

--- a/packages/pure-cell/src/index.module.css
+++ b/packages/pure-cell/src/index.module.css
@@ -25,11 +25,11 @@
     transition: opacity 0.15s ease-in-out;
     padding: 0;
 
-    &:hover {
+    &.hover {
         opacity: 0.8;
     }
 
-    &:active {
+    &.active {
         opacity: 0.6;
     }
 }
@@ -40,11 +40,11 @@
     cursor: pointer;
     transition: opacity 0.15s ease-in-out;
 
-    &:hover {
+    &.hover {
         opacity: 0.8;
     }
 
-    &:active {
+    &.active {
         opacity: 0.6;
     }
 }

--- a/packages/pure-cell/src/vars.css
+++ b/packages/pure-cell/src/vars.css
@@ -1,0 +1,6 @@
+@import '../../themes/src/default.css';
+
+:root {
+    --pure-cell-clickable-area-hover-opacity: 1;
+    --pure-cell-clickable-area-active-opacity: 1;
+}

--- a/packages/themes/src/mixins/click.css
+++ b/packages/themes/src/mixins/click.css
@@ -15,6 +15,7 @@
 @import './circular-progress-bar/click.css';
 @import './select/click.css';
 @import './progress-bar/click.css';
+@import './pure-cell/click.css';
 @import './icon-view/click.css';
 @import './system-message/click.css';
 @import './side-panel/click.css';
@@ -28,6 +29,7 @@
     @mixin navigation-bar-click;
     @mixin select-click;
     @mixin progress-bar-click;
+    @mixin pure-cell-click;
     @mixin amount-click;
     @mixin checkbox-group-click;
     @mixin tabs-click;

--- a/packages/themes/src/mixins/pure-cell/click.css
+++ b/packages/themes/src/mixins/pure-cell/click.css
@@ -1,0 +1,4 @@
+@define-mixin pure-cell-click {
+    --pure-cell-clickable-area-hover-opacity: 0.8;
+    --pure-cell-clickable-area-active-opacity: 0.6;
+}


### PR DESCRIPTION
# Опишите проблему
Необходимо было добавить разные кликабельные области для PureCell. 

Дизайн https://www.figma.com/file/xsWJdFDoAyA8VkbuMxP4yR/Web-%3A%3A-Core-Wrappers?type=design&node-id=0-1&mode=design&t=vQhXj8io04PKwbws-0

# Шаги для воспроизведения
Добавить onClick для Graphic Main Addon FooterButton и PureCelll

# Ожидаемое поведение
При нажатии на кликабельную область стработает только обрабочик этой области ( при наличии пропса onClick у PureCell ), hover и active состояния воспроизводятся только у кликабельной области. При взаимодействии со всей PureCell ячейкой,  hover и active состояния воспроизводятся на всей ячейке ( при наличии пропса onClick у PureCell )
