### PR TITLE
fix(pure-cell): fix active state on mouse up outside component

### DIFF
--- a/.changeset/quiet-experts-march.md
+++ b/.changeset/quiet-experts-march.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pure-cell': patch
+---
+
+Исправлено active состояние при mouseup событии за пределами компонента

--- a/packages/pure-cell/src/component.tsx
+++ b/packages/pure-cell/src/component.tsx
@@ -134,7 +134,11 @@ const PureCellComponent = forwardRef<HTMLElement, PureCellProps>(
 
         const mouseEvents = {
             onMouseEnter: setHover,
-            onMouseLeave: unsetHover,
+            onMouseLeave: () => {
+                unsetHover();
+                // Убираем на случай, если уводим курсор за пределы компонента при сработавшем onMouseDown
+                unsetActive();
+            },
             onMouseDown: setActive,
             onMouseUp: unsetActive,
         };


### PR DESCRIPTION
При клике на комопонент и отпускании клавиши мыши за его пределами остается класс active, т.к. событие mouseup, на который висит обработчик для снятия класса, отрабатывает только если мы отпускаем мышку внутри компонента. Полечил довольно простым вариантом - убираю active класс, если мышку уводим за пределы компонента

DS-9053