### PR TITLE
fix(calendar): fix ios safari behaviour

### DIFF
--- a/.changeset/long-planes-share.md
+++ b/.changeset/long-planes-share.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-calendar': patch
+---
+
+Обновление react-virtuoso

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "react-textarea-autosize": "^8.3.4",
         "react-transition-group": "^4.4.5",
         "react-virtual": "^2.3.2",
-        "react-virtuoso": "^2.12.0",
+        "react-virtuoso": "^4.12.5",
         "recharts": "^2.12.7",
         "simplebar": "^5.3.8",
         "swiper": "^6.8.2",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -28,7 +28,7 @@
         "date-fns": "^2.16.1",
         "react-merge-refs": "^1.1.0",
         "react-transition-group": "^4.4.5",
-        "react-virtuoso": "^2.12.0",
+        "react-virtuoso": "^4.12.5",
         "tslib": "^2.4.0"
     },
     "themesVersion": "13.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18558,6 +18558,11 @@ react-virtuoso@^2.12.0:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"
 
+react-virtuoso@^4.12.5:
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.12.5.tgz#cf92efc2527e56d6df1d4d63c6e4dd3fac5a4030"
+  integrity sha512-YeCbRRsC9CLf0buD0Rct7WsDbzf+yBU1wGbo05/XjbcN2nJuhgh040m3y3+6HVogTZxEqVm45ac9Fpae4/MxRQ==
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
В сафари для IOS есть проблема с календарями, не всегда показывается нужный календарь при открытии. 
Виртуализация 2 версии работает не корректно и безконфликтное обновление до 4-ой проблему решает.

https://github.com/user-attachments/assets/3b20b328-ccfa-4efb-96f6-4bca57fb4855

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset


Если есть визуальные изменения
- [x] Прикреплено изображение было/стало
