### PR TITLE
fix(file-upload-item): fix content text truncate

### DIFF
--- a/.changeset/silent-swans-heal.md
+++ b/.changeset/silent-swans-heal.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-file-upload-item': patch
+---
+
+Поправлено обрезание длинного текста при truncate: true

--- a/packages/file-upload-item/src/components/content/content.module.css
+++ b/packages/file-upload-item/src/components/content/content.module.css
@@ -2,7 +2,8 @@
 
 .container {
     padding: var(--gap-2) 0 0 var(--gap-16);
-    width: 100%;
+    flex-grow: 1;
+    min-width: 0;
     cursor: pointer;
 
     &.single {
@@ -19,10 +20,8 @@
 
     & .title {
         margin-bottom: var(--gap-4);
-    }
-
-    & .title {
         display: block;
+        overflow-wrap: break-word;
 
         &.truncate {
             white-space: nowrap;


### PR DESCRIPTION
# Опишите проблему
При использовании опции truncate если текст длинный, а блок, в котором находится компонент ограничен по ширине, то текст начинает расширять компонент и он вылезает за границы

# Шаги для воспроизведения
1. Поместить FileUploadItem внутрь блока с ограниченной шириной
2. title должен быть достаточно длинным
3. Применяем проп truncate: true

# Ожидаемое поведение
Текст обрезается и компонент не вылезает за границы блока