### PR TITLE
feat(themes): footer side panel unification for click theme

### DIFF
--- a/.changeset/loud-oranges-flow.md
+++ b/.changeset/loud-oranges-flow.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-themes': patch
+---
+
+Для темы click в side-panel footer приведен к общей теме

--- a/packages/themes/src/mixins/side-panel/click.css
+++ b/packages/themes/src/mixins/side-panel/click.css
@@ -1,5 +1,3 @@
 @define-mixin side-panel-click {
-    --side-panel-footer-highlight-background: var(--color-light-base-bg-secondary);
     --side-panel-header-highlight-box-shadow: none;
-    --side-panel-footer-highlight-box-shadow: none;
 }


### PR DESCRIPTION
Вернул для футера сайд панели темы 'click' box-shadow и background целевой реализации
[Макет](https://www.figma.com/design/lGWq8DtnUcSkRasagBuwq6/Web----Core?node-id=208-72557&t=9extBkoFQpHAshZG-0)
