### PR TITLE
Fix --gap-0

### DIFF
--- a/packages/vars/src/gaps.css
+++ b/packages/vars/src/gaps.css
@@ -30,7 +30,7 @@
     --gap-8xl-neg: -128px; /* deprecated */
 
     /* новые значения, используйте их */
-    --gap-0: 0;
+    --gap-0: 0px;
     --gap-2: var(--gap-3xs);
     --gap-4: var(--gap-2xs);
     --gap-8: var(--gap-xs);


### PR DESCRIPTION


# Опишите проблему
У --gap-0 неправильная размерность;
Из за этого, при использовании с calc могут быть проблемы Согласно спеке calc для length data type должны быть объявлены юниты. Проблему можно увидеть на примере



# Шаги для воспроизведения
```css
:root {
   --gap-0: 0;
}

.header {
  position: fixed;
  top: calc(100px + var(--gap-0))
}
```

```html
<div class="header">
    header
</div>
```

# Ожидаемое поведение
--gap-0 должен содержать юниты

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):


## Смартфон (если данных нет оставте блок пустым):


# Дополнительная информация
Дополнительная информация
