### PR TITLE
feat: attach: split & add d/m imports

### DIFF
--- a/.changeset/popular-cars-study.md
+++ b/.changeset/popular-cars-study.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-attach': minor
+---
+
+-   Добавлены десктоп/мобайл импорты

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@alfalab/core-components-button": "^11.11.6",
         "@alfalab/core-components-keyboard-focusable": "^4.1.1",
+        "@alfalab/core-components-mq": "^4.4.0",
         "@alfalab/core-components-progress-bar": "^3.5.2",
         "@alfalab/icons-glyph": "^2.210.0",
         "@alfalab/utils": "^1.18.0",

--- a/packages/attach/src/Component.responsive.tsx
+++ b/packages/attach/src/Component.responsive.tsx
@@ -1,0 +1,51 @@
+import React, { forwardRef } from 'react';
+
+import { useIsDesktop } from '@alfalab/core-components-mq';
+
+import { type AttachProps } from './Component';
+import { AttachDesktop } from './desktop';
+import { AttachMobile } from './mobile';
+
+export type AttachResponsiveProps = AttachProps & {
+    /**
+     * Контрольная точка, с нее начинается desktop версия
+     * @default 1024
+     */
+    breakpoint?: number;
+
+    /**
+     * Версия, которая будет использоваться при серверном рендеринге
+     */
+    client?: 'desktop' | 'mobile';
+
+    /**
+     * Значение по-умолчанию для хука useMatchMedia
+     * @deprecated Используйте client
+     */
+    defaultMatchMediaValue?: boolean | (() => boolean);
+};
+
+export const AttachResponsive = forwardRef<HTMLInputElement, AttachResponsiveProps>(
+    (
+        {
+            children,
+            breakpoint,
+            client,
+            defaultMatchMediaValue = client === undefined ? undefined : client === 'desktop',
+            ...restProps
+        },
+        ref,
+    ) => {
+        const isDesktop = useIsDesktop(breakpoint, defaultMatchMediaValue);
+
+        const Component = isDesktop ? AttachDesktop : AttachMobile;
+
+        return (
+            <Component ref={ref} {...restProps}>
+                {children}
+            </Component>
+        );
+    },
+);
+
+AttachResponsive.displayName = 'AttachResponsive';

--- a/packages/attach/src/Component.tsx
+++ b/packages/attach/src/Component.tsx
@@ -10,7 +10,9 @@ import React, {
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
-import { Button, ButtonProps } from '@alfalab/core-components-button';
+import { type ButtonProps } from '@alfalab/core-components-button';
+import { type ButtonDesktop } from '@alfalab/core-components-button/desktop';
+import { type ButtonMobile } from '@alfalab/core-components-button/mobile';
 import { KeyboardFocusable } from '@alfalab/core-components-keyboard-focusable';
 import { ProgressBar } from '@alfalab/core-components-progress-bar';
 import { PaperclipMIcon } from '@alfalab/icons-glyph/PaperclipMIcon';
@@ -105,6 +107,13 @@ export type AttachProps = Omit<
     dataTestId?: string;
 };
 
+type AttachPrivateProps = {
+    /**
+     *  Компонент Button
+     */
+    Button: typeof ButtonDesktop | typeof ButtonMobile;
+}
+
 const MULTIPLE_TEXTS: [string, string, string] = ['файл', 'файла', 'файлов'];
 
 const SIZE_TO_CLASSNAME_MAP = {
@@ -120,7 +129,7 @@ const SIZE_TO_CLASSNAME_MAP = {
     64: 'size-64',
 };
 
-export const Attach = React.forwardRef<HTMLInputElement, AttachProps>(
+export const Attach = React.forwardRef<HTMLInputElement, AttachProps & AttachPrivateProps>(
     (
         {
             size = 48,
@@ -141,6 +150,7 @@ export const Attach = React.forwardRef<HTMLInputElement, AttachProps>(
             value,
             onChange,
             onClear,
+            Button,
             ...restProps
         },
         ref,

--- a/packages/attach/src/desktop/Component.desktop.tsx
+++ b/packages/attach/src/desktop/Component.desktop.tsx
@@ -1,0 +1,9 @@
+import React, { forwardRef } from 'react';
+
+import { ButtonMobile } from '@alfalab/core-components-button/mobile';
+
+import { type AttachProps, Attach } from '../Component';
+
+export const AttachDesktop = forwardRef<HTMLInputElement, AttachProps>(
+    (props: AttachProps, ref) => <Attach {...props} Button={ButtonMobile} ref={ref} />,
+);

--- a/packages/attach/src/desktop/index.ts
+++ b/packages/attach/src/desktop/index.ts
@@ -1,0 +1,1 @@
+export * from './Component.desktop';

--- a/packages/attach/src/docs/development.mdx
+++ b/packages/attach/src/docs/development.mdx
@@ -4,6 +4,13 @@ import { Attach } from '../index';
 ## Подключение
 
 ```jsx
+// Десктоп
+import { AttachDesktop } from '@alfalab/core-components/attach/desktop';
+
+// Мобайл
+import { AttachMobile } from '@alfalab/core-components/attach/mobile';
+
+// Респонсив
 import { Attach } from '@alfalab/core-components/attach';
 ```
 

--- a/packages/attach/src/index.ts
+++ b/packages/attach/src/index.ts
@@ -1,1 +1,4 @@
-export * from './Component';
+export {
+    AttachResponsive as Attach,
+    type AttachResponsiveProps as AttachProps,
+} from './Component.responsive';

--- a/packages/attach/src/mobile/Component.mobile.tsx
+++ b/packages/attach/src/mobile/Component.mobile.tsx
@@ -1,0 +1,9 @@
+import React, { forwardRef } from 'react';
+
+import { ButtonDesktop } from '@alfalab/core-components-button/desktop';
+
+import { type AttachProps, Attach } from '../Component';
+
+export const AttachMobile = forwardRef<HTMLInputElement, AttachProps>(
+    (props: AttachProps, ref) => <Attach {...props} Button={ButtonDesktop} ref={ref} />,
+);

--- a/packages/attach/src/mobile/index.ts
+++ b/packages/attach/src/mobile/index.ts
@@ -1,0 +1,1 @@
+export * from './Component.mobile';


### PR DESCRIPTION
# Опишите проблему
Сплит компонента. Добавлены десктоп/мобайл импорты

# Чек лист
- [х] Документация

# Внешний вид
Без изменений

# Дополнительная информация
Было: index.js: 37 kB
Стало: desktop: 34,8 kB (минус 2,2 kB)