### PR TITLE
refactor(switch): get rid of deprecated

### DIFF
--- a/.changeset/wise-buttons-sort.md
+++ b/.changeset/wise-buttons-sort.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-switch': major
+---
+
+Удалён пропс `inactive`, который был отмечен как `deprecated` в core-components@43.x.x. Вместо него используйте пропс `disabled`

--- a/packages/switch/src/Component.test.tsx
+++ b/packages/switch/src/Component.test.tsx
@@ -108,10 +108,10 @@ describe('Switch', () => {
             expect(cb).not.toBeCalled();
         });
 
-        test('should not call `onChange` prop if inactive', () => {
+        test('should not call `onChange` prop if disabled', () => {
             const cb = jest.fn();
 
-            const { container } = render(<Switch onChange={cb} inactive={true} />);
+            const { container } = render(<Switch onChange={cb} disabled={true} />);
 
             if (container.firstElementChild) {
                 fireEvent.click(container.firstElementChild);
@@ -120,10 +120,10 @@ describe('Switch', () => {
             expect(cb).not.toBeCalled();
         });
 
-        test('should not call `onChange` prop if inactive and checked', () => {
+        test('should not call `onChange` prop if disabled and checked', () => {
             const cb = jest.fn();
 
-            const { container } = render(<Switch onChange={cb} checked={true} inactive={true} />);
+            const { container } = render(<Switch onChange={cb} checked={true} disabled={true} />);
 
             if (container.firstElementChild) {
                 fireEvent.click(container.firstElementChild);

--- a/packages/switch/src/Component.tsx
+++ b/packages/switch/src/Component.tsx
@@ -63,13 +63,6 @@ export type SwitchProps = Omit<
     disabled?: boolean;
 
     /**
-     * @deprecated данный проп больше не используется, временно оставлен для обратной совместимости
-     * Используйте props disabled
-     * Управление состоянием активен / неактивен
-     */
-    inactive?: boolean;
-
-    /**
      * Отображение ошибки
      */
     error?: ReactNode | boolean;
@@ -106,7 +99,6 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
             addons,
             block,
             disabled,
-            inactive,
             error,
             label,
             hint,
@@ -135,8 +127,8 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
         return (
             <label
                 className={cn(styles.component, styles[align], className, {
-                    [styles.disabled]: disabled || inactive,
-                    [colorStyles[colors].disabled]: disabled || inactive,
+                    [styles.disabled]: disabled,
+                    [colorStyles[colors].disabled]: disabled,
 
                     [styles.checked]: checked,
                     [colorStyles[colors].checked]: checked,
@@ -150,7 +142,7 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
                 <input
                     type='checkbox'
                     onChange={handleChange}
-                    disabled={disabled || inactive}
+                    disabled={disabled}
                     checked={checked}
                     name={name}
                     value={value}

--- a/packages/switch/src/__image_snapshots__/switch-default-theme-snap.png
+++ b/packages/switch/src/__image_snapshots__/switch-default-theme-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06421d5e69bdea35f8dfc6aab742a7bb88eadf808aab203c37df6377fdb53043
-size 41504
+oid sha256:93eafd167a153ea5f991ea267af8eb68609f29bad6c9ffe4f12ed79e0f5ee03e
+size 20477

--- a/packages/switch/src/component.screenshots.test.tsx
+++ b/packages/switch/src/component.screenshots.test.tsx
@@ -39,7 +39,6 @@ describe('Switch', () => {
                             hint: ['', 'Подсказка'],
                             checked: [false, true],
                             disabled: [false, true],
-                            inactive: [false, true],
                         },
                         size: { width: 240, height: 60 },
                     }),

--- a/packages/switch/src/docs/Component.stories.mdx
+++ b/packages/switch/src/docs/Component.stories.mdx
@@ -17,7 +17,6 @@ import Changelog from '../../CHANGELOG.md?raw';
         const [checked, setChecked] = React.useState(false);
         const handleChange = () => setChecked(!checked);
         const disabled = boolean('disabled', false);
-        const inactive = boolean('inactive', false);
         const checkedKnob = boolean('checked', false);
         const reversed = boolean('reversed', false);
         const block = boolean('block', false);
@@ -31,7 +30,6 @@ import Changelog from '../../CHANGELOG.md?raw';
         return (
             <Switch
                 disabled={disabled}
-                inactive={inactive}
                 checked={checked || checkedKnob}
                 reversed={reversed}
                 block={block}


### PR DESCRIPTION
Удалён пропс `inactive`, который был отмечен как `deprecated` в core-components@43.x.x. Вместо него используйте пропс `disabled`
