### PR TITLE
refactor(calendar): range logic

### DIFF
--- a/.changeset/brave-paws-lie.md
+++ b/.changeset/brave-paws-lie.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-calendar": minor
+---
+
+refactor(calendar): упрощена работа с периодами. Теперь достаточно использовать только value и onChange. Режим выбора периода управляется пропсой rangeBehavior. Пропсы selectedFrom и selectedTo помечены как deprecated.

--- a/.changeset/brave-paws-lie.md
+++ b/.changeset/brave-paws-lie.md
@@ -2,4 +2,4 @@
 "@alfalab/core-components-calendar": minor
 ---
 
-refactor(calendar): упрощена работа с периодами. Теперь достаточно использовать только value и onChange. Режим выбора периода управляется пропсой rangeBehavior. Пропсы selectedFrom и selectedTo помечены как deprecated.
+Упрощена работа с периодами. Теперь достаточно использовать только value и onChange. Режим выбора периода управляется пропсой rangeBehavior. Пропсы selectedFrom и selectedTo помечены как deprecated.

--- a/packages/calendar/src/components/calendar-mobile/Component.tsx
+++ b/packages/calendar/src/components/calendar-mobile/Component.tsx
@@ -15,7 +15,7 @@ import { getDataTestId } from '@alfalab/core-components-shared';
 import { CalendarDesktop } from '../../desktop';
 import { Month } from '../../typings';
 import { useCalendar } from '../../useCalendar';
