### PR TITLE
feat(calendar): adding data-test-id

### DIFF
--- a/.changeset/angry-bananas-punch.md
+++ b/.changeset/angry-bananas-punch.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-calendar": patch
+---
+
+Добавили dataTestId к PeriodSlider

--- a/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
@@ -44,10 +44,12 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
           <div
             aria-live="polite"
             class="component period"
+            data-test-id="period-slider"
           >
             <button
               aria-label="Предыдущий период"
               class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+              data-test-id="period-slider-btn-previous-day"
               type="button"
             >
               <span
@@ -80,6 +82,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
             <button
               aria-label="Следующий период"
               class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+              data-test-id="period-slider-btn-next-day"
               type="button"
             >
               <span
@@ -957,10 +960,12 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
           <div
             aria-live="polite"
             class="component period"
+            data-test-id="period-slider"
           >
             <button
               aria-label="Предыдущий период"
               class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+              data-test-id="period-slider-btn-previous-day"
               type="button"
             >
               <span
@@ -993,6 +998,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
             <button
               aria-label="Следующий период"
               class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+              data-test-id="period-slider-btn-next-day"
               type="button"
             >
               <span

--- a/packages/calendar/src/Component.test.tsx
+++ b/packages/calendar/src/Component.test.tsx
@@ -77,6 +77,18 @@ describe('Calendar', () => {
         expect(getByTestId(testId)).toBeInTheDocument();
     });
 
