### PR TITLE
chore: fix screenshot

### DIFF
--- a/packages/calendar-range/src/__image_snapshots__/calendar-range-dark-preview-snap.png
+++ b/packages/calendar-range/src/__image_snapshots__/calendar-range-dark-preview-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6335f5c47308afee368e20a75db7b91a815ed7eac3d087804968168f25d58187
-size 22781
+oid sha256:097a6c57bb5d0c80d8ae44cae7145a20f72bcff25d05b6295270b4167bc24b98
+size 22662

--- a/packages/calendar-range/src/__image_snapshots__/calendar-range-dark-preview-snap.png
+++ b/packages/calendar-range/src/__image_snapshots__/calendar-range-dark-preview-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:097a6c57bb5d0c80d8ae44cae7145a20f72bcff25d05b6295270b4167bc24b98
-size 22662
+oid sha256:0473edc16f544171a2cde92fb57f2c67b5289fffedacd51dc65f83eacffd779e
+size 22689

--- a/packages/calendar-range/src/__image_snapshots__/calendar-range-off-days-0-snap.png
+++ b/packages/calendar-range/src/__image_snapshots__/calendar-range-off-days-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7a57210c5849224dd3df722f1825944f0881a88dd69c83ef5e0280b4f7bbc26
-size 35252
+oid sha256:73bc78aa8d5e84fd5dfdbc62896a5cc1a6bcf7ff495c1abd8d50f005f68f5a8b
+size 35852

--- a/packages/calendar-range/src/__image_snapshots__/calendar-range-preview-snap.png
+++ b/packages/calendar-range/src/__image_snapshots__/calendar-range-preview-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6da872b0e6e2ac10a107465ccbc4323198e6c95e1c21df605f15f9bdc3e72f37
-size 23989
+oid sha256:a87de20375f6626bea7e31eb537a2c3127737dedd66271f31a5f027dc4dfe9a5
+size 24161


### PR DESCRIPTION
Обновление скриншота. Переодически стреляет во время прогона скриншот тестов. В нем немного изменяется цвет текста в инпуте. Судя по всему тулза считывает такие изменения с погрешностью.