### PR TITLE
fix(select-with-tags): исключение возможности проброса onClear на div в BaseFormControl

### DIFF
--- a/.changeset/wild-experts-sleep.md
+++ b/.changeset/wild-experts-sleep.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select-with-tags': minor
+---
+
+Исключение возможности проброса onClear через компонент `SelectWithTag` в `BaseFormControl`

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -73,6 +73,7 @@ export const TagList: FC<
     label,
     valueRenderer,
     onInput,
+    onClear,
     handleDeleteTag,
     collapseTagList,
     moveInputToNewLine,


### PR DESCRIPTION
Исключение возможности проброса onClear через компонент `SelectWithTag` в `BaseFormControl`

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
