### PR TITLE
fix: add fallback padding for devices without bottom safe area

### DIFF
--- a/packages/modal/src/components/footer/mobile.module.css
+++ b/packages/modal/src/components/footer/mobile.module.css
@@ -5,7 +5,7 @@
     padding: var(--gap-16);
 
     @media (display-mode: standalone) {
-        padding-bottom: var(--sab);
+        padding-bottom: max(var(--sab), var(--gap-16));
     }
 }
 

--- a/packages/side-panel/src/components/footer/mobile.module.css
+++ b/packages/side-panel/src/components/footer/mobile.module.css
@@ -5,7 +5,7 @@
     padding: var(--gap-16);
 
     @media (display-mode: standalone) {
-        padding-bottom: var(--sab);
+        padding-bottom: max(var(--sab), var(--gap-16));
     }
 }
 


### PR DESCRIPTION
Фолбэк для отступа, если нет нижней safe area. Например, для айфонов с Touch ID

# Чек лист
- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [ ] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [ ] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
