### PR TITLE
feat(*): added support safe area for side-panel

### DIFF
--- a/packages/side-panel/src/mobile/mobile.module.css
+++ b/packages/side-panel/src/mobile/mobile.module.css
@@ -19,6 +19,6 @@
     flex-direction: column;
     width: 100%;
     flex: 1;
-    padding-top: env(--safe-area-inset-bottom, 0);
-    padding-bottom: env(--safe-area-inset-bottom, 0);
+    padding-top: env(safe-area-inset-bottom, 0);
+    padding-bottom: env(safe-area-inset-bottom, 0);
 }

--- a/packages/side-panel/src/mobile/mobile.module.css
+++ b/packages/side-panel/src/mobile/mobile.module.css
@@ -19,4 +19,6 @@
     flex-direction: column;
     width: 100%;
     flex: 1;
+    padding-top: env(--safe-area-inset-bottom, 0);
+    padding-bottom: env(--safe-area-inset-bottom, 0);
 }


### PR DESCRIPTION
# Опишите проблему

side-panel не ограничевает контент при включеннной safe-area

# Шаги для воспроизведения
Использовать компонент side-panel в приложении с включенным safe-area

# Ожидаемое поведение
SidePanel учитывает safe-area

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** <img width="437" alt="Screenshot 2024-12-06 at 16 54 58" src="https://github.com/user-attachments/assets/5402108d-61b3-466f-a3be-f05456d4eb15">  ** | ** <img width="451" alt="Screenshot 2024-12-06 at 16 54 06" src="https://github.com/user-attachments/assets/d4cf6a08-6fe0-4d7b-84d0-0696a1f8e7e9">    **|


# Тестовый стенд

## Смартфон
 - Device: any which supports safe area
 - OS: iOS/ Android
 - Browser: Safari any which supports safe area

# Дополнительная информация
Дополнительная информация
