### PR TITLE
fix(bottom-sheet): fix safe area

### DIFF
--- a/.changeset/neat-bikes-rush.md
+++ b/.changeset/neat-bikes-rush.md
@@ -1,0 +1,8 @@
+---
+"@alfalab/core-components-bottom-sheet": patch
+"@alfalab/core-components-input-autocomplete": patch
+"@alfalab/core-components-input": patch
+"@alfalab/core-components-picker-button": patch
+---
+
+Исправлен отступ кнопок в компоненте `bottom-sheet` для iOS систем

--- a/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
+++ b/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
           >
             <div
               class="wrapper"
-              style="max-height: 744px;"
             >
               <div
                 class="component"
@@ -128,7 +127,6 @@ exports[`Bottom sheet Snapshots tests should match snapshot with action button 1
           >
             <div
               class="wrapper"
-              style="max-height: 744px;"
             >
               <div
                 class="component"

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -14,7 +14,7 @@ import { HandledEvents } from 'react-swipeable/es/types';
 import cn from 'classnames';
 
 import { BaseModal } from '@alfalab/core-components-base-modal';
-import { fnUtils, getDataTestId } from '@alfalab/core-components-shared';
+import { fnUtils, getDataTestId, os } from '@alfalab/core-components-shared';
 
 import { Footer } from './components/footer/Component';
 import { Header, HeaderProps } from './components/header/Component';
@@ -114,7 +114,10 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                 );
             }
 
-            return [0, fullHeight - headerOffset];
+            const iOSViewHeight = document?.documentElement?.clientHeight || window.innerHeight;
+            const viewHeight = os.isIOS() ? iOSViewHeight : fullHeight;
+
+            return [0, viewHeight - headerOffset];
         }, [fullHeight, headerOffset, magneticAreasProp]);
 
         const lastMagneticArea = magneticAreas[magneticAreas.length - 1];
@@ -562,7 +565,6 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                 keepMounted={keepMounted}
             >
                 <div
-                    style={{ ...getHeightStyles() }}
                     className={cn(styles.wrapper, {
                         [styles.fullscreen]: headerOffset === 0 && sheetOffset === 0,
                     })}
@@ -571,6 +573,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                     <div
                         className={cn(styles.component, bgClassName, className, {
                             [styles.withTransition]: swipingInProgress === false,
+                            [styles.safeAreaBottom]: os.isIOS(),
                         })}
                         style={{
                             ...getSwipeStyles(),

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -140,4 +140,8 @@
     }
 }
 
+.safeAreaBottom {
+    padding-bottom: env(safe-area-inset-bottom);
+}
+
 @mixin bg-class-list;

--- a/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
@@ -115,7 +115,6 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
           >
             <div
               class="wrapper"
-              style="max-height: 744px; height: 744px;"
             >
               <div
                 class="component sheet"

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -247,7 +247,6 @@ exports[`Snapshots tests should display opened correctly 2`] = `
         >
           <div
             class="wrapper"
-            style="max-height: 744px;"
           >
             <div
               class="component sheet"
@@ -1366,7 +1365,6 @@ exports[`Snapshots tests should display opened correctly 4`] = `
         >
           <div
             class="wrapper"
-            style="max-height: 744px;"
           >
             <div
               class="component sheet"
@@ -2485,7 +2483,6 @@ exports[`Snapshots tests should display opened correctly 6`] = `
         >
           <div
             class="wrapper"
-            style="max-height: 744px;"
           >
             <div
               class="component sheet"


### PR DESCRIPTION
# Опишите проблему
В компоненте bottom-sheet существует проблема, связанная с address bar. При открытии компонента, кнопки пересекаются с системной областью телефона (home полоска).
![safe-area](https://github.com/core-ds/core-components/assets/45999900/5d4f71c8-b224-4f36-8d56-779189708a3e)

Это может приводить к подобному поведению (обратите внимание что address bar располагается сверху)

https://github.com/core-ds/core-components/assets/45999900/c05198ef-f251-4566-bc0b-54d1af56dda4

# Дополнительная информация
- Внес исправление, которое добавляет отступ снизу с помощью системной переменной `env()` (для iOS);
- Поправил расчет высоты компонента (для iOS);
- Избавился от дублирования стилей в обертке компонента.