### PR TITLE
fix(icon-view): fix rectangle background position

### DIFF
--- a/.changeset/new-rockets-bathe.md
+++ b/.changeset/new-rockets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-icon-view': patch
+---
+
+Исправлено положение фона для Rectangle

--- a/packages/icon-view/src/components/rectangle/component.tsx
+++ b/packages/icon-view/src/components/rectangle/component.tsx
@@ -30,9 +30,9 @@ const heights: Record<Required<RectangleProps>['size'], number> = {
     48: 34,
     56: 40,
     64: 46,
-    72: 56,
+    72: 52,
     80: 58,
-    128: 94,
+    128: 92,
 };
 
 export const Rectangle = forwardRef<HTMLDivElement, RectangleProps>(


### PR DESCRIPTION
Исправлена высота для некоторых фонов shape = Rectangle. 

Проблема была связана с тем, что значение height не соответствовало реальной высоте фона, path фона выравнивался по верхнему краю svg

| Было | Стало |
|------|-------|
|<img width="392" alt="before2" src="https://github.com/user-attachments/assets/96fa9202-456a-439f-96ab-51fff1c35eb5" /> |  <img width="418" alt="after2" src="https://github.com/user-attachments/assets/616022fd-14a4-47cf-abc0-e958a4cc88ce" />|

### Было:
<img width="858" alt="before1" src="https://github.com/user-attachments/assets/e5293071-98b9-45bf-931f-efa4faf67ecc" />

### Стало:
<img width="834" alt="after1" src="https://github.com/user-attachments/assets/6d737dbd-c9d2-41b7-b1f2-94ce5e492a0e" />


