### PR TITLE
feat: pass-code: add desktop / mobile imports

### DIFF
--- a/.changeset/happy-moose-grab.md
+++ b/.changeset/happy-moose-grab.md
@@ -1,0 +1,7 @@
+---
+'@alfalab/core-components-pass-code': minor
+---
+
+   - Добавлены десктоп/мобайл импорты
+   - Мелкий рефакторинг css - вынесены общие стили в коммон
+   - Добавлено sideEffects: false

--- a/packages/pass-code/package.json
+++ b/packages/pass-code/package.json
@@ -10,6 +10,7 @@
         "access": "public",
         "directory": "dist"
     },
+    "sideEffects": false,
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.1 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.1 || ^18.0.0"

--- a/packages/pass-code/src/Component.responsive.tsx
+++ b/packages/pass-code/src/Component.responsive.tsx
@@ -2,8 +2,8 @@ import React, { forwardRef } from 'react';
 
 import { useIsDesktop } from '@alfalab/core-components-mq';
 
-import { PassCodeDesktop } from './desktop/PassCodeDesktop';
-import { PassCodeMobile } from './mobile/PassCodeMobile';
+import { PassCodeDesktop } from './desktop';
+import { PassCodeMobile } from './mobile';
 import { PassCodeProps } from './typings';
 
 export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(

--- a/packages/pass-code/src/desktop/desktop.module.css
+++ b/packages/pass-code/src/desktop/desktop.module.css
@@ -1,8 +1,2 @@
 @import '../../../vars/src/index.css';
 @import '../vars.css';
-
-.component {
-    box-sizing: border-box;
-    padding: var(--gap-8) var(--gap-16) var(--gap-16);
-    min-width: var(--pass-code-min-width);
-}

--- a/packages/pass-code/src/desktop/index.ts
+++ b/packages/pass-code/src/desktop/index.ts
@@ -1,0 +1,1 @@
+export * from './PassCodeDesktop';

--- a/packages/pass-code/src/docs/development.mdx
+++ b/packages/pass-code/src/docs/development.mdx
@@ -6,6 +6,11 @@ import vars from '!!raw-loader!../vars.css';
 ## Подключение
 
 ```jsx
+// Десктоп/мобайл
+import { PassCodeDesktop } from '@alfalab/core-components/pass-code/desktop';
+import { PassCodeMobile } from '@alfalab/core-components/pass-code/mobile';
+
+// Респонсив
 import { PassCode } from '@alfalab/core-components/pass-code';
 
 // Если добавляете аддон, то можно обернуть его в KeyPadButton. Так не понадобится подгонять стили под другие кнопки.
@@ -14,8 +19,8 @@ import { KeyPadButton } from '@alfalab/core-components/pass-code';
 
 ## Использование dataTestId
 
-В компоненте используются модификаторы для `dataTestId`.  
-Для удобного поиска элементов можно воспользоваться функцией `getPassCodeTestIds`.  
+В компоненте используются модификаторы для `dataTestId`.
+Для удобного поиска элементов можно воспользоваться функцией `getPassCodeTestIds`.
 Импорт из `@alfalab/core-components/pass-code/shared`.
 
 Функция возвращает объект:

--- a/packages/pass-code/src/index.module.css
+++ b/packages/pass-code/src/index.module.css
@@ -3,6 +3,9 @@
 
 .component {
     min-height: var(--pass-code-min-height);
+    box-sizing: border-box;
+    padding: var(--gap-8) var(--gap-16) var(--gap-16);
+    min-width: var(--pass-code-min-width);
 }
 
 .inputProgressContainer {

--- a/packages/pass-code/src/mobile/index.ts
+++ b/packages/pass-code/src/mobile/index.ts
@@ -1,0 +1,1 @@
+export * from './PassCodeMobile';

--- a/packages/pass-code/src/mobile/mobile.module.css
+++ b/packages/pass-code/src/mobile/mobile.module.css
@@ -2,11 +2,8 @@
 @import '../vars.css';
 
 .component {
-    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     justify-content: end;
     height: var(--pass-code-height);
-    padding: var(--gap-8) var(--gap-16) var(--gap-16);
-    min-width: var(--pass-code-min-width);
 }


### PR DESCRIPTION
# Опишите проблему
Доработки и оптимизации:
- Добавлены десктоп/мобайл импорты
- Мелкий рефакторинг css - вынесены общие стили в коммон
- Добавлено sideEffects: false

# Ожидаемое поведение
Без изменений

# Внешний вид
Без изменений

# Дополнительная информация
Респонсив: 23,1 kB
д/м версии: 20,8 kB
