### PR TITLE
fix(international-phone-input): fix xl size paddings

### DIFF
--- a/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
                       class="bottomAddons"
                     >
                       <div
-                        class="component component component input search size-48 size-48"
+                        class="component component component input search size-48 size-48 size-48"
                       >
                         <div
                           class="inner inner inner inner"

--- a/packages/international-phone-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/international-phone-input/src/__snapshots__/Component.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`InternationalPhoneInput should match snapshot 1`] = `
             tabindex="-1"
           >
             <div
-              class="component size-48"
+              class="component size-56"
             >
               <div
                 aria-controls="downshift-:r0:-menu"
@@ -63,7 +63,7 @@ exports[`InternationalPhoneInput should match snapshot 1`] = `
                   </span>
                 </span>
                 <svg
-                  class="arrow size-48"
+                  class="arrow size-56"
                   fill="currentColor"
                   focusable="false"
                   height="24"

--- a/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
+++ b/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
@@ -201,6 +201,7 @@ export const BaseInternationalPhoneInput = forwardRef<
                 fieldWidth={inputWrapperRef.current?.getBoundingClientRect().width}
                 onOpen={handleCountrySelectOpen}
                 open={showCountrySelect}
+                size={size}
             />
         );
 

--- a/packages/international-phone-input/src/components/country-select/Component.tsx
+++ b/packages/international-phone-input/src/components/country-select/Component.tsx
@@ -1,4 +1,5 @@
 import React, { ElementType, useCallback, useMemo } from 'react';
+import cn from 'classnames';
 
 import {
     BaseOption,
@@ -9,6 +10,7 @@ import {
 import { getDataTestId } from '@alfalab/core-components-shared';
 import { WorldMagnifierMIcon } from '@alfalab/icons-glyph/WorldMagnifierMIcon';
 
+import { SIZE_TO_CLASSNAME_MAP } from '../../consts';
 import { Country } from '../../types';
 import { FlagIcon } from '../flag-icon';
 import { EMPTY_COUNTRY_SELECT_FIELD, SelectField } from '../select-field';
@@ -47,6 +49,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
     onChange,
     view = 'desktop',
     SelectComponent,
+    size,
     ...restProps
 }) => {
     const options = useMemo(
@@ -58,7 +61,12 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
                     key: iso2,
                     value: areas[0],
                     content: (
-                        <span className={styles.option}>
+                        <span
+                            className={cn([
+                                styles.option,
+                                size && styles[SIZE_TO_CLASSNAME_MAP[size]],
+                            ])}
+                        >
                             <FlagIcon country={iso2} className={styles.flag} />
 
                             <span className={styles.optionTextWrap}>
@@ -69,7 +77,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
                     ),
                 };
             }) || [],
