### PR TITLE
refactor(dropzone): get rid of 'overlayVisible' prop

### DIFF
--- a/.changeset/large-boxes-confess.md
+++ b/.changeset/large-boxes-confess.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components': major
+'@alfalab/core-components-dropzone': major
+---
+
+Удален пропс `overlayVisible`, который был помечен как `deprecated` в core-components@15.x.x

--- a/packages/dropzone/src/Component.tsx
+++ b/packages/dropzone/src/Component.tsx
@@ -45,12 +45,6 @@ export type DropzoneProps = {
     block?: boolean;
 
     /**
-     * @deprecated(используйте Overlay)
-     * Позволяет вручную управлять видимостью заглушки
-     */
-    overlayVisible?: boolean;
-
-    /**
      * Компонент оверлея
      */
     Overlay?: ComponentType<OverlayProps>;
@@ -92,7 +86,6 @@ export const Dropzone: FC<DropzoneProps> = ({
     children,
     text = 'Перетащите файлы',
     error = false,
-    overlayVisible,
     Overlay = DefaultOverlay,
     onDragEnter,
     onDragLeave,
@@ -110,7 +103,7 @@ export const Dropzone: FC<DropzoneProps> = ({
      */
     const dragCounter = useRef(0);
 
-    const isOverlayVisible = Boolean(dragOver || overlayVisible);
+    const isOverlayVisible = Boolean(dragOver);
 
     const handleDragOver = useCallback(
         (event: React.DragEvent<HTMLElement>) => {

--- a/packages/dropzone/src/docs/Component.stories.tsx
+++ b/packages/dropzone/src/docs/Component.stories.tsx
@@ -43,7 +43,6 @@ export const dropzone: Story = {
                     <Dropzone
                         error={boolean('error', false)}
                         block={boolean('block', false)}
-                        overlayVisible={boolean('overlayVisible (deprecated)', undefined)}
                         disabled={boolean('disabled', false)}
                         onDrop={handleDrop}
                     >


### PR DESCRIPTION
Удален пропс `overlayVisible`, который был помечен как `deprecated` в core-components@15.x.x