-import { useRangeBehavior } from '../../useRangeBehavior';
+import { useRange } from '../../useRange';
 import {
     addonArrayToHashTable,
     dateArrayToHashTable,
@@ -58,7 +58,7 @@ export const CalendarMonthOnlyView = ({
     shape = 'rounded',
     scrollableContainer,
 }: CalendarContentProps) => {
-    const range = useRangeBehavior({
+    const range = useRange({
         mode,
         value,
         selectedFrom,

--- a/packages/calendar/src/components/calendar-mobile/Component.tsx
+++ b/packages/calendar/src/components/calendar-mobile/Component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import mergeRefs from 'react-merge-refs';
 import { Virtuoso } from 'react-virtuoso';
 import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
@@ -21,6 +21,7 @@ import {
     dateArrayToHashTable,
     generateMonths,
     generateWeeks,
+    isRangeValue,
     limitDate,
     monthName,
     WEEKDAYS,
@@ -87,8 +88,7 @@ export const CalendarMonthOnlyView = ({
         [range.value],
     );
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const startingDate = useMemo(() => (range.value ? new Date(range.value) : new Date()), []);
+    const startingDate = useRef(range.value);
 
     const defaultMonth = useMemo(
         () =>
@@ -125,7 +125,7 @@ export const CalendarMonthOnlyView = ({
         const prevMonths: Month[] = [];
         const nextMonths: Month[] = [];
 
-        const date = new Date(startingDate.getTime());
+        const date = startingDate.current ? new Date(startingDate.current) : new Date();
         const currentYear = date.getFullYear();
         const currYearMonths = generateMonths(date, {});
 
@@ -155,17 +155,7 @@ export const CalendarMonthOnlyView = ({
             }),
             title: `${monthName(item.date)} ${item.date.getFullYear()}`,
         }));
-    }, [
-        events,
-        offDays,
-        holidays,
-        dayAddons,
-        startingDate,
-        minDate,
-        maxDate,
-        yearsAmount,
-        selected,
-    ]);
+    }, [events, offDays, holidays, dayAddons, minDate, maxDate, yearsAmount, selected]);
 
     const initialMonthIndex = useMemo(() => {
         const date = range.value || range.selectedFrom || activeMonth.getTime() || Date.now();
@@ -306,8 +296,8 @@ export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
         };
 
         const renderFooter = () => {
-            const valueFrom = typeof value === 'object' ? value.dateFrom : selectedFrom;
-            const valueTo = typeof value === 'object' ? value.dateTo : selectedTo;
+            const valueFrom = isRangeValue(value) ? value.dateFrom : selectedFrom;
+            const valueTo = isRangeValue(value) ? value.dateTo : selectedTo;
 
             if (valueFrom || valueTo) {
                 let selectButtonDisabled = !valueFrom || !valueTo;

--- a/packages/calendar/src/desktop/Component.desktop.tsx
+++ b/packages/calendar/src/desktop/Component.desktop.tsx
@@ -15,7 +15,7 @@ import { PeriodSlider } from '../components/period-slider';
 import { YearsTable } from '../components/years-table';
 import { DayAddons, SelectorView, View } from '../typings';
 import { useCalendar } from '../useCalendar';
-import { useRangeBehavior } from '../useRangeBehavior';
+import { useRange } from '../useRange';
 import { limitDate } from '../utils';
 
 import styles from './desktop.module.css';
@@ -215,7 +215,7 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
         const scrollableNodeRef = useRef<HTMLDivElement>(null);
         const firstUpdate = useRef(true);
 
-        const range = useRangeBehavior({
+        const range = useRange({
             mode,
             value,
             selectedFrom,

--- a/packages/calendar/src/desktop/Component.desktop.tsx
+++ b/packages/calendar/src/desktop/Component.desktop.tsx
@@ -439,21 +439,3 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
         );
     },
 );
-
-export function Test() {
-    const [value, setValue] = React.useState<{ dateFrom?: number; dateTo?: number }>();
-
-    return (
-        <div>
-            <div>{JSON.stringify(value)}</div>
-            <CalendarDesktop
-                value={value}
-                onChange={(dateFrom, dateTo) => setValue({ dateFrom, dateTo })}
-                mode='range'
-                rangeBehavior='reset'
-                selectorView='month-only'
-                showCurrentYearSelector={true}
-            />
-        </div>
-    );
-}

--- a/packages/calendar/src/desktop/Component.desktop.tsx
+++ b/packages/calendar/src/desktop/Component.desktop.tsx
@@ -15,6 +15,7 @@ import { PeriodSlider } from '../components/period-slider';
 import { YearsTable } from '../components/years-table';
 import { DayAddons, SelectorView, View } from '../typings';
 import { useCalendar } from '../useCalendar';
+import { useRangeBehavior } from '../useRangeBehavior';
 import { limitDate } from '../utils';
 
 import styles from './desktop.module.css';
@@ -50,7 +51,19 @@ export type CalendarDesktopProps = {
     /**
      * Выбранная дата (timestamp)
      */
-    value?: number;
+    value?: number | { dateFrom?: number; dateTo?: number };
+
+    /**
+     * Режим выбора дат
+     * @default single
+     */
+    mode?: 'single' | 'range';
+
+    /**
+     * Тип выбора границ в календаре
+     * @default clarification
+     */
+    rangeBehavior?: 'clarification' | 'reset';
 
     /**
      * Открытый месяц (timestamp)
@@ -74,11 +87,13 @@ export type CalendarDesktopProps = {
 
     /**
      * Начало выделенного периода (timestamp)
+     * @deprecated используйте value вместе с mode='range'
      */
     selectedFrom?: number;
 
     /**
      * Конец выделенного периода (timestamp)
+     * @deprecated используйте value вместе с mode='range'
      */
     selectedTo?: number;
 
@@ -110,7 +125,7 @@ export type CalendarDesktopProps = {
     /**
      * Обработчик выбора даты
      */
-    onChange?: (date?: number) => void;
+    onChange?: (date?: number, dateTo?: number) => void;
 
     /**
      * Обработчик нажатия на кнопку месяца
@@ -167,6 +182,8 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
             contentClassName,
             defaultView = 'days',
             selectorView = 'full',
+            mode = 'single',
+            rangeBehavior,
             value,
             month: monthTimestamp,
             minDate: minDateTimestamp,
@@ -198,7 +215,19 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
         const scrollableNodeRef = useRef<HTMLDivElement>(null);
         const firstUpdate = useRef(true);
 
-        const selected = useMemo(() => (value ? new Date(value) : undefined), [value]);
+        const range = useRangeBehavior({
+            mode,
+            value,
+            selectedFrom,
+            selectedTo,
+            rangeBehavior,
+            onChange,
+        });
+
+        const selected = useMemo(
+            () => (range.value ? new Date(range.value) : undefined),
+            [range.value],
+        );
 
         const defaultMonth = useMemo(
             () =>
@@ -251,7 +280,7 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
             events,
             holidays,
             dayAddons,
-            onChange,
+            onChange: range.onChange,
             onMonthChange,
         });
 
@@ -316,12 +345,12 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
         }, [view]);
 
         useDidUpdateEffect(() => {
-            const newMonth = value && startOfMonth(value);
+            const newMonth = range.value && startOfMonth(range.value);
 
             if (newMonth && newMonth.getTime() !== activeMonth.getTime()) {
                 setMonthByDate(newMonth);
             }
-        }, [value]);
+        }, [range.value]);
 
         const shouldUseCustomScrollbar = useCustomWebkitScrollbar();
 
@@ -377,8 +406,8 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
                         <DaysTable
                             weeks={weeks}
                             activeMonth={activeMonth}
-                            selectedFrom={selectedFrom}
-                            selectedTo={selectedTo}
+                            selectedFrom={range.selectedFrom}
+                            selectedTo={range.selectedTo}
                             getDayProps={getDayProps}
                             highlighted={highlighted}
                             rangeComplete={rangeComplete}
@@ -410,3 +439,21 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
         );
     },
 );
+
+export function Test() {
+    const [value, setValue] = React.useState<{ dateFrom?: number; dateTo?: number }>();
+
+    return (
+        <div>
+            <div>{JSON.stringify(value)}</div>
+            <CalendarDesktop
+                value={value}
+                onChange={(dateFrom, dateTo) => setValue({ dateFrom, dateTo })}
+                mode='range'
+                rangeBehavior='reset'
+                selectorView='month-only'
+                showCurrentYearSelector={true}
+            />
+        </div>
+    );
+}

--- a/packages/calendar/src/docs/description.mdx
+++ b/packages/calendar/src/docs/description.mdx
@@ -12,17 +12,18 @@ render(() => {
         setValue();
     }, [firstRadioValue]);
 
-    const getDateString = React.useCallback((date) => {
-        const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-        const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
-        const year = date.getFullYear();
+    const format = React.useCallback((timestamp) => {
+        if (!timestamp) return '';
 
-        return `${day}.${month}.${year}`;
+        return new Intl.DateTimeFormat("ru-RU", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit"
+        }).format(new Date(timestamp));
     }, []);
 
     const selectedDate = React.useMemo(() => {
-        const date = new Date(value);
-        return getDateString(date);
+        return format(value);
     }, [value]);
 
     const onFirstRadioChange = React.useCallback((_, payload) => {
@@ -78,17 +79,18 @@ render(() => {
         setValue();
     }, [firstRadioValue]);
 
-    const getDateString = React.useCallback((date) => {
-        const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-        const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
-        const year = date.getFullYear();
+    const format = React.useCallback((timestamp) => {
+        if (!timestamp) return '';
 
-        return `${day}.${month}.${year}`;
+        return new Intl.DateTimeFormat("ru-RU", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit"
+        }).format(new Date(timestamp));
     }, []);
 
     const selectedDate = React.useMemo(() => {
-        const date = new Date(value);
-        return getDateString(date);
+        return format(value);
     }, [value]);
 
     const onFirstRadioChange = React.useCallback((_, payload) => {
@@ -131,82 +133,26 @@ render(() => {
 
 ```jsx live mobileHeight={640}
 render(() => {
-    const [firstRadioValue, setFirstRadioValue] = React.useState('clarification');
-    const [secondRadioValue, setSecondRadioValue] = React.useState('range');
+    const [rangeBehavior, setRangeBehavior] = React.useState('clarification');
+    const [value, setValue] = React.useState();
 
-    const {
-        selectedFrom: selectedFromClarification,
-        selectedTo: selectedToClarification,
-        updatePeriod: updatePeriodClarification,
-    } = usePeriod();
+    const format = React.useCallback((timestamp) => {
+        if (!timestamp) return '';
 
-    const {
-        selectedFrom: selectedFromReset,
-        selectedTo: selectedToReset,
-        updatePeriod: updatePeriodReset,
-    } = usePeriodWithReset();
-
-    const allowSelectionFromEmptyRange = secondRadioValue === 'singleAndRange';
+        return new Intl.DateTimeFormat("ru-RU", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit"
+        }).format(new Date(timestamp));
+    }, []);
 
     React.useEffect(() => {
-        updatePeriodClarification();
-        updatePeriodReset();
-    }, [firstRadioValue, secondRadioValue]);
-
-    const isClarification = React.useMemo(
-        () => firstRadioValue === 'clarification',
-        [firstRadioValue],
-    );
-
-    const updatePeriod = React.useMemo(() => {
-        return isClarification ? updatePeriodClarification : updatePeriodReset;
-    }, [isClarification, updatePeriodClarification, updatePeriodReset]);
-
-    const getDateString = React.useCallback((date) => {
-        if (!date) return '';
-
-        const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-        const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
-        const year = date.getFullYear();
-
-        return `${day}.${month}.${year}`;
-    }, []);
-
-    const selectedFrom = React.useMemo(() => {
-        return isClarification ? selectedFromClarification : selectedFromReset;
-    }, [isClarification, selectedFromClarification, selectedFromReset]);
-
-    const selectedTo = React.useMemo(() => {
-        return isClarification ? selectedToClarification : selectedToReset;
-    }, [isClarification, selectedToClarification, selectedToReset]);
+        setValue([]);
+    }, [rangeBehavior]);
 
     const selectedRange = React.useMemo(() => {
-        if (selectedFrom && selectedTo) {
-            const selectedFromDate = new Date(selectedFrom);
-            const selectedToDate = new Date(selectedTo);
-            return `${getDateString(selectedFromDate)} - ${getDateString(selectedToDate)}`;
-        }
-
-        if (allowSelectionFromEmptyRange) {
-            if (selectedFrom) {
-                const selectedFromDate = new Date(selectedFrom);
-                return `${getDateString(selectedFromDate)}`;
-            } else if (selectedTo) {
-                const selectedToDate = new Date(selectedTo);
-                return `${getDateString(selectedToDate)}`;
-            }
-        }
-
-        return '';
-    }, [allowSelectionFromEmptyRange, selectedFrom, selectedTo]);
-
-    const onSecondRadioChange = React.useCallback((_, payload) => {
-        setSecondRadioValue(payload.value);
-    }, []);
-
-    const onFirstRadioChange = React.useCallback((_, payload) => {
-        setFirstRadioValue(payload.value);
-    }, []);
+        return `${format(value ? value.dateFrom : undefined)} - ${format(value ? value.dateTo : undefined)}`;
+    }, [value]);
 
     const calendarStyles = {
         border: '1px solid rgba(233, 233, 235, 1)',
@@ -221,38 +167,23 @@ render(() => {
         <div style={{ width: 344 }}>
             <div style={calendarStyles}>
                 <CalendarDesktop
-                    responsive={true}
-                    selectedFrom={selectedFrom}
-                    selectedTo={selectedTo}
-                    onChange={updatePeriod}
+                    mode='range'
+                    rangeBehavior={rangeBehavior}
+                    value={value}
+                    onChange={(dateFrom, dateTo) => setValue({ dateFrom, dateTo })}
                     selectorView='month-only'
                     showCurrentYearSelector={true}
+                    responsive={true}
                 />
             </div>
             <p style={{ marginTop: 32, marginBottom: 32 }}>Values: {selectedRange}</p>
-            <div style={{ marginBottom: 32 }}>
-                <RadioGroup
-                    label='Режим'
-                    direction='vertical'
-                    name='radioGroup'
-                    onChange={onSecondRadioChange}
-                    value={secondRadioValue}
-                >
-                    <Radio size='m' label='Принимает диапазон значений' value='range' />
-                    <Radio
-                        size='m'
-                        label='Может принимать и диапазон и дату'
-                        value='singleAndRange'
-                    />
-                </RadioGroup>
-            </div>
             <div>
                 <RadioGroup
                     label='Тип выбора границ'
                     direction='vertical'
-                    name='radioGroupFirst'
-                    onChange={onFirstRadioChange}
-                    value={firstRadioValue}
+                    name='rangeBehavior'
+                    onChange={(_, payload) => setRangeBehavior(payload.value)}
+                    value={rangeBehavior}
                 >
                     <Radio size='m' label='Уточнение' value='clarification' />
                     <Radio size='m' label='Сброс' value='reset' />
@@ -265,82 +196,29 @@ render(() => {
 render(() => {
     const [open, setOpen] = React.useState(false);
 
-    const [firstRadioValue, setFirstRadioValue] = React.useState('clarification');
-    const [secondRadioValue, setSecondRadioValue] = React.useState('range');
+    const [rangeBehavior, setRangeBehavior] = React.useState('clarification');
+    const [selectionMode, setSelectionMode] = React.useState('range');
+    const [value, setValue] = React.useState();
 
-    const {
-        selectedFrom: selectedFromClarification,
-        selectedTo: selectedToClarification,
-        updatePeriod: updatePeriodClarification,
-    } = usePeriod();
+    const format = React.useCallback((timestamp) => {
+        if (!timestamp) return '';
 
-    const {
-        selectedFrom: selectedFromReset,
-        selectedTo: selectedToReset,
-        updatePeriod: updatePeriodReset,
-    } = usePeriodWithReset();
-
-    const allowSelectionFromEmptyRange = secondRadioValue === 'singleAndRange';
+        return new Intl.DateTimeFormat("ru-RU", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit"
+        }).format(new Date(timestamp));
+    }, []);
 
     React.useEffect(() => {
-        updatePeriodClarification();
-        updatePeriodReset();
-    }, [firstRadioValue, secondRadioValue]);
-
-    const isClarification = React.useMemo(
-        () => firstRadioValue === 'clarification',
-        [firstRadioValue],
-    );
-
-    const updatePeriod = React.useMemo(() => {
-        return isClarification ? updatePeriodClarification : updatePeriodReset;
-    }, [isClarification, updatePeriodClarification, updatePeriodReset]);
-
-    const getDateString = React.useCallback((date) => {
-        if (!date) return '';
-
-        const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-        const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
-        const year = date.getFullYear();
-
-        return `${day}.${month}.${year}`;
-    }, []);
-
-    const selectedFrom = React.useMemo(() => {
-        return isClarification ? selectedFromClarification : selectedFromReset;
-    }, [isClarification, selectedFromClarification, selectedFromReset]);
-
-    const selectedTo = React.useMemo(() => {
-        return isClarification ? selectedToClarification : selectedToReset;
-    }, [isClarification, selectedToClarification, selectedToReset]);
+        setValue([]);
+    }, [rangeBehavior]);
 
     const selectedRange = React.useMemo(() => {
-        if (selectedFrom && selectedTo) {
-            const selectedFromDate = new Date(selectedFrom);
-            const selectedToDate = new Date(selectedTo);
-            return `${getDateString(selectedFromDate)} - ${getDateString(selectedToDate)}`;
-        }
+        return `${format(value ? value.dateFrom : undefined)} - ${format(value ? value.dateTo : undefined)}`;
+    }, [value]);
 
-        if (allowSelectionFromEmptyRange) {
-            if (selectedFrom) {
-                const selectedFromDate = new Date(selectedFrom);
-                return `${getDateString(selectedFromDate)}`;
-            } else if (selectedTo) {
-                const selectedToDate = new Date(selectedTo);
-                return `${getDateString(selectedToDate)}`;
-            }
-        }
-
-        return '';
-    }, [allowSelectionFromEmptyRange, selectedFrom, selectedTo]);
-
-    const onSecondRadioChange = React.useCallback((_, payload) => {
-        setSecondRadioValue(payload.value);
-    }, []);
-
-    const onFirstRadioChange = React.useCallback((_, payload) => {
-        setFirstRadioValue(payload.value);
-    }, []);
+    const allowSelectionFromEmptyRange = selectionMode === 'singleAndRange';
 
     return (
         <Container>
@@ -348,11 +226,12 @@ render(() => {
                 Открыть календарь
             </Button>
             <CalendarMobile
+                mode='range'
+                rangeBehavior={rangeBehavior}
+                value={value}
+                onChange={(dateFrom, dateTo) => setValue({ dateFrom, dateTo })}
                 onClose={() => setOpen(false)}
                 open={open}
-                selectedFrom={selectedFrom}
-                selectedTo={selectedTo}
-                onChange={updatePeriod}
                 selectorView='month-only'
                 allowSelectionFromEmptyRange={allowSelectionFromEmptyRange}
             />
@@ -361,9 +240,9 @@ render(() => {
                 <RadioGroup
                     label='Режим'
                     direction='vertical'
-                    name='radioGroup'
-                    onChange={onSecondRadioChange}
-                    value={secondRadioValue}
+                    name='selectionMode'
+                    onChange={(_, payload) => setSelectionMode(payload.value)}
+                    value={selectionMode}
                 >
                     <Radio size='m' label='Принимает диапазон значений' value='range' />
                     <Radio
@@ -377,9 +256,9 @@ render(() => {
                 <RadioGroup
                     label='Тип выбора границ'
                     direction='vertical'
-                    name='radioGroupFirst'
-                    onChange={onFirstRadioChange}
-                    value={firstRadioValue}
+                    name='rangeBehavior'
+                    onChange={(_, payload) => setRangeBehavior(payload.value)}
+                    value={rangeBehavior}
                 >
                     <Radio size='m' label='Уточнение' value='clarification' />
                     <Radio size='m' label='Сброс' value='reset' />

--- a/packages/calendar/src/useRange.ts
+++ b/packages/calendar/src/useRange.ts
@@ -3,19 +3,19 @@ import { useEffect } from 'react';
 import type { CalendarDesktopProps } from './desktop';
 import { usePeriod, usePeriodWithReset } from './usePeriod';
 
-type UseRangeBehaviorProps = Pick<
+type UseRangeProps = Pick<
     CalendarDesktopProps,
     'mode' | 'value' | 'rangeBehavior' | 'onChange' | 'selectedFrom' | 'selectedTo'
 >;
 
-export function useRangeBehavior({
+export function useRange({
     mode = 'single',
     value,
     selectedFrom,
     selectedTo,
     rangeBehavior,
     onChange,
-}: UseRangeBehaviorProps) {
+}: UseRangeProps) {
     const valueFrom = typeof value === 'object' ? value.dateFrom : value;
     const valueTo = typeof value === 'object' ? value.dateTo : value;
 

--- a/packages/calendar/src/useRange.ts
+++ b/packages/calendar/src/useRange.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import type { CalendarDesktopProps } from './desktop';
 import { usePeriod, usePeriodWithReset } from './usePeriod';
+import { isRangeValue } from './utils';
 
 type UseRangeProps = Pick<
     CalendarDesktopProps,
@@ -16,8 +17,8 @@ export function useRange({
     rangeBehavior,
     onChange,
 }: UseRangeProps) {
-    const valueFrom = typeof value === 'object' ? value.dateFrom : value;
-    const valueTo = typeof value === 'object' ? value.dateTo : value;
+    const valueFrom = isRangeValue(value) ? value.dateFrom : value;
+    const valueTo = isRangeValue(value) ? value.dateTo : value;
 
     const periodHook = rangeBehavior === 'clarification' ? usePeriod : usePeriodWithReset;
 

--- a/packages/calendar/src/useRangeBehavior.ts
+++ b/packages/calendar/src/useRangeBehavior.ts
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+
+import type { CalendarDesktopProps } from './desktop';
+import { usePeriod, usePeriodWithReset } from './usePeriod';
+
+type UseRangeBehaviorProps = Pick<
+    CalendarDesktopProps,
+    'mode' | 'value' | 'rangeBehavior' | 'onChange' | 'selectedFrom' | 'selectedTo'
+>;
+
+export function useRangeBehavior({
+    mode = 'single',
+    value,
+    selectedFrom,
+    selectedTo,
+    rangeBehavior,
+    onChange,
+}: UseRangeBehaviorProps) {
+    const valueFrom = typeof value === 'object' ? value.dateFrom : value;
+    const valueTo = typeof value === 'object' ? value.dateTo : value;
+
+    const periodHook = rangeBehavior === 'clarification' ? usePeriod : usePeriodWithReset;
+
+    const period = periodHook({
+        initialSelectedFrom: valueFrom,
+        initialSelectedTo: valueTo,
+    });
+
+    useEffect(() => {
+        if (mode === 'single') {
+            return;
+        }
+
+        // Внешние изменения
+        if (valueFrom !== period.selectedFrom) {
+            period.setStart(valueFrom);
+        }
+
+        if (valueTo !== period.selectedTo) {
+            period.setEnd(valueTo);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [mode, valueFrom, valueTo]);
+
+    useEffect(() => {
+        if (mode === 'single') {
+            return;
+        }
+
+        // Внутренние изменения (действия пользователя)
+        if (valueFrom !== period.selectedFrom || valueTo !== period.selectedTo) {
+            onChange?.(period.selectedFrom, period.selectedTo);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [mode, period.selectedFrom, period.selectedTo]);
+
+    const minValue = (() => {
+        if (mode === 'single') {
+            return valueFrom;
+        }
+
+        const values = [period.selectedFrom, period.selectedTo, valueFrom, valueTo].filter(
+            Boolean,
+        ) as number[];
+
+        if (!values.length) return undefined;
+
+        return Math.min(...values);
+    })();
+
+    if (mode === 'single') {
+        return {
+            selectedFrom,
+            selectedTo,
+            onChange,
+            onReset: onChange ? () => onChange(undefined) : undefined,
+            value: valueFrom,
+        };
+    }
+
+    return {
+        selectedFrom: period.selectedFrom,
+        selectedTo: period.selectedTo,
+        onChange: period.updatePeriod,
+        onReset: period.resetPeriod,
+        value: minValue,
+    };
+}

--- a/packages/calendar/src/utils.ts
+++ b/packages/calendar/src/utils.ts
@@ -25,6 +25,7 @@ import subMonths from 'date-fns/subMonths';
 import { getDataTestId } from '@alfalab/core-components-shared';
 
 import { DateShift, Day, DayAddons, Month, SpecialDays, SpecialDaysAddon } from './typings';
+import { CalendarProps } from '.';
 
 export const DAYS_IN_WEEK = 7;
 export const MONTHS_IN_YEAR = 12;
@@ -298,4 +299,10 @@ export function getCalendarMobileTestIds(dataTestId: string) {
         btnApply: getDataTestId(dataTestId, 'btn-apply'),
         btnReset: getDataTestId(dataTestId, 'btn-reset'),
     };
+}
+
+export function isRangeValue(
+    value: CalendarProps['value'],
+): value is { dateFrom?: number | undefined; dateTo?: number | undefined } {
+    return Boolean(value) && typeof value === 'object';
 }


### PR DESCRIPTION
*Предлагаемые изменения в Calendar*

Т.к. основной запрос был на предоставление более удобного апи для выбора периода в компоненте Calendar, то предлагаю следующие изменения:

1. Не делать мажоррку, либо компонент V2, а только добавить в текущее апи возможность работы с диапазонами дат.
2. Добавить проп `mode?: 'single' | 'range';`
3. По аналогии с UniversalDateInput добавить проп `rangeBehavior` и избавить пользователя от необходимости самому настраивать хуки usePeriod и usePeriodWithReset.
4. Изменить тип `value` на `value?: number | { dateFrom?: number; dateTo?: number };`
5. Изменить тип `onChange` на `(date: number, dateTo?: number) => void`

Кажется, что данных изменений будет достаточно, чтобы решить основные проблемы с текущим компонентом, а также не сломать обратную совместимость и не заставлять пользователей переезжать на новый компонент.