### PR TITLE
Fix/ampay 6720

### DIFF
--- a/.changeset/famous-zebras-peel.md
+++ b/.changeset/famous-zebras-peel.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-international-phone-input': minor
+---
+
+добавил телефонные коды для Абхазии

--- a/.changeset/famous-zebras-peel.md
+++ b/.changeset/famous-zebras-peel.md
@@ -2,4 +2,4 @@
 '@alfalab/core-components-international-phone-input': minor
 ---
 
-добавил телефонные коды для Абхазии
+Добавлены телефонные коды для Абхазии

--- a/packages/international-phone-input/src/__image_snapshots__/international-phone-input-desktop-interactions-flag-select-snap.png
+++ b/packages/international-phone-input/src/__image_snapshots__/international-phone-input-desktop-interactions-flag-select-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db7695e83e5d746c7bfe61ef11f46bff0ba9b03600770f5b744c8090299fbaa3
-size 20537
+oid sha256:f7c0bc0455f59a495c1751c1c49f574c17027d4cd6d3504f4a6fff4dd96f22c8
+size 19834

--- a/packages/international-phone-input/src/__image_snapshots__/international-phone-input-mobile-interactions-flag-select-snap.png
+++ b/packages/international-phone-input/src/__image_snapshots__/international-phone-input-mobile-interactions-flag-select-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2decf51d3ca0f8eb506c882d4eb3ee4343e2f6ba1d6c4234188872c1c9b32c80
-size 40112
+oid sha256:a145fc694f99a7a8b5486c373d3c7cd6dd28971de2b66fbf240443d875d682e0
+size 39400

--- a/packages/international-phone-input/src/data/country-data.ts
+++ b/packages/international-phone-input/src/data/country-data.ts
@@ -21,6 +21,7 @@
 export type CountriesData = [string, string[], string, string, string?, number?, string[]?];
 
 export const countriesData: CountriesData[] = [
+    ['Абхазия', ['europe'], 'ge-ab', '7', '... ... .. ..', 1, ['840', '940']],
     ['Афганистан', ['asia'], 'af', '93'],
     ['Албания', ['europe'], 'al', '355'],
     ['Алжир', ['africa', 'north-africa'], 'dz', '213'],


### PR DESCRIPTION
# Опишите проблему
Не отображается флаг для кодов номеров Абхазии

# Шаги для воспроизведения
1. ввести код `+7840` или `+7940`

# Ожидаемое поведение
Отображается флаг Абхазии

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд
