### PR TITLE
fix(base-modal): change TransitionProps type to CSSTransitionProps [DS-9260]

### DIFF
--- a/.changeset/hot-avocados-report.md
+++ b/.changeset/hot-avocados-report.md
@@ -1,0 +1,5 @@
+---
+"@alfalab/core-components-base-modal": patch
+---
+
+Исправлен тип `TransitionProps` на `CSSTransitionProps` в `base-modal`

--- a/packages/base-modal/src/Component.tsx
+++ b/packages/base-modal/src/Component.tsx
@@ -17,7 +17,7 @@ import React, {
 import FocusLock from 'react-focus-lock';
 import mergeRefs from 'react-merge-refs';
 import { CSSTransition } from 'react-transition-group';
-import { TransitionProps } from 'react-transition-group/Transition';
+import { TransitionProps as CSSTransitionProps } from 'react-transition-group/Transition';
 import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 import cn from 'classnames';
 
@@ -152,7 +152,7 @@ export type BaseModalProps = {
     /**
      * Пропсы для анимации (CSSTransition)
      */
-    transitionProps?: Partial<TransitionProps>;
+    transitionProps?: Partial<CSSTransitionProps>;
 
     /**
      * Рендерить ли в контейнер через портал.
@@ -445,7 +445,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
             return scrollHandler.current || wrapperRef.current;
         }, [scrollHandler]);
 
-        const handleEntered: Required<TransitionProps>['onEntered'] = useCallback(
+        const handleEntered: Required<CSSTransitionProps>['onEntered'] = useCallback(
             (node, isAppearing) => {
                 scrollableNodeRef.current = getScrollHandler();
 
@@ -465,7 +465,7 @@ export const BaseModal = forwardRef<HTMLDivElement, BaseModalProps>(
             [addResizeHandle, getScrollHandler, handleScroll, onMount, transitionProps],
         );
 
-        const handleExited: Required<TransitionProps>['onExited'] = useCallback(
+        const handleExited: Required<CSSTransitionProps>['onExited'] = useCallback(
             (node) => {
                 removeResizeHandle();
 

--- a/packages/base-modal/src/Component.tsx
+++ b/packages/base-modal/src/Component.tsx
@@ -17,7 +17,7 @@ import React, {
 import FocusLock from 'react-focus-lock';
 import mergeRefs from 'react-merge-refs';
 import { CSSTransition } from 'react-transition-group';
-import { TransitionProps as CSSTransitionProps } from 'react-transition-group/Transition';
+import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 import cn from 'classnames';
 


### PR DESCRIPTION
Исправлен тип TransitionProps на CSSTransitionProps в base-modal.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало
