### PR TITLE
feat(space): add current key for Item

### DIFF
--- a/.changeset/neat-sloths-yawn.md
+++ b/.changeset/neat-sloths-yawn.md
@@ -1,0 +1,17 @@
+---
+'@alfalab/core-components-checkbox': patch
+'@alfalab/core-components-custom-picker-button': patch
+'@alfalab/core-components-gallery': patch
+'@alfalab/core-components-icon-view': patch
+'@alfalab/core-components-input-autocomplete': patch
+'@alfalab/core-components-international-phone-input': patch
+'@alfalab/core-components-intl-phone-input': patch
+'@alfalab/core-components-picker-button': patch
+'@alfalab/core-components-select': patch
+'@alfalab/core-components-select-with-tags': patch
+'@alfalab/core-components-space': patch
+'@alfalab/core-components-table': patch
+'@alfalab/core-components-tabs': patch
+---
+
+Для дочернего компонента-оберки Space -> Item прокидываем key который передали или сгенерировал react

--- a/packages/space/src/Component.tsx
+++ b/packages/space/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { Children, forwardRef, ReactElement, ReactNode } from 'react';
+import React, { Children, forwardRef, isValidElement, ReactNode } from 'react';
 import cn from 'classnames';
 
 import Item from './Item';
@@ -121,7 +121,7 @@ export const Space = forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
         <Item
             className={itemClassName}
             dividerClassName={styles.divider}
-            key={(child as ReactElement).key}
+            key={isValidElement(child) ? child.key : `${itemClassName}-${i}`}
             direction={direction}
             horizontalSize={horizontalSize}
             verticalSize={verticalSize}

--- a/packages/space/src/Component.tsx
+++ b/packages/space/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { Children, forwardRef, ReactNode } from 'react';
+import React, { Children, forwardRef, ReactElement, ReactNode } from 'react';
 import cn from 'classnames';
 
 import Item from './Item';
@@ -121,7 +121,7 @@ export const Space = forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
         <Item
             className={itemClassName}
             dividerClassName={styles.divider}
-            key={`${itemClassName}-${i}`}
+            key={(child as ReactElement).key}
             direction={direction}
             horizontalSize={horizontalSize}
             verticalSize={verticalSize}


### PR DESCRIPTION
# Опишите проблему
При использовании компонента Space, если удалить дочерний элемент, то все остальные элементы размонитруются и смонтируются заново, при условии что key никак не меняется при этом

# Шаги для воспроизведения
Добавить в Space несколько элементов и после удалить первый
```
<Space>
  {rows.map(({text, id}) => (
      <Component key={id}>
        {text}
      </Component>        
  ))}
</Space>
<button>
 Удалить первую строку
</button>
```

Пример можно посмотреть тут
https://codesandbox.io/s/infallible-water-27jjg5?file=/src/index.js

# Ожидаемое поведение
Удалится первый элемент, остальные никак не среагируют на это

# Чек лист
- [ ] Тесты
- [ ] Документация

