### PR TITLE
refactor(circular-progress-bar): get rid of letter sizes

### DIFF
--- a/.changeset/thick-laws-search.md
+++ b/.changeset/thick-laws-search.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components': major
+'@alfalab/core-components-circular-progress-bar': major
+---
+
+Удалены буквенные размеры компонента, которые были отмечены как deprecated в core-components@44.x.x

--- a/packages/circular-progress-bar/src/Component.tsx
+++ b/packages/circular-progress-bar/src/Component.tsx
@@ -27,7 +27,6 @@ export type CircularProgressBarProps = {
     /**
      * Уровень прогресса, %
      */
-
     value:
         | number
         | {
@@ -98,8 +97,7 @@ export type CircularProgressBarProps = {
     view?: 'positive' | 'negative';
 
     /**
-     * Размер (xxl — 144×144px, xl — 128×128px, l — 80×80px, m — 64×64px, s — 48×48px, xs — 24×24px)
-     * @description xs, s, m, l, xl, xxl deprecated, используйте вместо них 24, 48, 64, 80, 128, 144 соответственно
+     * Размер (144 — 144×144px, 128 — 128×128px, 80 — 80×80px, 64 — 64×64px, 48 — 48×48px, 24 — 24×24px)
      * @default 64
      */
     size?: ComponentSize;
@@ -142,12 +140,12 @@ export type CircularProgressBarProps = {
     /**
      * Высота компонента, min = 24; max = 144
      * использовать совместно с size :
-     * xxl от 144
-     * xl  от 128 до 143
-     * l   от 80 до 127
-     * m   от 64 до 79
-     * s   от 48 до 63
-     * xs  от 24 до 47
+     * 144 от 144
+     * 128 от 128 до 143
+     * 80 от 80 до 127
+     * 64 от 64 до 79
+     * 48 от 48 до 63
+     * 24 от 24 до 47
      */
     height?: number;
 

--- a/packages/circular-progress-bar/src/types/component-size.ts
+++ b/packages/circular-progress-bar/src/types/component-size.ts
@@ -1,1 +1,1 @@
-export type ComponentSize = 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs' | 24 | 48 | 64 | 80 | 128 | 144;
+export type ComponentSize = 24 | 48 | 64 | 80 | 128 | 144;

--- a/packages/generic-wrapper/src/docs/description.mdx
+++ b/packages/generic-wrapper/src/docs/description.mdx
@@ -128,7 +128,7 @@ render(() => {
                 <Typography.Text>30 600,90 ₽</Typography.Text>
             </GenericWrapper>
             <GenericWrapper>
-                <CircularProgressBar value={25} subtitle='дней' size='l' />
+                <CircularProgressBar value={25} subtitle='дней' size={80} />
             </GenericWrapper>
         </GenericWrapper>
         <Gap size={20} />


### PR DESCRIPTION
Удалены буквенные размеры компонента, которые были отмечены как deprecated в core-components@44.x.x