### PR TITLE
fix(phone-input): clearing country code in clearableCountryCode mode

### DIFF
--- a/.changeset/healthy-rockets-kiss.md
+++ b/.changeset/healthy-rockets-kiss.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-phone-input': minor
+---
+
+Исправлено удаление номера в режиме clearableCountryCode

--- a/packages/phone-input/src/Component.test.tsx
+++ b/packages/phone-input/src/Component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { PhoneInput } from './index';
@@ -34,6 +34,36 @@ describe('PhoneInput', () => {
             await userEvent.type(inputElement, '{backspace}');
             expect(inputElement.value).toBe('+7 ');
         });
+
+        it('with clearableCountryCode === true', async () => {
+            const { getByTestId } = render(
+                <PhoneInput dataTestId={dataTestId} clearableCountryCode={true} />,
+            );
+            const inputElement = getByTestId(dataTestId) as HTMLInputElement;
+
+            await userEvent.type(inputElement, '2');
+
+            expect(inputElement.value).toBe('+7 2');
+
+            await userEvent.type(inputElement, '{backspace>10}');
+
+            expect(inputElement.value).toBe('');
+        });
+
+        it('with clearableCountryCode === false', async () => {
+            const { getByTestId } = render(
+                <PhoneInput dataTestId={dataTestId} clearableCountryCode={false} />,
+            );
+            const inputElement = getByTestId(dataTestId) as HTMLInputElement;
+
+            await userEvent.type(inputElement, '2');
+
+            expect(inputElement.value).toBe('+7 2');
+
+            await userEvent.type(inputElement, '{backspace>10}');
+
+            expect(inputElement.value).toBe('+7 ');
+        });
         /*
          * TODO: хотелось бы добавить тестов на проверку удаления цифр в номере,
          * но не нашел способа двигать каретку
@@ -41,7 +71,7 @@ describe('PhoneInput', () => {
     });
 
     describe('should update input by value prop', () => {
-        it('with clearableCountryCode === true', () => {
+        it('with clearableCountryCode === true', async () => {
             const { getByTestId, rerender } = render(
                 <PhoneInput dataTestId={dataTestId} clearableCountryCode={true} />,
             );
@@ -54,8 +84,8 @@ describe('PhoneInput', () => {
             expect(inputElement.value).toBe('+7 99');
         });
 
-        it('with clearableCountryCode === false', () => {
-            const { getByTestId, rerender } = render(
+        it('with clearableCountryCode === false', async () => {
+            const { getByTestId, rerender, debug } = render(
                 <PhoneInput dataTestId={dataTestId} clearableCountryCode={false} />,
             );
             const inputElement = getByTestId(dataTestId) as HTMLInputElement;

--- a/packages/phone-input/src/Component.test.tsx
+++ b/packages/phone-input/src/Component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { PhoneInput } from './index';
@@ -71,7 +71,7 @@ describe('PhoneInput', () => {
     });
 
     describe('should update input by value prop', () => {
-        it('with clearableCountryCode === true', async () => {
+        it('with clearableCountryCode === true', () => {
             const { getByTestId, rerender } = render(
                 <PhoneInput dataTestId={dataTestId} clearableCountryCode={true} />,
             );
@@ -84,8 +84,8 @@ describe('PhoneInput', () => {
             expect(inputElement.value).toBe('+7 99');
         });
 
-        it('with clearableCountryCode === false', async () => {
-            const { getByTestId, rerender, debug } = render(
+        it('with clearableCountryCode === false', () => {
+            const { getByTestId, rerender } = render(
                 <PhoneInput dataTestId={dataTestId} clearableCountryCode={false} />,
             );
             const inputElement = getByTestId(dataTestId) as HTMLInputElement;

--- a/packages/phone-input/src/Component.tsx
+++ b/packages/phone-input/src/Component.tsx
@@ -76,6 +76,11 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                     setCaretPosition({ position: currentCaretPosition, inputRef });
                 }
 
+                // в режиме clearableCountryCode удаляет лишний пробел, чтобы можно было стереть код города.
+                if (rawValue === '+7' && conformedValue === '' && clearableCountryCode) {
+                    setCaretPosition({ position: countryPrefix.length - 1, inputRef });
+                }
+
                 // Удаление цифры перед кодом страны удаляет только саму цифру, код остается ("+7 1" -> "+7 ")
                 if (rawValue === countryPrefix) {
                     return rawValue;
@@ -141,6 +146,7 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                 defaultValue={clearableCountryCode ? restProps.defaultValue : countryPrefix}
                 mask={mask}
                 onBeforeDisplay={handleBeforeDisplay}
+                keepCharPositions={true}
                 type='tel'
                 ref={mergeRefs([ref, inputRef])}
             />

--- a/packages/phone-input/src/Component.tsx
+++ b/packages/phone-input/src/Component.tsx
@@ -76,7 +76,7 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                     setCaretPosition({ position: currentCaretPosition, inputRef });
                 }
 
-                // в режиме clearableCountryCode удаляет лишний пробел, чтобы можно было стереть код города.
+                // // В режиме clearableCountryCode удаляет лишний пробел, чтобы можно было стереть код города.
                 if (rawValue === '+7' && conformedValue === '' && clearableCountryCode) {
                     setCaretPosition({ position: countryPrefix.length - 1, inputRef });
                 }
@@ -98,7 +98,7 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                  * Это происходит потому что цифра 7 есть уже в маске
                  */
                 if (rawValue[1] === '7') {
-                    const masked = conformToMask(`+7${rawValue}`, mask, config);
+                    const masked = conformToMask(`+7 ${rawValue}`, mask, config);
 
                     return masked.conformedValue;
                 }

--- a/packages/phone-input/src/Component.tsx
+++ b/packages/phone-input/src/Component.tsx
@@ -98,7 +98,7 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                  * Это происходит потому что цифра 7 есть уже в маске
                  */
                 if (rawValue[1] === '7') {
-                    const masked = conformToMask(`+7 ${rawValue}`, mask, config);
+                    const masked = conformToMask(`+7${rawValue}`, mask, config);
 
                     return masked.conformedValue;
                 }
@@ -146,7 +146,6 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
                 defaultValue={clearableCountryCode ? restProps.defaultValue : countryPrefix}
                 mask={mask}
                 onBeforeDisplay={handleBeforeDisplay}
-                keepCharPositions={true}
                 type='tel'
                 ref={mergeRefs([ref, inputRef])}
             />


### PR DESCRIPTION
# Опишите проблему
при удалении символов в инпуте в режиме clearableCountryCode каретка перескакивает код города не удаляя его

# Шаги для воспроизведения
заполнить phone-input и посимвольно удалить номер

# Ожидаемое поведение
после удаления номера, также должен удалиться код страны

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** <img width="406" alt="image" src="https://github.com/user-attachments/assets/009e4e42-6e93-4365-8767-998aa6872ebc">  ** | ** <img width="435" alt="image" src="https://github.com/user-attachments/assets/e5675cb9-11c9-4c00-8ba1-95a6b7ef4e6e">    **|


