### PR TITLE
feat(dropzone): Изменен тип аргумента в onDrop на File[]

### DIFF
--- a/.changeset/rude-beers-talk.md
+++ b/.changeset/rude-beers-talk.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-dropzone': major
+---
+
+Изменен тип параметра на Files[] в обработчике onDrop

--- a/packages/dropzone/src/Component.test.tsx
+++ b/packages/dropzone/src/Component.test.tsx
@@ -13,6 +13,7 @@ describe('Dropzone', () => {
     const dataTransfer = {
         files: {
             item: (itemIndex: number) => filesList[itemIndex],
+            ...filesList,
             length: filesList.length,
         },
         items: filesList,
@@ -140,7 +141,7 @@ describe('Dropzone', () => {
 
             fireDragEventWithFiles(dropzone, 'drop');
 
-            expect(handleDrop.mock.calls[0][0]).toEqual(dataTransfer.files);
+            expect(handleDrop.mock.calls[0][0]).toEqual(Array.from(dataTransfer.files));
         });
 
         it('should not call drag callbacks when disabled', () => {

--- a/packages/dropzone/src/Component.tsx
+++ b/packages/dropzone/src/Component.tsx
@@ -51,7 +51,7 @@ export type DropzoneProps = {
     /**
      * Обработчик события 'drop'
      */
-    onDrop?: (files: FileList) => void;
+    onDrop?: (files: File[]) => void;
 
     /**
      * Обработчик события 'dragover'
@@ -165,7 +165,7 @@ export const Dropzone: FC<DropzoneProps> = ({
 
             if (event.dataTransfer.files && event.dataTransfer.files.length > 0) {
                 if (onDrop) {
-                    onDrop(event.dataTransfer.files);
+                    onDrop(Array.from(event.dataTransfer.files));
                 }
 
                 event.dataTransfer.clearData();


### PR DESCRIPTION
:wave:

BREAKING CHANGE: Изменен тип принимаемого аругумента в обработчике onDrop c FileList на File[]

# Опишите проблему
Имеем такую конструкцию 
![image](https://github.com/core-ds/core-components/assets/62112300/21374c40-76e9-4119-9844-a322c74b6269)
Dropzone + Attach
Attach возвращает файлы типа File[], Dropzone -> FileList

Для консистентности перевел тип Dropzone в File[]
Наврядли кто-то использовал методы FileList-а `item` например, но все-же это мажорка