### PR TITLE
Fix/tabs dependency

### DIFF
--- a/.changeset/new-doors-peel.md
+++ b/.changeset/new-doors-peel.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tabs': patch
+---
+
+Поправлен импорт компонента skeleton

--- a/packages/tabs/src/components/secondary-tablist/Component.tsx
+++ b/packages/tabs/src/components/secondary-tablist/Component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cn from 'classnames';
 
-import { Skeleton } from '@alfalab/core-components/skeleton';
+import { Skeleton } from '@alfalab/core-components-skeleton';
 
 import { useTabs } from '../../hooks/use-tabs';
 import { PlatformProps, SecondaryTabListProps, Styles } from '../../typings';

--- a/packages/tabs/src/components/title/Component.tsx
+++ b/packages/tabs/src/components/title/Component.tsx
@@ -1,7 +1,7 @@
 import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import cn from 'classnames';
 
-import { Skeleton, SkeletonProps } from '@alfalab/core-components/skeleton';
+import { Skeleton, SkeletonProps } from '@alfalab/core-components-skeleton';
 
 import { Styles, TabListTitle } from '../../typings';
 

--- a/packages/tabs/src/typings.ts
+++ b/packages/tabs/src/typings.ts
@@ -1,6 +1,6 @@
 import { FC, MouseEvent, ReactElement, ReactNode, Ref } from 'react';
 
-import { SkeletonProps } from '@alfalab/core-components/skeleton';
+import { SkeletonProps } from '@alfalab/core-components-skeleton';
 import { TagProps } from '@alfalab/core-components-tag';
 
 export type SelectedId = string | number;


### PR DESCRIPTION
# Опишите проблему
@alfalab/core-components-tabs использует скелетон из @alfalab/core-components, вместо @alfalab/core-components-skeleton напрямую

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10
