### PR TITLE
chore: update @alfalab/utils

### DIFF
--- a/.changeset/tough-wasps-matter.md
+++ b/.changeset/tough-wasps-matter.md
@@ -1,0 +1,10 @@
+---
+'@alfalab/core-components-amount': patch
+'@alfalab/core-components-amount-input': patch
+'@alfalab/core-components-attach': patch
+'@alfalab/core-components-confirmation-v1': patch
+'@alfalab/core-components-intl-phone-input': patch
+'@alfalab/core-components-product-cover': patch
+---
+
+Обновлена версия @alfalab/utils до 1.18.0

--- a/.changeset/tough-wasps-matter.md
+++ b/.changeset/tough-wasps-matter.md
@@ -1,10 +1,10 @@
 ---
-'@alfalab/core-components-amount': patch
-'@alfalab/core-components-amount-input': patch
-'@alfalab/core-components-attach': patch
-'@alfalab/core-components-confirmation-v1': patch
-'@alfalab/core-components-intl-phone-input': patch
-'@alfalab/core-components-product-cover': patch
+'@alfalab/core-components-amount': minor
+'@alfalab/core-components-amount-input': minor
+'@alfalab/core-components-attach': minor
+'@alfalab/core-components-confirmation-v1': minor
+'@alfalab/core-components-intl-phone-input': minor
+'@alfalab/core-components-product-cover': minor
 ---
 
 Обновлена версия @alfalab/utils до 1.18.0

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@alfalab/icons-glyph": "^2.210.0",
         "@alfalab/icons-logotype": "^2.27.0",
         "@alfalab/react-canvas-pattern-lock": "^2.0.7",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "@dnd-kit/core": "^6.0.7",
         "@dnd-kit/sortable": "^7.0.2",
         "@juggle/resize-observer": "^3.3.1",

--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -18,7 +18,7 @@
         "@alfalab/core-components-input": "^15.5.1",
         "@alfalab/core-components-with-suffix": "^4.2.13",
         "@alfalab/data": "^1.9.1",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0",
         "@alfalab/core-components-shared": "^0.15.0"

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -13,7 +13,7 @@
     "sideEffects": false,
     "dependencies": {
         "@alfalab/data": "^1.9.1",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0"
     },

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -19,7 +19,7 @@
         "@alfalab/core-components-keyboard-focusable": "^4.1.1",
         "@alfalab/core-components-progress-bar": "^3.5.2",
         "@alfalab/icons-glyph": "^2.210.0",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "react-merge-refs": "^1.1.0",
         "tslib": "^2.4.0"

--- a/packages/confirmation-v1/package.json
+++ b/packages/confirmation-v1/package.json
@@ -17,7 +17,7 @@
         "@alfalab/core-components-loader": "^3.2.4",
         "@alfalab/hooks": "^1.13.1",
         "@alfalab/icons-glyph": "^2.210.0",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0"
     },

--- a/packages/intl-phone-input/package.json
+++ b/packages/intl-phone-input/package.json
@@ -19,7 +19,7 @@
         "@alfalab/core-components-select": "^17.20.4",
         "@alfalab/hooks": "^1.13.1",
         "@alfalab/icons-glyph": "^2.210.0",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "libphonenumber-js": "^1.10.30",
         "react-merge-refs": "1.1.0",

--- a/packages/product-cover/package.json
+++ b/packages/product-cover/package.json
@@ -21,7 +21,7 @@
         "@alfalab/core-components-shared": "^0.15.0",
         "@alfalab/icons-glyph": "^2.210.0",
         "@alfalab/hooks": "^1.13.1",
-        "@alfalab/utils": "^1.17.1",
+        "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,14 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
   integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
 
+"@alfalab/core-components-shared@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@alfalab/core-components-shared/-/core-components-shared-0.14.1.tgz#3b18787ce563b306b1c2216f837070fc4601c57a"
+  integrity sha512-T6W5+gMS5BWemqjsqjlSx4RnHKwRInbaijIX1JI5KwHiPrJo3iQOhR5gKmOSMlvIgFCNYcNI3VoMxJokQi+7CQ==
+  dependencies:
+    "@alfalab/hooks" "^1.13.1"
+    tslib "^2.4.0"
+
 "@alfalab/core-components@>=35.1.0":
   version "44.2.0"
   resolved "https://registry.yarnpkg.com/@alfalab/core-components/-/core-components-44.2.0.tgz#3e7366bc60f6a7b18853961ae6be1af80333528a"
@@ -154,6 +162,14 @@
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@alfalab/utils/-/utils-1.17.1.tgz#5e509bafb3b1482c48047767985df1f76e1a2065"
   integrity sha512-MniVTU5muLg2f8uX0jp3wQRB5LiadhqCSvNfasLYJA+EHksjXwc5vZm1mh/n+Mku5e8B72rpSnUmGRU1DESArg==
+  dependencies:
+    "@alfalab/data" "^1.9.1"
+    lodash "^4.17.21"
+
+"@alfalab/utils@^1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@alfalab/utils/-/utils-1.18.0.tgz#d1d68f780a7938ac01f00db4bca70a618ecdda38"
+  integrity sha512-MEtCheju5gQOTX3g5X3gRCRlsIY2Q6qsb5VxvbA7JmnM5gOmFsMnOP8oOVAVXVIXnuvSMBlqYtDrVgrtrNDsTg==
   dependencies:
     "@alfalab/data" "^1.9.1"
     lodash "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,14 +7,6 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
   integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
 
-"@alfalab/core-components-shared@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@alfalab/core-components-shared/-/core-components-shared-0.14.1.tgz#3b18787ce563b306b1c2216f837070fc4601c57a"
-  integrity sha512-T6W5+gMS5BWemqjsqjlSx4RnHKwRInbaijIX1JI5KwHiPrJo3iQOhR5gKmOSMlvIgFCNYcNI3VoMxJokQi+7CQ==
-  dependencies:
-    "@alfalab/hooks" "^1.13.1"
-    tslib "^2.4.0"
-
 "@alfalab/core-components@>=35.1.0":
   version "44.2.0"
   resolved "https://registry.yarnpkg.com/@alfalab/core-components/-/core-components-44.2.0.tgz#3e7366bc60f6a7b18853961ae6be1af80333528a"


### PR DESCRIPTION
Поднята версия `@alfalab/utils` до 1.18.0