### PR TITLE
refactor(slider): get rid of deprecated

### DIFF
--- a/.changeset/orange-rice-float.md
+++ b/.changeset/orange-rice-float.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-slider': major
+---
+
+Удалены буквенные размеры компонента, которые были отмечены как `deprecated` в core-components@44.x.x

--- a/packages/slider/src/Component.tsx
+++ b/packages/slider/src/Component.tsx
@@ -80,9 +80,9 @@ export type SliderProps = {
 
     /**
      * Размер
-     * @description s, m deprecated, используйте вместо них 2, 4 соответственно
+     * @default 2
      */
-    size?: 's' | 'm' | 2 | 4;
+    size?: 2 | 4;
 
     /**
      * Обработчик поля ввода
@@ -105,13 +105,6 @@ export type SliderProps = {
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
-};
-
-export const SIZE_TO_CLASSNAME_MAP = {
-    s: 'size-2',
-    m: 'size-4',
-    2: 'size-2',
-    4: 'size-4',
 };
 
 export const Slider: FC<SliderProps> = ({
@@ -234,7 +227,7 @@ export const Slider: FC<SliderProps> = ({
 
     return (
         <div
-            className={cn(styles.component, className, styles[SIZE_TO_CLASSNAME_MAP[size]])}
+            className={cn(styles.component, className, styles[`size-${size}`])}
             ref={sliderRef}
             data-test-id={dataTestId}
             {...{ disabled }}


### PR DESCRIPTION
Удалены буквенные размеры компонента, которые были отмечены как `deprecated` в core-components@44.x.x