### PR TITLE
fix(intl-phone-input): ability to overwrite country-data

### DIFF
--- a/.changeset/violet-dancers-check.md
+++ b/.changeset/violet-dancers-check.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-international-phone-input': minor
+---
+
+optional prop customCountriesList was added to be able to overwrite default country-data

--- a/.changeset/violet-dancers-check.md
+++ b/.changeset/violet-dancers-check.md
@@ -2,4 +2,4 @@
 '@alfalab/core-components-international-phone-input': minor
 ---
 
-optional prop customCountriesList was added to be able to overwrite default country-data
+добавлен опциональный проп customCountriesList, который можно использовать, чтобы переопределить дефолтный массив country-data

--- a/packages/international-phone-input/src/Component.test.tsx
+++ b/packages/international-phone-input/src/Component.test.tsx
@@ -8,6 +8,7 @@ import {
     getInternationalPhoneInputDesktopTestIds,
     getInternationalPhoneInputMobileTestIds,
 } from './utils';
+import { countriesData } from './data/country-data';
 
 describe('InternationalPhoneInput', () => {
     Object.defineProperty(window, 'matchMedia', {
@@ -743,5 +744,39 @@ describe('InternationalPhoneInput', () => {
         );
 
         expect(getByTestIdHint(testIds.fieldHint)).toBeInTheDocument();
+    });
+
+    it('should be able to overwrite countries list with initCountriesList prop', async () => {
+        const dti = 'test-dti';
+
+        let initCountriesList = countriesData.map((countryData) => {
+            if (countryData[4]) {
+                const fullNumberLength =
+                    countryData[3].length + countryData[4].replace(/\s/g, '').length;
+                const additionalNumberLength = 15 - fullNumberLength;
+
+                if (additionalNumberLength > 0) {
+                    // Overwrite number length
+                    countryData[4] = `${countryData[4]} ${'.'.repeat(additionalNumberLength)}`;
+                }
+            }
+
+            return countryData;
+        });
+
+        const { getByTestId } = render(
+            <InternationalPhoneInputStateful
+                label='Номер телефона'
+                placeholder='Введите номер телефона'
+                dataTestId={dti}
+                initCountriesList={initCountriesList}
+            />,
+        );
+
+        const input = getByTestId(dti);
+
+        await userEvent.type(input, '+123451234512345');
+
+        expect(input).toHaveValue('+1 234 512 3451 2345');
     });
 });

--- a/packages/international-phone-input/src/Component.test.tsx
+++ b/packages/international-phone-input/src/Component.test.tsx
@@ -746,10 +746,10 @@ describe('InternationalPhoneInput', () => {
         expect(getByTestIdHint(testIds.fieldHint)).toBeInTheDocument();
     });
 
-    it('should be able to overwrite countries list with initCountriesList prop', async () => {
+    it('should be able to overwrite countries list with customCountriesList prop', async () => {
         const dti = 'test-dti';
 
-        let initCountriesList = countriesData.map((countryData) => {
+        let customCountriesList = countriesData.map((countryData) => {
             if (countryData[4]) {
                 const fullNumberLength =
                     countryData[3].length + countryData[4].replace(/\s/g, '').length;
@@ -769,7 +769,7 @@ describe('InternationalPhoneInput', () => {
                 label='Номер телефона'
                 placeholder='Введите номер телефона'
                 dataTestId={dti}
-                initCountriesList={initCountriesList}
+                customCountriesList={customCountriesList}
             />,
         );
 

--- a/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
+++ b/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
@@ -54,14 +54,14 @@ export const BaseInternationalPhoneInput = forwardRef<
             clear: clearProp,
             open: openProps,
             defaultOpen,
-            initCountriesList,
+            customCountriesList,
             ...restProps
         },
         ref,
     ) => {
         const countriesData = useMemo(
-            () => initCountries(countries, initCountriesList),
-            [countries, initCountriesList],
+            () => initCountries(countries, customCountriesList),
+            [countries, customCountriesList],
         );
         const inputRef = useRef<HTMLInputElement>(null);
         const inputWrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
+++ b/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
@@ -54,11 +54,15 @@ export const BaseInternationalPhoneInput = forwardRef<
             clear: clearProp,
             open: openProps,
             defaultOpen,
+            initCountriesList,
             ...restProps
         },
         ref,
     ) => {
-        const countriesData = useMemo(() => initCountries(countries), [countries]);
+        const countriesData = useMemo(
+            () => initCountries(countries, initCountriesList),
+            [countries, initCountriesList],
+        );
         const inputRef = useRef<HTMLInputElement>(null);
         const inputWrapperRef = useRef<HTMLDivElement>(null);
 

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -45,9 +45,7 @@ type CommonPhoneInputProps = {
     defaultIso2?: string;
 
     /**
-     *
      * Список правил парсинга номеров телефонов по странам (для переопределения дефолтного)
-     * @type {CountriesData[]}
      */
     customCountriesList?: CountriesData[];
 

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -10,6 +10,7 @@ import type { InputAutocompleteMobileProps } from '@alfalab/core-components-inpu
 import { OptionShape } from '@alfalab/core-components-select/typings';
 
 import type { SharedCountrySelectProps } from './components/country-select';
+import { CountriesData } from './data/country-data';
 
 export type Country = {
     name: string;
@@ -42,6 +43,13 @@ type CommonPhoneInputProps = {
      * Дефолтный код страны
      */
     defaultIso2?: string;
+
+    /**
+     *
+     * Список правил парсинга номеров телефонов по странам (для переопределения дефолтного)
+     * @type {CountriesData[]}
+     */
+    initCountriesList?: CountriesData[];
 
     /**
      * Возможность стереть код страны

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -49,7 +49,7 @@ type CommonPhoneInputProps = {
      * Список правил парсинга номеров телефонов по странам (для переопределения дефолтного)
      * @type {CountriesData[]}
      */
-    initCountriesList?: CountriesData[];
+    customCountriesList?: CountriesData[];
 
     /**
      * Возможность стереть код страны

--- a/packages/international-phone-input/src/utils/index.ts
+++ b/packages/international-phone-input/src/utils/index.ts
@@ -5,13 +5,14 @@ import { GroupShape, isGroup, OptionShape } from '@alfalab/core-components-selec
 import { getDataTestId, maskUtils } from '@alfalab/core-components-shared';
 
 import { DEFAULT_PHONE_FORMAT } from '../consts';
-import { countriesData } from '../data/country-data';
+import { CountriesData, countriesData } from '../data/country-data';
 import type { AreaItem, Country } from '../types';
 
-export function initCountries(iso2s?: string[]) {
+export function initCountries(iso2s?: string[], initCountriesList?: CountriesData[]) {
+    const data = initCountriesList ?? countriesData;
     const filteredCountriesData = Array.isArray(iso2s)
-        ? countriesData.filter((country) => iso2s.includes(country[2]))
-        : countriesData;
+        ? data.filter((country) => iso2s.includes(country[2]))
+        : data;
 
     return filteredCountriesData.map((country) => {
         const countryItem: Country = {

--- a/packages/international-phone-input/src/utils/index.ts
+++ b/packages/international-phone-input/src/utils/index.ts
@@ -8,8 +8,8 @@ import { DEFAULT_PHONE_FORMAT } from '../consts';
 import { CountriesData, countriesData } from '../data/country-data';
 import type { AreaItem, Country } from '../types';
 
-export function initCountries(iso2s?: string[], initCountriesList?: CountriesData[]) {
-    const data = initCountriesList ?? countriesData;
+export function initCountries(iso2s?: string[], customCountriesList?: CountriesData[]) {
+    const data = customCountriesList ?? countriesData;
     const filteredCountriesData = Array.isArray(iso2s)
         ? data.filter((country) => iso2s.includes(country[2]))
         : data;


### PR DESCRIPTION
# Опишите проблему
Требование от НСПК: возможная длина номера тлф до 15 цифр

Добавил пропс для переопределения дефолтного массива countriesData, чтобы по месту использования компонента можно было передать массив в котором уже будет нужная длина номеров телефонов