### PR TITLE
feat(calendar): add back button to header

### DIFF
--- a/.changeset/olive-lions-love.md
+++ b/.changeset/olive-lions-love.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-calendar': minor
+---
+
+Добавлена возможность управлять кнопкой назад для CalendarMobile (пропсы hasBackButton, onBack)

--- a/packages/calendar/src/components/calendar-mobile/Component.tsx
+++ b/packages/calendar/src/components/calendar-mobile/Component.tsx
@@ -59,6 +59,8 @@ export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
             cancelButtonContent = 'Отмена',
             selectButtonContent = 'Выбрать',
             resetButtonContent = 'Сбросить',
+            hasBackButton = false,
+            onBack,
             ...restProps
         },
         ref,
@@ -204,10 +206,12 @@ export const CalendarMobile = forwardRef<HTMLDivElement, CalendarMobileProps>(
                 {hasHeader && (
                     <ModalMobile.Header
                         hasCloser={true}
+                        hasBackButton={hasBackButton}
                         title={title}
                         sticky={true}
                         bottomAddons={renderDayNames()}
                         className={cn({ [styles.withZIndex]: selectorView === 'full' })}
+                        onBack={onBack}
                     />
                 )}
                 <ModalMobile.Content className={styles.contentModal} flex={true}>

--- a/packages/calendar/src/components/calendar-mobile/typings.ts
+++ b/packages/calendar/src/components/calendar-mobile/typings.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import type { ModalHeaderProps } from '@alfalab/core-components-modal/shared';
+
 import { CalendarDesktopProps } from '../../desktop';
 
 type OmittedCalendarProps = 'headerClassName' | 'contentClassName';
@@ -87,4 +89,5 @@ export type CalendarMobileProps = {
      */
     resetButtonContent?: string;
 } & CalendarContentProps &
-    Pick<CalendarDesktopProps, OmittedCalendarContentProps>;
+    Pick<CalendarDesktopProps, OmittedCalendarContentProps> &
+    Pick<ModalHeaderProps, 'hasBackButton' | 'onBack'>;

--- a/packages/calendar/src/docs/Component.stories.mdx
+++ b/packages/calendar/src/docs/Component.stories.mdx
@@ -113,11 +113,13 @@ export const MONTHS = {
                         <Button onClick={() => setOpen(true)}>Открыть календарь</Button>
                         <CalendarMobile
                             onClose={() => setOpen(false)}
+                            onBack={() => setOpen(false)}
                             open={open}
                             value={value}
                             onChange={setValue}
                             defaultView={defaultView}
                             selectorView={selectorView}
+                            hasBackButton={boolean('hasBackButton', false)}
                         />
                     </>
                 );
@@ -127,12 +129,14 @@ export const MONTHS = {
                         <Button onClick={() => setOpen(true)}>Открыть календарь (период)</Button>
                         <CalendarMobile
                             onClose={() => setOpen(false)}
+                            onBack={() => setOpen(false)}
                             open={open}
                             onChange={updatePeriod}
                             selectedFrom={selectedFrom}
                             selectedTo={selectedTo}
                             defaultView={defaultView}
                             selectorView={selectorView}
+                            hasBackButton={boolean('hasBackButton', false)}
                         />
                     </>
                 );


### PR DESCRIPTION
DS-10203

Добавлена возможность управлять кнопкой назад для CalendarMobile (пропсы hasBackButton, onBack)