### PR TITLE
fix(select): fix measuring height of visible options

### DIFF
--- a/.changeset/green-tables-rest.md
+++ b/.changeset/green-tables-rest.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': patch
+---
+
+Поправлена отображаемая высота списка опций при optionsListWidth: 'field'

--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -171,7 +171,15 @@ export const OptionsList = forwardRef<HTMLDivElement, OptionsListProps>(
                     horizontalAutoStretch={optionsListWidth === 'content'}
                     scrollableNodeProps={scrollableNodeProps}
                     contentNodeProps={{ ref: listRef }}
-                    maskProps={{ className: measured ? undefined : styles.mask }}
+                    maskProps={{
+                        /*
+                         * Для корректного подсчета высоты опций(иначе для optionsListWidth: 'field'
+                         * высота опции всегда будет равна высоте одной строчки)
+                         */
+                        className: cn({
+                            [styles.mask]: optionsListWidth === 'content' && !measured,
+                        }),
+                    }}
                 >
                     {renderListItems()}
                 </Scrollbar>


### PR DESCRIPTION
# Опишите проблему
Неправильно подсчитывается высота скроллбара при наличии многострочных опций и optionsListWidth: 'field'

# Шаги для воспроизведения
1. Select с optionsListWidth: 'field' и многострочной опцией(ями)
2. Раскрыть список

# Ожидаемое поведение
Должно быть видно 5 опций, либо все, если их количество меньше пяти. Все остальное доступно по скроллу

# Дополнительная информация
[Ссылка на таску](https://jira.moscow.alfaintra.net/browse/DS-8885)
Сейчас
<img width="963" alt="Снимок экрана 2025-02-03 в 11 51 22" src="https://github.com/user-attachments/assets/23e53085-8efc-42aa-b7d3-aafd99d2feca" />
Должно быть
<img width="933" alt="Снимок экрана 2025-02-03 в 11 51 28" src="https://github.com/user-attachments/assets/9f73a0a9-ea1c-4429-8619-0aec62ff17a6" />
