### PR TITLE
feat(confirmation): extend 'texts' prop with phone numbers

### DIFF
--- a/.changeset/purple-pets-whisper.md
+++ b/.changeset/purple-pets-whisper.md
@@ -1,0 +1,7 @@
+---
+'@alfalab/core-components-confirmation': minor
+---
+
+Расширен пропс `texts` компонента `Confirmation`:
+- `domesticPhone` — номер телефона для звонков по России (по умолчанию 8 800 200 00 00)
+- `internationalPhone` — номер телефона для звонков из-за границы (по умолчанию +7 495 78 888 78).

--- a/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
@@ -539,7 +539,7 @@ exports[`Confirmation Snapshot tests should match snapshot with HINT screen 2`] 
         >
           <a
             class="component primary withoutUnderline phoneLink"
-            href="tel:+78002000000"
+            href="tel:88002000000"
           >
             <span
               class="text"

--- a/packages/confirmation/src/components/screens/hint/component.tsx
+++ b/packages/confirmation/src/components/screens/hint/component.tsx
@@ -6,6 +6,7 @@ import { Link } from '@alfalab/core-components-link';
 import { Typography } from '@alfalab/core-components-typography';
 
 import { ConfirmationContext } from '../../../context';
+import { getPhoneHref } from '../../../utils';
 import { Header } from '../../header';
 
 import styles from './index.module.css';
@@ -20,6 +21,8 @@ export type HintProps = {
 export const Hint: FC<HintProps> = ({ mobile }) => {
     const { alignContent, texts, onChangeScreen, onChangeState, breakpoint } =
         useContext(ConfirmationContext);
+
+    const { domesticPhone = '', internationalPhone = '', hintButton } = texts;
 
     const handleReturnButtonClick = () => {
         onChangeScreen('INITIAL');
@@ -49,11 +52,11 @@ export const Hint: FC<HintProps> = ({ mobile }) => {
             >
                 <div className={cn(styles.phoneWrap, { [styles.phoneContentMobile]: mobile })}>
                     <Link
-                        href='tel:+78002000000'
+                        href={getPhoneHref(domesticPhone)}
                         underline={false}
                         className={cn(styles.phoneLink, { [styles.typographyThemeMobile]: mobile })}
                     >
-                        8 800 200 00 00
+                        {domesticPhone}
                     </Link>
                     <Typography.Text
                         view='primary-medium'
@@ -71,11 +74,11 @@ export const Hint: FC<HintProps> = ({ mobile }) => {
 
                 <div className={cn(styles.phoneWrap, { [styles.phoneContentMobile]: mobile })}>
                     <Link
-                        href='tel:+74957888878'
+                        href={getPhoneHref(internationalPhone)}
                         underline={false}
                         className={cn(styles.phoneLink, { [styles.typographyThemeMobile]: mobile })}
                     >
-                        +7 495 78 888 78
+                        {internationalPhone}
                     </Link>
                     <Typography.Text
                         view='primary-medium'
@@ -111,7 +114,7 @@ export const Hint: FC<HintProps> = ({ mobile }) => {
                 className={styles.hintButton}
                 breakpoint={breakpoint}
             >
-                {texts.hintButton}
+                {hintButton}
             </Button>
         </div>
     );

--- a/packages/confirmation/src/types.ts
+++ b/packages/confirmation/src/types.ts
@@ -97,12 +97,12 @@ export type ConfirmationProps = {
     onTempBlockFinished?: () => void;
 
     /**
-     * Возввращает объект, где ключ - название экрана (screen), значение - компонент для экрана
+     * Возвращает объект, где ключ - название экрана (screen), значение - компонент для экрана
      */
-    getScreensMap?: (defaulScreensMap: ScreensMap) => ScreensMap;
+    getScreensMap?: (defaultScreensMap: ScreensMap) => ScreensMap;
 
     /**
-     * Дочерние элементы.
+     * Дочерние элементы
      */
     children?: ReactNode;
 
@@ -184,7 +184,8 @@ export type ConfirmationTexts = {
      * Экран HINT
      */
     hintButton?: string; // кнопка 'Вернуться'
-
+    domesticPhone?: string; // номер телефона для звонков по России
+    internationalPhone?: string; // номер телефона для звонков из-за границы
     /**
      * Экран FATAL_ERROR
      */
@@ -215,7 +216,7 @@ export type ScreensMap = {
     [key: string]: ComponentType;
 };
 
-export const defaultTexts = {
+export const defaultTexts: ConfirmationTexts = {
     title: 'Введите код из\xa0сообщения',
     codeError: 'Код введён неверно',
     codeChecking: '',
@@ -232,4 +233,6 @@ export const defaultTexts = {
     tempBlockDescription: 'Повторное подтверждение кодом будет возможно через 24\xa0часа',
     codeSended: 'Код выслан',
     countdown: 'Запросить повторно можно через',
+    domesticPhone: '8 800 200 00 00',
+    internationalPhone: '+7 495 78 888 78',
 };

--- a/packages/confirmation/src/utils.ts
+++ b/packages/confirmation/src/utils.ts
@@ -105,3 +105,12 @@ export const useConfirmation = ({ state, screen, blockSmsRetry }: UseConfirmatio
         setConfirmationBlockSmsRetry,
     };
 };
+
+const NON_NUMBER_OR_PLUS_REGEXP = new RegExp(/[^\d+]/g);
+
+/**
+ * @returns ссылку для набора номера
+ */
+export function getPhoneHref(phone: string): string {
+    return `tel:${phone.replace(NON_NUMBER_OR_PLUS_REGEXP, '')}`;
+}


### PR DESCRIPTION
Расширен пропс `texts` компонента `Confirmation`. Добавлены 2 текстовки:
- `domesticPhone` — номер телефона для звонков по России (по дефолту 8 800 200 00 00)
- `internationalPhone` — номер телефона для звонков из-за границы (по дефолту +7 495 78 888 78).