### PR TITLE
fix(masked-input): export type

### DIFF
--- a/.changeset/lazy-pots-glow.md
+++ b/.changeset/lazy-pots-glow.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-masked-input': patch
+---
+
+Экспорт типа TextMaskConfig для фикса ошибки ts

--- a/packages/masked-input/src/Component.tsx
+++ b/packages/masked-input/src/Component.tsx
@@ -9,7 +9,7 @@ import styles from './index.module.css';
 
 // TODO: заставить rollup добавлять кастомные декларации в сборку
 type Mask = Array<string | RegExp>;
-type TextMaskConfig = {
+export type TextMaskConfig = {
     currentCaretPosition: number;
     rawValue: string;
     previousConformedValue: string;


### PR DESCRIPTION
# Опишите проблему
При при обновлении пакетов появилась ошибка ts 
<img width="785" alt="image" src="https://github.com/user-attachments/assets/6164598a-72bd-4516-a021-d0429864710c">
