### PR TITLE
Добавлена поддержка argb в get-color-var

### DIFF
--- a/.changeset/smart-ants-repair.md
+++ b/.changeset/smart-ants-repair.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-shared': patch
+---
+
+Добавлена поддержка и преобразование argb в rgba у функции get-color-var

--- a/packages/shared/src/get-color-var/get-color-var.ts
+++ b/packages/shared/src/get-color-var/get-color-var.ts
@@ -1,3 +1,4 @@
+import { modifyColor } from './modify-color';
 import { translateColors } from './translatecolors';
 import { Color, HexColor, PaletteColor, Theme } from './types';
 
@@ -63,7 +64,7 @@ export const getColorVar = ({
 
     // Часть 2, проверка на hex
     if (isHexColor(color)) {
-        return color;
+        return modifyColor(color);
     }
 
     // Часть 3, поведение не по схеме: просто отдаём цвет так, как он пришел

--- a/packages/shared/src/get-color-var/modify-color.test.ts
+++ b/packages/shared/src/get-color-var/modify-color.test.ts
@@ -1,0 +1,9 @@
+import { modifyColor } from './modify-color';
+
+describe('modifyColor', () => {
+    it('should convert ARGB color to RGBA format', () => {
+        expect(modifyColor('#FF0000FF')).toBe('rgba(0, 0, 255, 1.00)');
+        expect(modifyColor('#8000FF00')).toBe('rgba(0, 255, 0, 0.50)');
+        expect(modifyColor('#00000000')).toBe('rgba(0, 0, 0, 0.00)');
+    });
+});

--- a/packages/shared/src/get-color-var/modify-color.ts
+++ b/packages/shared/src/get-color-var/modify-color.ts
@@ -8,7 +8,13 @@ export function modifyColor(color: string): string {
         return color;
     }
 
-    const [alpha, red, green, blue] = color.match(/([0-9a-fA-F]{2})/g)!.map((s) => parseInt(s, 16));
+    const matches = color.match(/([0-9a-fA-F]{2})/g);
+
+    if (!matches) {
+        return color;
+    }
+
+    const [alpha, red, green, blue] = matches.map((s) => parseInt(s, 16));
 
     return `rgba(${red}, ${green}, ${blue}, ${(alpha / 255).toFixed(2)})`;
 }

--- a/packages/shared/src/get-color-var/modify-color.ts
+++ b/packages/shared/src/get-color-var/modify-color.ts
@@ -4,17 +4,11 @@
  * @returns Цвет в формате "rgba(r, g, b, a)" для использования в CSS
  */
 export function modifyColor(color: string): string {
-    // Проверяем формат #AARRGGBB (8 символов с решеткой)
-    if (color.startsWith('#') && color.length === 9) {
-        // Извлекаем компоненты цвета
-        const alpha = parseInt(color.slice(1, 3), 16) / 255; // Преобразуем A в десятичное значение от 0 до 1
-        const red = parseInt(color.slice(3, 5), 16);
-        const green = parseInt(color.slice(5, 7), 16);
-        const blue = parseInt(color.slice(7, 9), 16);
-
-        // Возвращаем цвет в формате rgba
-        return `rgba(${red}, ${green}, ${blue}, ${alpha.toFixed(2)})`;
+    if (!/^#([0-9a-fA-F]){8}$/.test(color)) {
+        return color;
     }
 
-    return color;
+    const [alpha, red, green, blue] = color.match(/([0-9a-fA-F]{2})/g)!.map((s) => parseInt(s, 16));
+
+    return `rgba(${red}, ${green}, ${blue}, ${(alpha / 255).toFixed(2)})`;
 }

--- a/packages/shared/src/get-color-var/modify-color.ts
+++ b/packages/shared/src/get-color-var/modify-color.ts
@@ -1,0 +1,20 @@
+/**
+ * Преобразует строку цвета из формата ARGB в формат RGBA для CSS.
+ * @param color Цвет в формате "#AARRGGBB"
+ * @returns Цвет в формате "rgba(r, g, b, a)" для использования в CSS
+ */
+export function modifyColor(color: string): string {
+    // Проверяем формат #AARRGGBB (8 символов с решеткой)
+    if (color.startsWith('#') && color.length === 9) {
+        // Извлекаем компоненты цвета
+        const alpha = parseInt(color.slice(1, 3), 16) / 255; // Преобразуем A в десятичное значение от 0 до 1
+        const red = parseInt(color.slice(3, 5), 16);
+        const green = parseInt(color.slice(5, 7), 16);
+        const blue = parseInt(color.slice(7, 9), 16);
+
+        // Возвращаем цвет в формате rgba
+        return `rgba(${red}, ${green}, ${blue}, ${alpha.toFixed(2)})`;
+    }
+
+    return color;
+}


### PR DESCRIPTION
Миддл может прислать #AARRGGBB формат и функция просто возвращала его. Добавлена функция преобразования такого hex в понятный для веба rgba.