### PR TITLE
fix: remove invalid props from dom

### DIFF
--- a/.changeset/weak-starfishes-leave.md
+++ b/.changeset/weak-starfishes-leave.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-picker-button': patch
+'@alfalab/core-components-tabs': patch
+---
+
+Убрана передача невалидных пропсов в DOM

--- a/packages/picker-button/src/field/Component.tsx
+++ b/packages/picker-button/src/field/Component.tsx
@@ -52,6 +52,7 @@ export const Field = ({
     labelView,
     FormControlComponent,
     icon,
+    onClear,
     ...restProps
 }: FieldProps) => {
     const Icon: ComponentType<SVGProps<SVGSVGElement>> = getIcon(

--- a/packages/tabs/src/components/title/Component.tsx
+++ b/packages/tabs/src/components/title/Component.tsx
@@ -33,6 +33,7 @@ export const Title = forwardRef<HTMLButtonElement, Props>(
             showSkeleton = false,
             skeletonProps,
             onResize,
+            dataTestId,
             ...restProps
         },
         ref,
@@ -67,6 +68,7 @@ export const Title = forwardRef<HTMLButtonElement, Props>(
         return hidden ? null : (
             <button
                 {...restProps}
+                data-test-id={dataTestId}
                 ref={mergeRefs([ref, buttonRef])}
                 disabled={disabled || showSkeleton}
                 type='button'

--- a/packages/tabs/src/hooks/use-tabs.tsx
+++ b/packages/tabs/src/hooks/use-tabs.tsx
@@ -130,7 +130,7 @@ export function useTabs({ titles = [], selectedId, onChange }: UseTabsProps) {
             tabIndex: itemSelected ? 0 : -1,
             'aria-selected': itemSelected,
             selected: itemSelected,
-            'data-test-id': getDataTestId(item.dataTestId, 'toggle'),
+            dataTestId: getDataTestId(item.dataTestId, 'toggle'),
             disabled: item.disabled,
             ref: mergeRefs(refs),
             onKeyDown: handleKeyDown,


### PR DESCRIPTION
# Опишите проблему
PickerButton и TabsCollapsible при открытии вызывали ошибку передачи в DOM пропсов в camelCase

# Шаги для воспроизведения
1. Открыть компонент PickerButton в dev режиме
2. Открыть компонент TabsCollapsible в dev режиме и нажать кнопку еще

# Ожидаемое поведение
В консоли не должно быть ошибок

# Чек лист
- [x] Тесты
- [x] Документация

# Тестовый стенд