### PR TITLE
refactor: get rid of deprecated props

### DIFF
--- a/.changeset/modern-cups-attack.md
+++ b/.changeset/modern-cups-attack.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-bottom-sheet': major
+---
+
+Удален пропс `ignoreScreenChange`, который был объявлен как `deprecated` в core-components@29.x.x

--- a/packages/bottom-sheet/src/types.ts
+++ b/packages/bottom-sheet/src/types.ts
@@ -13,7 +13,7 @@ export type BottomSheetProps = {
     /**
      * Метод, позволяющий донастраивать высоту контейнера для BottomSheet, например с учётом safe-area
      */
-    adjustContainerHeight?: (height: number) => number
+    adjustContainerHeight?: (height: number) => number;
     /**
      * Контент
      */
@@ -237,12 +237,6 @@ export type BottomSheetProps = {
      * Отключает ловушку фокуса
      */
     disableFocusLock?: boolean;
-
-    /**
-     * @deprecated данный проп больше не используется, временно оставлен для обратной совместимости
-     * Не анимировать шторку при изменении размера вьюпорта
-     */
-    ignoreScreenChange?: boolean;
 
     /**
      * Свойства для Бэкдропа


### PR DESCRIPTION
Удалено объявление пропса ignoreScreenChange. Сама реализация данного пропса отсутствует