### PR TITLE
fix(select): removed default setting allowUnselect as true in useSelectWithApply

### DIFF
--- a/.changeset/happy-timers-remember.md
+++ b/.changeset/happy-timers-remember.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': patch
+---
+
+Убрано проставление пропса allowUnselect: true в хуке useSelectWithApply

--- a/packages/select/src/presets/useSelectWithApply/hook.tsx
+++ b/packages/select/src/presets/useSelectWithApply/hook.tsx
@@ -222,7 +222,6 @@ export function useSelectWithApply({
                 onChange: handleToggleAll,
             },
         },
-        allowUnselect: true,
         multiple: true,
         options: memoizedOptions,
         onChange: handleChange,


### PR DESCRIPTION
# Опишите проблему
При использовании хука useSelectWithApply на выходе получаем по дефолту проставленный проп allowUnselect: true.  Из-за этого при нажатии на клавишу Backspace в пустой строке поиска снимается выбор с уже добавленных элементов
[ссылка на таску](https://jira.moscow.alfaintra.net/browse/DS-7918)

# Шаги для воспроизведения
1. Выбираем несколько пунктов меню
2. Нажимаем применить
3. Снова открываем строку поиска для добавления
4. Кликаем по клавише Backspace

# Ожидаемое поведение
Ранее выбранные  пункты остаются
