### PR TITLE
fix(international-phone-input): removed unused prop onClear

### DIFF
--- a/.changeset/tasty-falcons-end.md
+++ b/.changeset/tasty-falcons-end.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-international-phone-input': patch
+---
+
+Убран не используемый проп onClear(обработчик можно пробросить в inputProps)

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -101,7 +101,7 @@ export type InternationalPhoneInputDesktopProps = CommonPhoneInputProps &
           >)
         | ({ options: InputAutocompleteDesktopProps['options'] } & Omit<
               InputAutocompleteDesktopProps,
-              'onChange' | 'onInput'
+              'onChange' | 'onInput' | 'onClear'
           >)
     );
 
@@ -113,7 +113,7 @@ export type InternationalPhoneInputMobileProps = CommonPhoneInputProps &
           >)
         | ({ options: InputAutocompleteMobileProps['options'] } & Omit<
               InputAutocompleteMobileProps,
-              'onChange' | 'onInput'
+              'onChange' | 'onInput' | 'onClear'
           >)
     );
 


### PR DESCRIPTION
Кратко сформулируйте суть доработки
В доке и в тс типе есть проп onClear, который вообще не используется в компоненте(обработчик должен добавляться через проп inpurProps). Это вводи пользователей в заблуждение. Теперь этого поля больше нет

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [ x У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
