### PR TITLE
fix(universal-date-input): fix onBlur handler in date-range-input

### DIFF
--- a/.changeset/healthy-buckets-compare.md
+++ b/.changeset/healthy-buckets-compare.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-universal-date-input': patch
+---
+
+Исправлена работа пропса onBlur для date-range варианта при использовании пикера

--- a/packages/universal-date-input/src/Component.test.tsx
+++ b/packages/universal-date-input/src/Component.test.tsx
@@ -4,6 +4,7 @@ import { UniversalDateInputDesktop } from './desktop';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getUniversalDateInputTestIds } from './utils';
+import { Calendar } from '../../calendar/src';
 
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -300,6 +301,26 @@ describe('UniversalDateInput', () => {
                 />,
             );
             expect(input.value).toBe(`12.12.2021${DATE_RANGE_SEPARATOR}13.12.2024`);
+        });
+
+        it('should call onBlur callback', async () => {
+            const onBlur = jest.fn();
+
+            const { queryByRole } = render(
+                <UniversalDateInputDesktop
+                    view='date-range'
+                    onBlur={onBlur}
+                    picker={true}
+                    Calendar={Calendar}
+                />,
+            );
+
+            const input = queryByRole('textbox') as HTMLInputElement;
+
+            await userEvent.click(input);
+            fireEvent.blur(input);
+
+            expect(onBlur).toBeCalledTimes(1);
         });
 
         describe('onInputChange tests', () => {

--- a/packages/universal-date-input/src/components/date-range-input/Component.tsx
+++ b/packages/universal-date-input/src/components/date-range-input/Component.tsx
@@ -179,8 +179,6 @@ export const DateRangeInput = forwardRef<HTMLInputElement, InnerDateRangeInputPr
         };
 
         const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
-            if (open) return;
-
             onBlur?.(event);
 
             if (autoCorrection) {


### PR DESCRIPTION
в варианте date-range не отрабатывал обработчик onBlur в случае, когда мы используем пикер. Убрал лишнее условие, которое блокировало выполнение хэндлера(в момент события blur setOpen еще не успевает отработать, поэтому никогда не попадаем дальше, при этом с открытым пикером у нас всегда состояние focus, поэтому условие лишнее, да и в других вариантах UniversalDateInput такого условия нет). Не выполнялась также и автокоррекция даты

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [х] Прикреплено изображение было/стало
Раньше(не отрабатывает onBlur и не выполняется autoCorrection)
<img width="414" alt="Снимок экрана 2025-05-23 в 19 58 59" src="https://github.com/user-attachments/assets/fe5fb368-e9ec-4942-a394-27c426876b8e" />

После
<img width="438" alt="Снимок экрана 2025-05-23 в 19 58 16" src="https://github.com/user-attachments/assets/2c82ab14-af26-4532-9c80-cdbd8954e38c" />

