### PR TITLE
feat(select): allow space in textarea

### DIFF
--- a/.changeset/tame-poets-do.md
+++ b/.changeset/tame-poets-do.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': minor
+---
+
+Разрешен ввод пробелов в textarea

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -402,7 +402,8 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
                 !autocomplete &&
                 !nativeSelect &&
                 (event.target as HTMLElement).tagName !== 'INPUT' &&
-                (event.target as HTMLElement).tagName !== 'BUTTON'
+                (event.target as HTMLElement).tagName !== 'BUTTON' &&
+                (event.target as HTMLElement).tagName !== 'TEXTAREA'
             ) {
                 // Открываем\закрываем меню по нажатию enter или пробела
                 event.preventDefault();


### PR DESCRIPTION
Разрешен ввод пробелов в textarea

Смоделировать баг можно следующим образом:
[Демо проблемы](https://core-ds.github.io/core-components/master/?path=/docs/sandbox--docs/code=const%20OPTIONS%20%3D%20%5B%0A%20%20%20%20%7B%20key%3A%20'1'%2C%20content%3A%20'One%20Two'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'2'%2C%20content%3A%20'Plutonium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'3'%2C%20content%3A%20'Americium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'4'%2C%20content%3A%20'Curium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'5'%2C%20content%3A%20'Berkelium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'6'%2C%20content%3A%20'Californium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'7'%2C%20content%3A%20'Einsteinium'%20%7D%2C%0A%20%20%20%20%7B%20key%3A%20'8'%2C%20content%3A%20'Fermium'%20%7D%2C%0A%5D%3B%0A%0Afunction%20Example()%20%7B%0A%20%20%20%20const%20%5Bcount%2C%20setCount%5D%20%3D%20React.useState(0)%3B%0A%20%20%20%20return%20(%0A%20%20%20%20%20%20%20%20%3Cdiv%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%3CSelectMobile%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20allowUnselect%3D%7Btrue%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20size%3D%7B56%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20options%3D%7BOPTIONS%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20placeholder%3D'%D0%92%D1%8B%D0%B1%D0%B5%D1%80%D0%B8%D1%82%D0%B5%20%D1%8D%D0%BB%D0%B5%D0%BC%D0%B5%D0%BD%D1%82'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20label%3D'%D0%9E%D0%B4%D0%B8%D0%BD%D0%BE%D1%87%D0%BD%D1%8B%D0%B9%20%D0%B2%D1%8B%D0%B1%D0%BE%D1%80'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20block%3D%7Btrue%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20optionsListProps%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20header%3A%20(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CTextarea%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20label%3D%7B'Label'%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20minRows%20%3D%7B2%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20block%3D%7Btrue%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%0A%20%20%20%20)%3B%0A%7D%0Arender(%0A%20%20%20%20%3CExample%20%2F%3E%0A))
1. раскрыть список 
2. в поле, находящемся в хедере списка, попробовать ввести "One Two"

**Ожидаемый результат:**
В поле, в которое мы вводили, мы видим One Two

**Фактический результат:**
После нажатия пробела список закрывается
