### PR TITLE
refactor(pure-cell): get rid of deprecated

### DIFF
--- a/.changeset/shy-ducks-help.md
+++ b/.changeset/shy-ducks-help.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pure-cell': major
+---
+
+Удален пропс `color` для `amount-title` который был отмечен как `deprecated` в  core-components@42.x.x. Вместо него используйте `titleProps.color`

--- a/packages/pure-cell/src/components/amount-title/component.tsx
+++ b/packages/pure-cell/src/components/amount-title/component.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 
 import { Amount as CoreAmount } from '@alfalab/core-components-amount';
 import { getDataTestId } from '@alfalab/core-components-shared';
-import { type Color, type TitleProps, TitleResponsive } from '@alfalab/core-components-typography';
+import { type TitleProps, TitleResponsive } from '@alfalab/core-components-typography';
 
 import { PureCellContext } from '../../component';
 import { AmountProps as AmountType } from '../typesProps';
@@ -11,12 +11,6 @@ import { AmountProps as AmountType } from '../typesProps';
 import styles from './index.module.css';
 
 type Props = {
-    /**
-     * Цвет денежного значения
-     * @deprecated Используйте titleProps.color
-     */
-    color?: Color;
-
     /**
      * Пропсы, которые будут прокинуты в компонент типографики
      */
@@ -39,7 +33,6 @@ export const AmountTitle: React.FC<Props> = ({
     minorUnits = 100,
     hidden,
     className,
-    color = 'primary',
     dataTestId,
     titleProps: titlePropsFromProps = {},
     ...restProps
@@ -49,7 +42,6 @@ export const AmountTitle: React.FC<Props> = ({
     const titleProps = {
         tag: 'h4',
         view: 'small',
-        color,
         ...titlePropsFromProps,
     } as Omit<TitleProps, 'className' | 'dataTestId'>;
 


### PR DESCRIPTION
Удален пропс `color` для `amount-title` который был отмечен как `deprecated` в  core-components@42.x.x. Вместо него используйте `titleProps.color`