+    it('should set `data-test-id` attribute for month-only view', () => {
+        const testId = 'test-id';
+        const { getByTestId } = render(<Calendar dataTestId={testId} selectorView='month-only' />);
+
+        expect(getByTestId(testId)).toBeInTheDocument();
+
+        const testIds = getCalendarMobileTestIds(testId);
+
+        expect(getByTestId(testIds.btnPreviousDate)).toBeInTheDocument();
+        expect(getByTestId(testIds.btnNextDate)).toBeInTheDocument();
+    });
+
     it('should set `data-test-id` attribute in mobile component', () => {
         const dti = 'modal-dti';
 
@@ -1402,10 +1414,9 @@ describe('Calendar', () => {
 describe('hook tests', () => {
     it('should fromDate less than toDate when initial dates is equal', () => {
         const initialDate = new Date('2024-01-01').getTime();
-        const newToDate = new Date('2024-01-02').getTime();
         const newFromDate = new Date('2023-12-01').getTime();
 
-        const { result, rerender } = renderHook(() =>
+        const { result } = renderHook(() =>
             usePeriod({
                 initialSelectedFrom: initialDate,
                 initialSelectedTo: initialDate,

--- a/packages/calendar/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar/src/__snapshots__/Component.test.tsx.snap
@@ -3408,10 +3408,12 @@ exports[`Calendar Display tests should match selectorView="month-only" snapshot 
       <div
         aria-live="polite"
         class="component period"
+        data-test-id="period-slider"
       >
         <button
           aria-label="Предыдущий период"
           class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+          data-test-id="period-slider-btn-previous-day"
           type="button"
         >
           <span
@@ -3444,6 +3446,7 @@ exports[`Calendar Display tests should match selectorView="month-only" snapshot 
         <button
           aria-label="Следующий период"
           class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+          data-test-id="period-slider-btn-next-day"
           type="button"
         >
           <span

--- a/packages/calendar/src/components/calendar-mobile/Component.tsx
+++ b/packages/calendar/src/components/calendar-mobile/Component.tsx
@@ -284,6 +284,7 @@ export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
                     responsive={true}
                     className={cn(className, styles.calendar)}
                     contentClassName={styles.content}
+                    dataTestId={getDataTestId(dataTestId, 'mobile')}
                     {...commonProps}
                     {...restProps}
                 />

--- a/packages/calendar/src/components/period-slider/Component.tsx
+++ b/packages/calendar/src/components/period-slider/Component.tsx
@@ -5,6 +5,7 @@ import startOfWeek from 'date-fns/startOfWeek';
 
 import { ButtonDesktop as Button } from '@alfalab/core-components-button/desktop';
 import { IconButton } from '@alfalab/core-components-icon-button';
+import { getDataTestId } from '@alfalab/core-components-shared';
 import { ChevronBackMIcon } from '@alfalab/icons-glyph/ChevronBackMIcon';
 
 import { monthName } from '../../utils';
@@ -129,7 +130,7 @@ export const PeriodSlider: FC<PeriodSliderProps> = ({
     onMonthClick,
     onYearClick,
     onPeriodClick,
-    dataTestId,
+    dataTestId = 'period-slider',
     emptyValueText = 'Укажите период',
 }) => {
     const [valueFrom, valueTo] = useMemo(() => {
@@ -253,6 +254,7 @@ export const PeriodSlider: FC<PeriodSliderProps> = ({
                     onClick={handlePrevArrowClick}
                     disabled={prevArrowDisabled || !valueFrom}
                     aria-label='Предыдущий период'
+                    dataTestId={getDataTestId(dataTestId, 'btn-previous-day')}
                 />
             )}
 
@@ -266,6 +268,7 @@ export const PeriodSlider: FC<PeriodSliderProps> = ({
                     onClick={handleNextArrowClick}
                     disabled={nextArrowDisabled || !valueFrom}
                     aria-label='Следующий период'
+                    dataTestId={getDataTestId(dataTestId, 'btn-next-day')}
                 />
             )}
         </div>

--- a/packages/calendar/src/components/period-slider/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar/src/components/period-slider/__snapshots__/Component.test.tsx.snap
@@ -5,10 +5,12 @@ exports[`PeriodSlider empty PeriodSlider empty PeriodSlider default title snapsh
   <div
     aria-live="polite"
     class="component"
+    data-test-id="period-slider"
   >
     <button
       aria-label="Предыдущий период"
       class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+      data-test-id="period-slider-btn-previous-day"
       disabled=""
       type="button"
     >
@@ -42,6 +44,7 @@ exports[`PeriodSlider empty PeriodSlider empty PeriodSlider default title snapsh
     <button
       aria-label="Следующий период"
       class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+      data-test-id="period-slider-btn-next-day"
       disabled=""
       type="button"
     >
@@ -76,10 +79,12 @@ exports[`PeriodSlider empty PeriodSlider empty PeriodSlider specific title snaps
   <div
     aria-live="polite"
     class="component"
+    data-test-id="period-slider"
   >
     <button
       aria-label="Предыдущий период"
       class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+      data-test-id="period-slider-btn-previous-day"
       disabled=""
       type="button"
     >
@@ -113,6 +118,7 @@ exports[`PeriodSlider empty PeriodSlider empty PeriodSlider specific title snaps
     <button
       aria-label="Следующий период"
       class="component text size-48 hug size-48 component text component text cc-icon-button arrow primary component"
+      data-test-id="period-slider-btn-next-day"
       disabled=""
       type="button"
     >

--- a/packages/calendar/src/desktop/Component.desktop.tsx
+++ b/packages/calendar/src/desktop/Component.desktop.tsx
@@ -4,7 +4,7 @@ import endOfDay from 'date-fns/endOfDay';
 import startOfDay from 'date-fns/startOfDay';
 import startOfMonth from 'date-fns/startOfMonth';
 
-import { hooks } from '@alfalab/core-components-shared';
+import { getDataTestId, hooks } from '@alfalab/core-components-shared';
 import { useDidUpdateEffect, useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
 import { DaysTable } from '../components/days-table';
@@ -348,6 +348,7 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
                                 onPrevArrowClick={handlePrevArrowClick}
                                 onNextArrowClick={handleNextArrowClick}
                                 onPeriodClick={onPeriodClick}
+                                dataTestId={getDataTestId(dataTestId, 'slider')}
                             />
                         ) : (
                             <MonthYearHeader

--- a/packages/calendar/src/docs/development.mdx
+++ b/packages/calendar/src/docs/development.mdx
@@ -18,8 +18,8 @@ import { CalendarMobile, CalendarMonthOnlyView, CalendarMonthOnlyViewHeader } fr
 
 ## Использование dataTestId
 
-В компоненте используются модификаторы для `dataTestId`.  
-Для удобного поиска элементов можно воспользоваться функцией `getCalendarMobileTestIds`.  
+В компоненте используются модификаторы для `dataTestId`.
+Для удобного поиска элементов можно воспользоваться функцией `getCalendarMobileTestIds`.
 Импорт из `@alfalab/core-components/calendar/shared`.
 
 Функция возвращает объект:
@@ -34,6 +34,8 @@ import { CalendarMobile, CalendarMonthOnlyView, CalendarMonthOnlyViewHeader } fr
     closer: `${dataTestId}-header-closer`,
     btnApply: `${dataTestId}-btn-apply`,
     btnReset: `${dataTestId}-btn-reset`,
+    btnNextDate: `${dataTestId}-slider-btn-next-day`,
+    btnPreviousDate: `${dataTestId}-slider-btn-previous-day`,
 };
 ```
 

--- a/packages/calendar/src/utils.ts
+++ b/packages/calendar/src/utils.ts
@@ -297,5 +297,7 @@ export function getCalendarMobileTestIds(dataTestId: string) {
         closer: getDataTestId(dataTestId, 'header-closer'),
         btnApply: getDataTestId(dataTestId, 'btn-apply'),
         btnReset: getDataTestId(dataTestId, 'btn-reset'),
+        btnNextDate: getDataTestId(dataTestId, 'slider-btn-next-day'),
+        btnPreviousDate: getDataTestId(dataTestId, 'slider-btn-previous-day'),
     };
 }


### PR DESCRIPTION
# Опишите проблему
Добавляю data-test-id к period-slider, чтобы проще подвязываться к стрелкам назад / вперед в автотестах
