### PR TITLE
refactor(segmented-control): get rid of deprecated

### DIFF
--- a/.changeset/clever-melons-love.md
+++ b/.changeset/clever-melons-love.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-segmented-control': major
+---
+
+Удалены буквенные размеры компонента, которые были отмечены как `deprecated` в core-components@44.x.x

--- a/packages/segmented-control/src/Component.tsx
+++ b/packages/segmented-control/src/Component.tsx
@@ -33,9 +33,9 @@ export type SegmentedControlProps = {
 
     /**
      * Размер компонента
-     * @description xs, xxs deprecated, используйте вместо них 40, 32 соответственно
+     * @default 32
      */
-    size?: 'xs' | 'xxs' | 32 | 40;
+    size?: 32 | 40;
 
     /**
      * Форма компонента
@@ -70,13 +70,6 @@ export type SegmentedControlProps = {
 };
 
 const MAX_SEGMENTS = 5;
-
-export const SIZE_TO_CLASSNAME_MAP = {
-    xxs: 'size-32',
-    xs: 'size-40',
-    32: 'size-32',
-    40: 'size-40',
-};
 
 export const SegmentedControl: FC<SegmentedControlProps> = ({
     className,
@@ -141,7 +134,7 @@ export const SegmentedControl: FC<SegmentedControlProps> = ({
                         styles.wrapper,
                         colorStyles[colors].wrapper,
                         styles[shape],
-                        styles[SIZE_TO_CLASSNAME_MAP[size]],
+                        styles[`size-${size}`],
                         {
                             [styles.disabled]: disabled,
                         },


### PR DESCRIPTION
Удалены буквенные размеры компонента, которые были отмечены как `deprecated` в core-components@44.x.x