### PR TITLE
feat(modal): change type for title from string to ReactNode

### DIFF
--- a/.changeset/rich-guests-peel.md
+++ b/.changeset/rich-guests-peel.md
@@ -2,4 +2,4 @@
 '@alfalab/core-components-navigation-bar-private': patch
 ---
 
-changed type of navigation-bar-private for title from string to ReactNode
+Изменен тип у компонента navigation-bar-private для пропса title со string на ReactNode

--- a/.changeset/rich-guests-peel.md
+++ b/.changeset/rich-guests-peel.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-navigation-bar-private': patch
+---
+
+changed type of navigation-bar-private for title from string to ReactNode

--- a/packages/navigation-bar-private/src/types.ts
+++ b/packages/navigation-bar-private/src/types.ts
@@ -12,7 +12,7 @@ export type NavigationBarPrivateProps = {
     /**
      * Заголовок шапки
      */
-    title?: string;
+    title?: ReactNode;
 
     /**
      * Подзаголовок (доступен только в мобильной версии)


### PR DESCRIPTION
# Опишите проблему
В заголовок модалки нужно добавить react элемент
Сейчас TS ругается что title должен быть строкой

# Шаги для воспроизведения
```
<Modal.Header
    title={ (
        <TitleView
            tag="div"
            view={ VIEWS.LARGE }
            subtitle="Подзаголовок"
        >
            Операции по{ NBSP }счёту
        </TitleView>
    ) }
    hasCloser={ true }
/>
`

# Ожидаемое поведение
При добавлении React элемента в пропс title, TS не выдается ошибку

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):

## Смартфон (если данных нет оставте блок пустым):

# Дополнительная информация