### PR TITLE
feat: safe area improvement

### DIFF
--- a/.changeset/pink-sloths-suffer.md
+++ b/.changeset/pink-sloths-suffer.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-base-modal': patch
+'@alfalab/core-components-bottom-sheet': patch
+'@alfalab/core-components-modal': patch
+'@alfalab/core-components-side-panel': patch
+---
+
+Исправление работы safe-area

--- a/packages/base-modal/src/Component.tsx
+++ b/packages/base-modal/src/Component.tsx
@@ -625,6 +625,10 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
                                                 styles.content,
                                                 contentClassName,
                                                 contentProps?.className,
+                                                {
+                                                    [styles.hasFooter]: hasFooter,
+                                                    [styles.hasHeader]: hasHeader,
+                                                },
                                             )}
                                         >
                                             {children}

--- a/packages/base-modal/src/index.module.css
+++ b/packages/base-modal/src/index.module.css
@@ -39,6 +39,18 @@ body:global(.is-locked) {
     display: flex;
     flex-direction: column;
     flex: 1;
+
+    &.hasFooter {
+        @media (display-mode: standalone) {
+            padding-bottom: unset;
+        }
+    }
+
+    &.hasHeader {
+        @media (display-mode: standalone) {
+            padding-top: unset;
+        }
+    }
 }
 
 .hidden {

--- a/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
+++ b/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
           class="component modal appear appearActive"
         >
           <div
-            class="content"
+            class="content hasHeader"
           >
             <div
               class="wrapper"
@@ -123,7 +123,7 @@ exports[`Bottom sheet Snapshots tests should match snapshot with action button 1
           class="component modal appear appearActive"
         >
           <div
-            class="content"
+            class="content hasFooter hasHeader"
           >
             <div
               class="wrapper"

--- a/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
           class="component modal appear appearActive"
         >
           <div
-            class="content"
+            class="content hasFooter hasHeader"
           >
             <div
               class="wrapper"

--- a/packages/modal/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/modal/src/__snapshots__/Component.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ModalDesktop snapshots tests should match snapshot 1`] = `
     class="component size-500 appear appearActive"
   >
     <div
-      class="content"
+      class="content hasFooter hasHeader"
     >
       <div
         class="header hasContent size-500"
@@ -145,7 +145,7 @@ exports[`ModalMobile snapshots tests should match snapshot 1`] = `
     class="component appear appearActive"
   >
     <div
-      class="content content"
+      class="content content hasFooter hasHeader"
     >
       <div
         class="header hasContent header"

--- a/packages/modal/src/components/footer/mobile.module.css
+++ b/packages/modal/src/components/footer/mobile.module.css
@@ -1,7 +1,12 @@
+@import '../../../../vars/src/safe-area.css';
 @import '../../vars.css';
 
 .footer {
     padding: var(--gap-16);
+
+    @media (display-mode: standalone) {
+        padding-bottom: var(--sab);
+    }
 }
 
 .sticky {

--- a/packages/modal/src/components/header/mobile.module.css
+++ b/packages/modal/src/components/header/mobile.module.css
@@ -3,14 +3,14 @@
 
 .header {
     padding: var(--modal-header-mobile-paddings);
+
+    @media (display-mode: standalone) {
+        padding-top: var(--sat);
+    }
 }
 
 .sticky {
     top: var(--gap-0);
-
-    @media (display-mode: standalone) {
-        top: var(--sat);
-    }
 }
 
 .content {

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -330,7 +330,7 @@ exports[`Snapshots tests should display opened correctly 4`] = `
         class="component modal appear appearActive"
       >
         <div
-          class="content"
+          class="content hasHeader"
         >
           <div
             class="wrapper"
@@ -1447,7 +1447,7 @@ exports[`Snapshots tests should display opened correctly 6`] = `
         class="component modal appear appearActive"
       >
         <div
-          class="content"
+          class="content hasHeader"
         >
           <div
             class="wrapper"

--- a/packages/side-panel/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/side-panel/src/__snapshots__/Component.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SidePanelDesktop snapshots tests should match snapshot 1`] = `
     class="component size-500 hidden rightPlacement enterRight enterActive"
   >
     <div
-      class="content"
+      class="content hasFooter hasHeader"
     >
       <div
         class="content appearRight enterActive"
@@ -149,7 +149,7 @@ exports[`SidePanelMobile snapshots tests should match snapshot 1`] = `
     class="component appear appearActive"
   >
     <div
-      class="content"
+      class="content content hasFooter hasHeader"
     >
       <div
         class="mobileContent"

--- a/packages/side-panel/src/components/footer/mobile.module.css
+++ b/packages/side-panel/src/components/footer/mobile.module.css
@@ -1,7 +1,12 @@
+@import '../../../../vars/src/safe-area.css';
 @import '../../vars.css';
 
 .footer {
     padding: var(--gap-16);
+
+    @media (display-mode: standalone) {
+        padding-bottom: var(--sab);
+    }
 }
 
 .sticky {

--- a/packages/side-panel/src/components/header/mobile.module.css
+++ b/packages/side-panel/src/components/header/mobile.module.css
@@ -3,14 +3,14 @@
 
 .header {
     padding: var(--side-panel-header-mobile-paddings);
+
+    @media (display-mode: standalone) {
+        padding-top: var(--sat);
+    }
 }
 
 .sticky {
     top: var(--gap-0);
-
-    @media (display-mode: standalone) {
-        top: var(--sat);
-    }
 }
 
 .content {

--- a/packages/side-panel/src/mobile/Component.mobile.tsx
+++ b/packages/side-panel/src/mobile/Component.mobile.tsx
@@ -40,6 +40,10 @@ const SidePanelMobileComponent = forwardRef<HTMLDivElement, SidePanelMobileProps
                 }}
                 className={cn(className, styles.component)}
                 scrollHandler='content'
+                contentProps={{
+                    ...restProps.contentProps,
+                    className: cn(styles.content, restProps.contentProps?.className),
+                }}
             >
                 <div className={styles.mobileContent}>{children}</div>
             </BaseModal>

--- a/packages/side-panel/src/mobile/mobile.module.css
+++ b/packages/side-panel/src/mobile/mobile.module.css
@@ -15,14 +15,16 @@
     flex: 1;
 }
 
+.content {
+    @media (display-mode: standalone) {
+        padding-top: var(--sat);
+        padding-bottom: var(--sab);
+    }
+}
+
 .mobileContent {
     display: flex;
     flex-direction: column;
     width: 100%;
     flex: 1;
-
-    @media (display-mode: standalone) {
-        padding-top: var(--sat);
-        padding-bottom: var(--sab);
-    }
 }


### PR DESCRIPTION
Доработка safe-area.
- Если нет header или footer, то отступ добавляется контентной области сверху и снизу соответсвенно;
- Если есть header или footer, то соотвествующие отступы контентной области убираются и формируются непосредственно в header или footer.

Это позволило исправить некоторые визуальные артифакты и проблемы с позиционированием header/footer в состоянии sticky/!sticky

Бета 10.02.25
https://www.npmjs.com/package/@alfalab/core-components/v/48.15.0-beta.0