### PR TITLE
feat(pure-cell): добавлен новый тип  отступа от графики [DS-10939]

### DIFF
--- a/.changeset/hungry-lies-rhyme.md
+++ b/.changeset/hungry-lies-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pure-cell': minor
+---
+
+- Добавлен новый тип `max` отступа от графики

--- a/packages/pure-cell/src/components/graphics/component.tsx
+++ b/packages/pure-cell/src/components/graphics/component.tsx
@@ -28,7 +28,7 @@ export type Props = {
     /**
      * Отступ от графики
      */
-    graphicPadding?: 'airy' | 'default' | 'compact' | 'tiny' | 'none';
+    graphicPadding?: 'max' | 'airy' | 'default' | 'compact' | 'tiny' | 'none';
 
     /**
      * Клик по контенту графики.

--- a/packages/pure-cell/src/components/graphics/index.module.css
+++ b/packages/pure-cell/src/components/graphics/index.module.css
@@ -22,6 +22,10 @@
         margin-right: var(--gap-0);
     }
 
+    &.max {
+        margin-right: var(--gap-24);
+    }
+
     &.airy {
         margin-right: var(--gap-16);
     }
@@ -43,6 +47,11 @@
     &.none {
         margin-bottom: var(--gap-0);
     }
+
+    &.max {
+        margin-bottom: var(--gap-24);
+    }
+
     &.airy {
         margin-bottom: var(--gap-16);
     }

--- a/packages/pure-cell/src/docs/Component.stories.mdx
+++ b/packages/pure-cell/src/docs/Component.stories.mdx
@@ -49,7 +49,7 @@ export const VIEWS = ['primary', 'secondary', 'tertiary', 'link', 'ghost'];
         );
         const graphicPadding = select(
             'graphicPadding',
-            ['airy', 'default', 'compact', 'tiny', 'none', undefined],
+            ['max', 'airy', 'default', 'compact', 'tiny', 'none', undefined],
             undefined,
         );
         const direction = select('direction', ['vertical', 'horizontal'], 'horizontal');
@@ -301,7 +301,7 @@ export const VIEWS = ['primary', 'secondary', 'tertiary', 'link', 'ghost'];
         );
         const graphicPadding = select(
             'graphicPadding',
-            ['airy', 'default', 'compact', 'tiny', 'none', undefined],
+            ['max', 'airy', 'default', 'compact', 'tiny', 'none', undefined],
             undefined,
         );
         const addonPadding = select('addonPadding', ['default', 'none'], 'default');


### PR DESCRIPTION
Добавлен новый тип `max` отступа от графики

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

<img width="1419" alt="Снимок экрана 2025-07-02 в 13 51 48" src="https://github.com/user-attachments/assets/710f45d7-2095-4672-a0bd-8452c8586e95" />

