### PR TITLE
fix: add stylelint ignore file;

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+


### PR DESCRIPTION
# Опишите проблему
При запуске `yarn lint:css` линтер ходит в `dist`

# Шаги для воспроизведения
При запуске `yarn lint:css` линтер не ходит в `dist`

# Ожидаемое поведение
При запуске `yarn lint:css` не показывает ошибки из dist