-        [countries],
+        [countries, size],
     );
 
     const renderOptionsList = useCallback(
@@ -99,6 +107,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
             <div className={styles.component} onClick={(event) => event.stopPropagation()}>
                 <SelectComponent
                     Option={BaseOption}
+                    size={size}
                     {...restProps}
                     dataTestId={getDataTestId(dataTestId, 'country-select')}
                     options={options}

--- a/packages/international-phone-input/src/components/country-select/index.module.css
+++ b/packages/international-phone-input/src/components/country-select/index.module.css
@@ -11,6 +11,10 @@
     display: flex;
     align-items: flex-start;
     padding: var(--gap-12);
+
+    &.size-72 {
+        padding-left: var(--gap-16);
+    }
 }
 
 .flag {

--- a/packages/international-phone-input/src/components/select-field/component.tsx
+++ b/packages/international-phone-input/src/components/select-field/component.tsx
@@ -6,6 +6,7 @@ import type { FieldProps } from '@alfalab/core-components-select/shared';
 import { useFocus } from '@alfalab/hooks';
 import { WorldMagnifierMIcon } from '@alfalab/icons-glyph/WorldMagnifierMIcon';
 
+import { SIZE_TO_CLASSNAME_MAP } from '../../consts';
 import { FlagIcon } from '../flag-icon';
 
 import styles from './index.module.css';
@@ -17,17 +18,6 @@ export const EMPTY_COUNTRY_SELECT_FIELD = {
 
 type SelectFieldProps = FieldProps & {
     size?: 's' | 'm' | 'l' | 'xl' | 48 | 56 | 64 | 72;
-};
-
-const SIZE_TO_CLASSNAME_MAP = {
-    s: 'size-48',
-    m: 'size-56',
-    l: 'size-64',
-    xl: 'size-72',
-    48: 'size-48',
-    56: 'size-56',
-    64: 'size-64',
-    72: 'size-72',
 };
 
 export const SelectField: FC<SelectFieldProps> = ({

--- a/packages/international-phone-input/src/consts.ts
+++ b/packages/international-phone-input/src/consts.ts
@@ -1,1 +1,13 @@
 export const DEFAULT_PHONE_FORMAT = '... ... ... ... ...';
+
+export const SIZE_TO_CLASSNAME_MAP = {
+    s: 'size-48',
+    m: 'size-56',
+    l: 'size-64',
+    xl: 'size-72',
+    40: 'size-40',
+    48: 'size-48',
+    56: 'size-56',
+    64: 'size-64',
+    72: 'size-72',
+};

--- a/packages/select/src/components/base-option/Component.tsx
+++ b/packages/select/src/components/base-option/Component.tsx
@@ -1,6 +1,7 @@
 import React, { FC, isValidElement } from 'react';
 import cn from 'classnames';
 
+import { SIZE_TO_CLASSNAME_MAP } from '../../consts';
 import { OptionProps } from '../../typings';
 import { BaseCheckmark } from '../base-checkmark';
 
@@ -20,6 +21,7 @@ export const BaseOption: FC<OptionProps> = ({
     innerProps,
     dataTestId,
     mobile = false,
+    size = 48,
 }) => {
     const content = children || option.content || option.key;
     const { showCheckMark = true } = option;
@@ -48,7 +50,7 @@ export const BaseOption: FC<OptionProps> = ({
     return (
         <div
             {...innerProps}
-            className={cn(styles.option, className, {
+            className={cn(styles.option, styles[SIZE_TO_CLASSNAME_MAP[size]], className, {
                 [styles.highlighted]: !mobile && highlighted,
                 [styles.selected]: selected,
                 [styles.disabled]: disabled,

--- a/packages/select/src/components/base-option/index.module.css
+++ b/packages/select/src/components/base-option/index.module.css
@@ -30,6 +30,10 @@
     &.checkmarkAfter.checkmarkAfter {
         padding: var(--gap-0) var(--gap-12) var(--gap-0) var(--gap-0);
 
+        &.size-72 {
+            padding-right: var(--gap-16);
+        }
+
         &.mobile {
             padding-right: var(--gap-20);
         }
@@ -37,6 +41,11 @@
 
     &.textContent {
         padding: var(--gap-12);
+
+        &.size-72 {
+            padding-left: var(--gap-16);
+            padding-right: var(--gap-16);
+        }
 
         &.mobile {
             padding: var(--gap-16) var(--gap-20) var(--gap-16) var(--gap-16);

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -24,6 +24,7 @@ import {
 import { fnUtils, getDataTestId } from '@alfalab/core-components-shared';
 import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
+import { SIZE_TO_CLASSNAME_MAP } from '../../consts';
 import type { AnyObject, OptionShape, OptionsListProps, SearchProps } from '../../typings';
 import {
     defaultAccessor,
@@ -564,10 +565,14 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
                     onChange={handleChange}
                     dataTestId={getDataTestId(dataTestId, 'search')}
                     onClear={handleClear}
-                    className={cn(searchProps?.componentProps?.className, {
-                        [styles.search]: view === 'desktop',
-                        [mobileStyles.search]: view === 'mobile',
-                    })}
+                    className={cn(
+                        searchProps?.componentProps?.className,
+                        {
+                            [styles.search]: view === 'desktop',
+                            [mobileStyles.search]: view === 'mobile',
+                        },
+                        size && styles[SIZE_TO_CLASSNAME_MAP[size]],
+                    )}
                     ref={mergeRefs([searchRef, searchProps?.componentProps?.ref || null])}
                 />
             );

--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -69,6 +69,11 @@
 .search {
     margin: var(--gap-12) var(--gap-12) var(--gap-0);
 
+    &.size-72 {
+        margin-left: var(--gap-16);
+        margin-right: var(--gap-16);
+    }
+
     &:last-child {
         margin-bottom: var(--gap-12);
     }

--- a/packages/select/src/components/search/index.module.css
+++ b/packages/select/src/components/search/index.module.css
@@ -4,3 +4,7 @@
 .component.component {
     width: auto;
 }
+
+.size-72 {
+    padding: var(--gap-0) var(--gap-16);
+}

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/Component.tsx
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/Component.tsx
@@ -39,6 +39,7 @@ export const OptionsListWithApply = forwardRef<HTMLDivElement, OptionsListWithAp
             header,
             headerProps,
             setSelectedDraft,
+            size,
             ...restProps
         }: OptionsListWithApplyProps,
         ref,
@@ -98,7 +99,7 @@ export const OptionsListWithApply = forwardRef<HTMLDivElement, OptionsListWithAp
                 <React.Fragment>
                     {header}
                     {showHeaderWithSelectAll && flatOptions.length > 0 && (
-                        <Header {...headerProps} />
+                        <Header {...headerProps} size={size} />
                     )}
                 </React.Fragment>
             );
@@ -107,6 +108,7 @@ export const OptionsListWithApply = forwardRef<HTMLDivElement, OptionsListWithAp
         return (
             <OptionsList
                 {...restProps}
+                size={size}
                 ref={ref}
                 visibleOptions={visibleOptions}
                 toggleMenu={toggleMenu}
@@ -124,6 +126,7 @@ export const OptionsListWithApply = forwardRef<HTMLDivElement, OptionsListWithAp
                         showClear={showClear}
                         selectedDraft={selectedDraft}
                         dataTestId={restProps?.dataTestId}
+                        size={size}
                     />
                 }
             />

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/footer/Component.tsx
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/footer/Component.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import cn from 'classnames';
 
 import { ButtonDesktop } from '@alfalab/core-components-button/desktop';
 import { getDataTestId } from '@alfalab/core-components-shared';
 
-import { OptionShape } from '../../../../typings';
+import { SIZE_TO_CLASSNAME_MAP } from '../../../../consts';
+import { OptionShape, OptionsListProps } from '../../../../typings';
 
 import styles from './index.module.css';
 
@@ -13,6 +15,7 @@ export type FooterProps = {
     showClear?: boolean;
     selectedDraft?: OptionShape[];
     dataTestId?: string;
+    size?: OptionsListProps['size'];
 };
 
 export const Footer = ({
@@ -21,11 +24,12 @@ export const Footer = ({
     showClear,
     selectedDraft = [],
     dataTestId,
+    size,
 }: FooterProps) => (
     <div
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        className={styles.footer}
+        className={cn(styles.footer, size && styles[SIZE_TO_CLASSNAME_MAP[size]])}
     >
         <ButtonDesktop
             size={32}

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/footer/index.module.css
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/footer/index.module.css
@@ -6,6 +6,10 @@
     padding: var(--gap-12);
     outline: none;
 
+    &.size-72 {
+        padding: var(--gap-12) var(--gap-16);
+    }
+
     & > .button + .button {
         margin-left: var(--select-option-list-footer-button-gap);
     }

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/header/Component.tsx
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/header/Component.tsx
@@ -3,6 +3,9 @@ import cn from 'classnames';
 
 import { Checkbox, CheckboxProps } from '@alfalab/core-components-checkbox';
 
+import { SIZE_TO_CLASSNAME_MAP } from '../../../../consts';
+import { OptionsListProps } from '../../../../typings';
+
 import styles from './index.module.css';
 
 export type HeaderProps = {
@@ -11,6 +14,7 @@ export type HeaderProps = {
     onChange?: CheckboxProps['onChange'];
     mobile?: boolean;
     dataTestId?: string;
+    size?: OptionsListProps['size'];
 };
 
 export const Header: React.FC<HeaderProps> = ({
@@ -19,8 +23,14 @@ export const Header: React.FC<HeaderProps> = ({
     indeterminate,
     mobile,
     dataTestId,
+    size,
 }) => (
-    <div className={cn({ [styles.desktop]: !mobile, [styles.mobile]: mobile })}>
+    <div
+        className={cn(size && styles[SIZE_TO_CLASSNAME_MAP[size]], {
+            [styles.desktop]: !mobile,
+            [styles.mobile]: mobile,
+        })}
+    >
         <Checkbox
             block={true}
             indeterminate={indeterminate}

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/header/index.module.css
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/header/index.module.css
@@ -2,6 +2,9 @@
 
 .desktop {
     padding: var(--gap-12);
+    &.size-72 {
+        padding-left: var(--gap-16);
+    }
 }
 
 .mobile {


### PR DESCRIPTION
Для international-phone-input размера XL горизонтальные паддинги исправлены на 16px в соответствии с дизайном

# Чек лист
- [X] Задача сформулирована и описана в JIRA
- [X] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [X] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [X] Код покрыт тестами и протестирован в различных браузерах
- [X] Добавленные пропсы добавлены в демки и описаны в документации
- [ ] К реквесту добавлен changeset

Если есть визуальные изменения
- [X] Прикреплено изображение было/стало
![Было](https://github.com/user-attachments/assets/eafeef5b-1cfd-470e-8752-922a634e5684)
![Стало](https://github.com/user-attachments/assets/3de5906d-ae6d-4a42-b1e7-2cac784f2455)

