### PR TITLE
zIndex для popover в комопненте input-autocomplete

### DIFF
--- a/packages/input-autocomplete/src/docs/Component.stories.tsx
+++ b/packages/input-autocomplete/src/docs/Component.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { text, select, boolean } from '@storybook/addon-knobs';
+import { text, select, boolean, number } from '@storybook/addon-knobs';
 
 import { Arrow, OptionShape } from '@alfalab/core-components-select/shared';
 import {
@@ -63,6 +63,7 @@ const renderComponent = (Component: any, props?: Partial<InputAutocompleteProps>
             error={text('error', '')}
             success={boolean('success', false)}
             hint={text('hint', '')}
+            zIndexPopover={number('zIndexPopover', 100)}
             allowUnselect={boolean('allowUnselect', true)}
             closeOnSelect={boolean('closeOnSelect', false)}
             Arrow={boolean('Arrow', false) ? Arrow : undefined}

--- a/packages/input-autocomplete/src/types.ts
+++ b/packages/input-autocomplete/src/types.ts
@@ -48,6 +48,11 @@ export interface InputAutocompleteCommonProps
      * Обработчик ввода
      */
     onInput?: (value: string, reason?: OnInputTypeReason) => void;
+
+    /**
+     * z-index поповера
+     */
+    zIndexPopover?: number;
 }
 
 type MobileProps = {


### PR DESCRIPTION
при использовании input-autocomplete в сайдбаре, сайдбар перекрывает своим z-index'ом z-index поповера, нужен пропс для того чтобы контролировать z-index поповера
