### PR TITLE
refactor(tooltip): get rid of deprecated props

### DIFF
--- a/.changeset/tame-dancers-grow.md
+++ b/.changeset/tame-dancers-grow.md
@@ -1,0 +1,7 @@
+---
+'@alfalab/core-components': major
+'@alfalab/core-components-gallery': major
+'@alfalab/core-components-tooltip': major
+---
+
+Удалён пропс `hasCloser`, который был отмечен как deprecated в core-components@27.x.x. Используйте вместо него `bottomSheetProps.hasCloser`

--- a/packages/tooltip/src/docs/Component.stories.tsx
+++ b/packages/tooltip/src/docs/Component.stories.tsx
@@ -131,7 +131,6 @@ export const tooltip_responsive: Story = {
                     fallbackPlacements={['bottom', 'top']}
                     actionButtonTitle={text('title', 'Хорошо')}
                     view={select('view', ['tooltip', 'hint'], 'tooltip')}
-                    hasCloser={select('hasCloser', [true, false], false)}
                 >
                     <div style={{ padding: '15px', border: '1px dashed rgba(0, 0, 0, 0.1)' }}>
                         Подробнее

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -194,12 +194,6 @@ export type TooltipResponsiveProps = Omit<TooltipDesktopProps, 'onClose' | 'onOp
     actionButtonTitle?: string;
 
     /**
-     * Наличие компонента крестика
-     * @deprecated(используйте bottomSheetProps.hasCloser)
-     */
-    hasCloser?: boolean;
-
-    /**
      *  Дополнительные пропсы компонента BottomSheet
      */
     bottomSheetProps?: Partial<BottomSheetProps>;


### PR DESCRIPTION
Удалён пропс `hasCloser`, который был отмечен как deprecated в core-components@27.x.x. Используйте вместо него `bottomSheetProps.hasCloser`
