### PR TITLE
[DRAFT] feat(SliderInput): added bold props

### DIFF
--- a/packages/slider-input/src/Component.tsx
+++ b/packages/slider-input/src/Component.tsx
@@ -73,6 +73,11 @@ export type SliderInputProps = Omit<
     value?: number | string;
 
     /**
+     * Жирность текста инпута
+     */
+    bold?: boolean;
+
+    /**
      * Значение слайдера
      */
     sliderValue?: number;
@@ -159,6 +164,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
             focusedClassName,
             fieldClassName,
             value = '',
+            bold = true,
             min = 0,
             max = 100,
             step = 1,
@@ -253,6 +259,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                         [styles.filled]: Boolean(value),
                         [styles.hasLabel]: label,
                         [styles.hasError]: Boolean(error),
+                        [styles.bold]: bold,
                     },
                     styles[SIZE_TO_CLASSNAME_MAP[size]],
                     className,

--- a/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SliderInput should match snapshot 1`] = `
 <div>
   <div
-    class="component size-48"
+    class="component bold size-48"
   >
     <div
       class="component component input size-48 size-48 block"

--- a/packages/slider-input/src/docs/Component.stories.tsx
+++ b/packages/slider-input/src/docs/Component.stories.tsx
@@ -23,6 +23,7 @@ export const slider_input: Story = {
                 min={number('min', 0)}
                 max={number('max', 100)}
                 step={number('step', 1)}
+                bold={boolean('bold', true)}
                 pips={
                     boolean('pips', false) && {
                         mode: 'values',

--- a/packages/slider-input/src/docs/description.mdx
+++ b/packages/slider-input/src/docs/description.mdx
@@ -190,6 +190,46 @@ render(() => {
 });
 ```
 
+## Bold
+
+Можно установить жирность текста инпута. По умолчанию - жирный.
+
+```jsx live
+render(() => {
+    const [value, setValue] = React.useState(5);
+    const [bold, setBold] = React.useState(true);
+
+    return (
+        <div style={{ width: isMobile() ? '100%' : 320 }}>
+            <SliderInput
+                value={value}
+                label='Label'
+                labelView={isMobile() ? 'outer' : 'inner'}
+                size={isMobile() ? 48 : 56}
+                pips={{
+                    mode: 'values',
+                    values: [1, 10 / 2, 10],
+                }}
+                min={1}
+                max={10}
+                step={1}
+                block={true}
+                bold={bold}
+                onChange={(_, { value }) => setValue(value)}
+                breakpoint={BREAKPOINT}
+            />
+            <Gap size='xl' />
+            <Switch
+                block={true}
+                checked={bold}
+                label='Жирность текста'
+                onChange={() => setBold((prev) => !prev)}
+            />
+        </div>
+    );
+});
+```
+
 ## Морфология
 
 Поле ввода является оберткой над [FormControl](?path=/docs/formcontrol--docs),

--- a/packages/slider-input/src/index.module.css
+++ b/packages/slider-input/src/index.module.css
@@ -98,12 +98,20 @@
 .input {
     & input,
     & input + div {
-        font-weight: var(--slider-input-font-weight);
         font-variant-numeric: tabular-nums;
     }
 
     & input::placeholder {
         font-weight: 400;
+    }
+}
+
+.bold {
+    .input {
+        & input,
+        & input + div {
+            font-weight: var(--slider-input-font-weight);
+        }
     }
 }
 


### PR DESCRIPTION
Доработка в рамках задачи https://jira.moscow.alfaintra.net/browse/DS-7659
В компонент SliderInput добавлен опциональный пропс bold, включённый по дефолту и не меняющий текущего внешнего вида компонента (font-weight остаётся в размере 700). При выключении пропса используется вес шрифта по-умолчанию (400). В описание добавлен пример с использованием нового пропса.

# Чек лист
- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [ ] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [ ] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
