### PR TITLE
fix(universal-modal): improve closing (DS-10314)

### DIFF
--- a/.changeset/two-colts-march.md
+++ b/.changeset/two-colts-march.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-universal-modal': patch
+---
+
+Исправлено закрытие модалки при использовании пропса `hasCloser`. Теперь не нужно прокидывать `onClose` компоненту `Header` - хэндлер будет браться с компонента `UniversalModal`

--- a/packages/universal-modal/src/Component.test.tsx
+++ b/packages/universal-modal/src/Component.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getUniversalModalTestIds } from './utils/getUniversalModalTestIds';
 import { UniversalModalResponsive } from './Component.responsive';
+import { UniversalModalDesktop } from './desktop';
 
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -31,9 +32,9 @@ describe('UniversalModal', () => {
     it('should have data-test-id', () => {
         const dti = 'modal-dti';
 
-        const { getByTestId } = render(
+        render(
             <UniversalModalResponsive dataTestId={dti} open={true}>
-                <UniversalModalResponsive.Header title='Title' dataTestId={dti} />
+                <UniversalModalResponsive.Header title='Title' dataTestId={dti} hasCloser={true} />
                 <UniversalModalResponsive.Content dataTestId={dti} />
                 <UniversalModalResponsive.Footer dataTestId={dti} />
             </UniversalModalResponsive>,
@@ -41,10 +42,73 @@ describe('UniversalModal', () => {
 
         const testIds = getUniversalModalTestIds(dti);
 
-        expect(getByTestId(testIds.modal)).toBeInTheDocument();
-        expect(getByTestId(testIds.header)).toBeInTheDocument();
-        expect(getByTestId(testIds.title)).toBeInTheDocument();
-        expect(getByTestId(testIds.content)).toBeInTheDocument();
-        expect(getByTestId(testIds.footer)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.modal)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.header)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.title)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.content)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.footer)).toBeInTheDocument();
+        expect(screen.getByTestId(testIds.closer)).toBeInTheDocument();
+    });
+
+    describe('interactive tests', () => {
+        it('should close by context "onClose"', async () => {
+            const dti = 'modal-dti';
+            const handleClose = jest.fn();
+
+            render(
+                <UniversalModalDesktop dataTestId={dti} open={true} onClose={handleClose}>
+                    <UniversalModalDesktop.Header title='Title' dataTestId={dti} hasCloser={true} />
+                </UniversalModalDesktop>,
+            );
+
+            const closer = screen.getByTestId(getUniversalModalTestIds(dti).closer);
+            fireEvent.click(closer);
+
+            expect(handleClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should close by header "onClose"', async () => {
+            const dti = 'modal-dti';
+            const handleClose = jest.fn();
+
+            render(
+                <UniversalModalDesktop dataTestId={dti} open={true}>
+                    <UniversalModalDesktop.Header
+                        title='Title'
+                        dataTestId={dti}
+                        hasCloser={true}
+                        onClose={handleClose}
+                    />
+                </UniversalModalDesktop>,
+            );
+
+            const closer = screen.getByTestId(getUniversalModalTestIds(dti).closer);
+            fireEvent.click(closer);
+
+            expect(handleClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should close by priority', async () => {
+            const dti = 'modal-dti';
+            const handleCloseContext = jest.fn();
+            const handleClose = jest.fn();
+
+            render(
+                <UniversalModalDesktop dataTestId={dti} open={true} onClose={handleCloseContext}>
+                    <UniversalModalDesktop.Header
+                        title='Title'
+                        dataTestId={dti}
+                        hasCloser={true}
+                        onClose={handleClose}
+                    />
+                </UniversalModalDesktop>,
+            );
+
+            const closer = screen.getByTestId(getUniversalModalTestIds(dti).closer);
+            fireEvent.click(closer);
+
+            expect(handleCloseContext).toHaveBeenCalledTimes(0);
+            expect(handleClose).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/universal-modal/src/components/header/desktop/Component.desktop.tsx
+++ b/packages/universal-modal/src/components/header/desktop/Component.desktop.tsx
@@ -34,14 +34,23 @@ export const HeaderDesktop: FC<HeaderDesktopProps> = ({
     titleClassName,
     dataTestId,
     bottomAddonsClassName,
+    onClose,
     ...restProps
 }) => {
-    const { setHasHeader, componentRef } = useContext(ModalContext);
+    const { setHasHeader, componentRef, onClose: handleCloseByContext } = useContext(ModalContext);
     const { modalHeaderHighlighted } = useContext(ResponsiveContext) || {};
 
     const titleRef = useRef<HTMLDivElement>(null);
 
     const hasContent = Boolean(title || children || restProps.bottomAddons);
+
+    const handleClose: NavigationBarPrivateProps['onClose'] = (...args) => {
+        if (onClose) {
+            return onClose(...args);
+        }
+
+        return handleCloseByContext(...args);
+    };
 
     useEffect(() => {
         setHasHeader(true);
@@ -70,6 +79,7 @@ export const HeaderDesktop: FC<HeaderDesktopProps> = ({
                 [desktopStyles.medium]: bigTitle,
             })}
             titleRef={titleRef}
+            onClose={handleClose}
         >
             {children}
         </NavigationBarPrivate>

--- a/packages/universal-modal/src/docs/development.mdx
+++ b/packages/universal-modal/src/docs/development.mdx
@@ -90,6 +90,7 @@ import { ArrowButtonDesktopMobile, CrossButtonDesktopMobile } from '@alfalab/cor
         title: `${dataTestId}-header-title`,
         content: `${dataTestId}-content`,
         footer: `${dataTestId}-footer`,
+        closer: `${dataTestId}-header-closer`,
 };
 ```
 

--- a/packages/universal-modal/src/utils/getUniversalModalTestIds.ts
+++ b/packages/universal-modal/src/utils/getUniversalModalTestIds.ts
@@ -7,5 +7,6 @@ export function getUniversalModalTestIds(dataTestId: string) {
         header: getDataTestId(dataTestId, 'header'),
         content: getDataTestId(dataTestId, 'content'),
         footer: getDataTestId(dataTestId, 'footer'),
+        closer: getDataTestId(dataTestId, 'header-closer'),
     };
 }


### PR DESCRIPTION
DS-10314

Фикс закрытия universal-modal
Ранее при использовании пропса hasCloser нужно было отдельно в компонент хэдера прокидывать onClose. Теперь onClose будет браться с компонента модалки (как в Modal и SidePanel)