### PR TITLE
fix(navigation-bar): fix title alignment

### DIFF
--- a/.changeset/silly-gorillas-attack.md
+++ b/.changeset/silly-gorillas-attack.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-navigation-bar': patch
+---
+``
+Исправлено выравнивание `title` при отсутствии аддона слева

--- a/packages/navigation-bar/src/Component.tsx
+++ b/packages/navigation-bar/src/Component.tsx
@@ -121,25 +121,23 @@ export const NavigationBar = forwardRef<HTMLDivElement, NavigationBarProps>(
         const rightAddonsRef = useRef<HTMLDivElement>(null);
         const hasLeftAddons = leftAddons && align !== 'left';
 
+        // добавляет отступ для того чтобы title находился по центру не зависимо от ширины аддонов
         useEffect(() => {
-            if (hasLeftAddons) {
-                const leftAddonsWidth = leftAddonsRef.current?.offsetWidth || 0;
-                const rightAddonsWidth = rightAddonsRef.current?.offsetWidth || 0;
+            const leftAddonsWidth = leftAddonsRef.current?.offsetWidth || 0;
+            const rightAddonsWidth = rightAddonsRef.current?.offsetWidth || 0;
 
-                const marginSize = Math.abs(rightAddonsWidth - leftAddonsWidth);
-                const shouldAddLeftMargin = rightAddonsWidth - leftAddonsWidth > 0;
+            const marginSize = Math.abs(rightAddonsWidth - leftAddonsWidth);
+            const shouldAddLeftMargin = rightAddonsWidth - leftAddonsWidth > 0;
 
-                setTitleMargin((prev) => {
-                    const newState = shouldAddLeftMargin
-                        ? { left: marginSize, right: 0 }
-                        : { left: 0, right: marginSize };
+            setTitleMargin((prev) => {
+                const newState = shouldAddLeftMargin
+                    ? { left: marginSize, right: 0 }
+                    : { left: 0, right: marginSize };
 
-                    const isStateChanged =
-                        prev.left !== newState.left || prev.right !== newState.right;
+                const isStateChanged = prev.left !== newState.left || prev.right !== newState.right;
 
-                    return isStateChanged ? newState : prev;
-                });
-            }
+                return isStateChanged ? newState : prev;
+            });
         }, [hasLeftAddons, leftAddons, rightAddons]);
 
         return (


### PR DESCRIPTION
Ранее title рассчитывал выравнивание при условии что присутствует addon слева. Это приводило к тому, что title смещался относительно центра, при отсутствии левого аддона.
<img width="448" alt="image" src="https://github.com/user-attachments/assets/10a1267b-25bd-4320-a335-fe85d2eaec62">

https://jira.moscow.alfaintra.net/browse/DS-7772