### PR TITLE
Remove styles property from PassCode

### DIFF
--- a/.changeset/olive-lamps-worry.md
+++ b/.changeset/olive-lamps-worry.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pass-code': patch
+---
+
+Убрано неработающее свойство 'styles'

--- a/packages/pass-code/src/Component.tsx
+++ b/packages/pass-code/src/Component.tsx
@@ -8,7 +8,7 @@ import { InputProgress } from './components/InputProgress';
 import { KeyPad } from './components/KeyPad';
 import { PassCodeProps } from './typings';
 
-import commonStyles from './index.module.css';
+import styles from './index.module.css';
 
 export type BasePassCodeProps = {
     /**
@@ -77,11 +77,6 @@ export type BasePassCodeProps = {
     defaultMatchMediaValue?: boolean | (() => boolean);
 
     /**
-     * Стили компонента
-     */
-    styles?: { [key: string]: string };
-
-    /**
      * Отключает ввод и удаление кода
      */
     disabled?: boolean;
@@ -101,7 +96,6 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
             onChange,
             maxCodeLength = 10,
             codeLength,
-            styles = {},
             disabled,
         },
         ref,
@@ -132,11 +126,11 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
 
         return (
             <div
-                className={cn(commonStyles.component, styles.component, className)}
+                className={cn(styles.component, className)}
                 ref={ref}
                 data-test-id={getDataTestId(dataTestId, 'wrapper')}
             >
-                <div className={cn(commonStyles.inputProgressContainer)}>
+                <div className={cn(styles.inputProgressContainer)}>
                     <Gap size={16} />
                     <InputProgress
                         dataTestId={dataTestId}

--- a/packages/pass-code/src/desktop/PassCodeDesktop.tsx
+++ b/packages/pass-code/src/desktop/PassCodeDesktop.tsx
@@ -1,10 +1,13 @@
 import React, { forwardRef } from 'react';
+import cn from 'classnames';
 
 import { PassCode } from '../Component';
 import { PassCodeProps } from '../typings';
 
 import styles from './desktop.module.css';
 
-export const PassCodeDesktop = forwardRef<HTMLDivElement, PassCodeProps>((restProps, ref) => (
-    <PassCode {...restProps} ref={ref} styles={styles} />
-));
+export const PassCodeDesktop = forwardRef<HTMLDivElement, PassCodeProps>(
+    ({ className, ...restProps }, ref) => (
+        <PassCode {...restProps} ref={ref} className={cn(styles.component, className)} />
+    ),
+);

--- a/packages/pass-code/src/index.module.css
+++ b/packages/pass-code/src/index.module.css
@@ -12,14 +12,3 @@
     position: relative;
     flex: 1 0 auto;
 }
-
-.message {
-    @mixin paragraph_primary_medium;
-
-    min-height: 24px;
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: var(--color-light-text-primary);
-}

--- a/packages/pass-code/src/mobile/PassCodeMobile.tsx
+++ b/packages/pass-code/src/mobile/PassCodeMobile.tsx
@@ -1,10 +1,13 @@
 import React, { forwardRef } from 'react';
+import cn from 'classnames';
 
 import { PassCode } from '../Component';
 import { PassCodeProps } from '../typings';
 
 import styles from './mobile.module.css';
 
-export const PassCodeMobile = forwardRef<HTMLDivElement, PassCodeProps>((restProps, ref) => (
-    <PassCode {...restProps} ref={ref} styles={styles} />
-));
+export const PassCodeMobile = forwardRef<HTMLDivElement, PassCodeProps>(
+    ({ className, ...restProps }, ref) => (
+        <PassCode {...restProps} ref={ref} className={cn(styles.component, className)} />
+    ),
+);


### PR DESCRIPTION
# Опишите проблему
В компоненте PassCode типами разрешено свойство `styles`, но оно сломано и не применяется.
Фактически свойство `styles` использовалось для внутреннего механизма применения css-классов для мобильного и десктопного вариантов компонента.
После обсуждения было решено, что свойство `styles` следует убрать (из типов), а для стилизации использовать `className`.

# Шаги для воспроизведения
1. Перейти на страницу https://core-ds.github.io/core-components/master/?path=/docs/sandbox--docs
2. Ввести код для воспроизведения:
```
function Example() {
    const [value, setValue] = React.useState('');
    return (
        <div>
            <PassCode
              styles={{ height: 600, backgroundColor: 'lightBlue' }}
              value={value}
              onChange={setValue}
              maxCodeLength={4}
            />
        </div>
    );
}
render(
    <Example />
)
```

# Ожидаемое поведение
При использовании компонента разработчик не должен иметь возможности использовать свойство `styles`

# Дополнительная информация
Визуальных изменений нет