### PR TITLE
feat(tooltip): add data-test-id for all parts of the tooltip component (DS-7656)

### DIFF
--- a/.changeset/short-shrimps-cough.md
+++ b/.changeset/short-shrimps-cough.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tooltip': major
+---
+
+Добавлены `data-test-id` для составляющих компонента `Tooltip`. Для контента тултипа теперь используется модификатор `${dataTestId}-content`

--- a/packages/tooltip/src/desktop/Component.desktop.tsx
+++ b/packages/tooltip/src/desktop/Component.desktop.tsx
@@ -11,6 +11,7 @@ import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
 import { Popover } from '@alfalab/core-components-popover';
+import { getDataTestId } from '@alfalab/core-components-shared';
 
 import type { TooltipDesktopProps } from '../types';
 
@@ -177,6 +178,7 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
             className: cn(styles.target, targetClassName, {
                 [styles.inline]: TargetTag === 'span',
             }),
+            'data-test-id': getDataTestId(dataTestId, 'target'),
         };
 
         switch (trigger) {
@@ -198,7 +200,7 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
     const getContentProps = (): HTMLAttributes<HTMLElement> => {
         const props = {
             ref: contentRef,
-            'data-test-id': dataTestId,
+            'data-test-id': getDataTestId(dataTestId, 'content'),
             className: cn(styles.component, contentClassName),
         };
 
@@ -240,6 +242,7 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
                 availableHeight={availableHeight}
                 useAnchorWidth={useAnchorWidth}
                 withTransition={withTransition}
+                dataTestId={getDataTestId(dataTestId, 'popover')}
             >
                 <div {...getContentProps()}>{content}</div>
             </Popover>

--- a/packages/tooltip/src/docs/development.mdx
+++ b/packages/tooltip/src/docs/development.mdx
@@ -15,6 +15,30 @@ import { TooltipDesktop } from '@alfalab/core-components/tooltip/desktop';
 // Мобильная версия
 import { TooltipMobile } from '@alfalab/core-components/tooltip/mobile';
 ```
+## Использование dataTestId
+
+В компоненте используются модификаторы для `dataTestId`.
+Для удобного поиска элементов можно воспользоваться функциями `getTooltipDesktopTestIds` и `getTooltipMobileTestIds`.
+Импорт из `@alfalab/core-components/tooltip/shared`.
+
+Функции возвращают объекты:
+
+```jsx
+// desktop
+{
+     target: `${dataTestId}-target`,
+     content: `${dataTestId}-content`,
+     popover:`${dataTestId}-popover`,
+};
+
+
+// mobile
+{
+    target: `${dataTestId}-target`,
+    bottomSheet: popover:`${dataTestId}-bottom-sheet`,
+};
+
+```
 
 ## Свойства
 

--- a/packages/tooltip/src/mobile/Component.mobile.tsx
+++ b/packages/tooltip/src/mobile/Component.mobile.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames';
 
 import { BottomSheet } from '@alfalab/core-components-bottom-sheet';
 import { ButtonMobile } from '@alfalab/core-components-button/mobile';
+import { getDataTestId } from '@alfalab/core-components-shared';
 
 import { TooltipMobileProps } from '../types';
 
@@ -19,6 +20,7 @@ export const TooltipMobile: React.FC<TooltipMobileProps> = ({
     getPortalContainer,
     targetTag: TargetTag = 'div',
     open: openProp,
+    dataTestId,
     ...restProps
 }) => {
     const [visible, setVisible] = useState(!!openProp);
@@ -50,6 +52,7 @@ export const TooltipMobile: React.FC<TooltipMobileProps> = ({
                 {...restProps}
                 container={getPortalContainer}
                 onClose={handleClose}
+                dataTestId={getDataTestId(dataTestId, 'bottom-sheet')}
             >
                 {content}
             </BottomSheet>
@@ -61,6 +64,7 @@ export const TooltipMobile: React.FC<TooltipMobileProps> = ({
                 className={cn(styles.target, targetClassName, {
                     [styles.inline]: TargetTag === 'span',
                 })}
+                data-test-id={getDataTestId(dataTestId, 'target')}
             >
                 {children?.props.disabled && <div className={styles.overlap} />}
                 {children}

--- a/packages/tooltip/src/shared/index.ts
+++ b/packages/tooltip/src/shared/index.ts
@@ -1,0 +1,1 @@
+export { getTooltipDesktopTestIds, getTooltipMobileTestIds } from '../utils';

--- a/packages/tooltip/src/utils.ts
+++ b/packages/tooltip/src/utils.ts
@@ -1,0 +1,16 @@
+import { getDataTestId } from '@alfalab/core-components-shared';
+
+export function getTooltipDesktopTestIds(dataTestId: string) {
+    return {
+        target: getDataTestId(dataTestId, 'target'),
+        content: getDataTestId(dataTestId, 'content'),
+        popover: getDataTestId(dataTestId, 'popover'),
+    };
+}
+
+export function getTooltipMobileTestIds(dataTestId: string) {
+    return {
+        target: getDataTestId(dataTestId, 'target'),
+        bottomSheet: getDataTestId(dataTestId, 'bottom-sheet'),
+    };
+}


### PR DESCRIPTION
Добавлен атрибут `data-test-id` для всех составляющих компонента `Tooltip` (target, content, popover / bottom-sheet). Ранее он был только у контента. Теперь к пропсу `dataTestId` добавляется модификатор и полученный `data-test-id` применяется к соответствующему элементу 

Задача: https://jira.moscow.alfaintra.net/browse/DS-7656
Issue GitHub: https://github.com/core-ds/core-components/issues/1425

