### PR TITLE
feat(select): Кастомный разделитель

### DIFF
--- a/.changeset/rotten-forks-help.md
+++ b/.changeset/rotten-forks-help.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': minor
+---
+
+Добавлен кастомный проп valueSeparator в Select, который позволяет прокинуть свой разделитель вместо значений, не создавая новую утилиту valueRenderer

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -41,6 +41,7 @@ export const Field = ({
     FormControlComponent,
     clear,
     onClear,
+    valueSeparator,
     ...restProps
 }: BaseFieldProps & FormControlProps & FieldProps) => {
     const [focused, setFocused] = useState(false);
@@ -52,7 +53,7 @@ export const Field = ({
     const handleFocus = useCallback(() => setFocused(true), []);
     const handleBlur = useCallback(() => setFocused(false), []);
 
-    const value = valueRenderer({ selected, selectedMultiple });
+    const value = valueRenderer({ selected, selectedMultiple, valueSeparator });
 
     const filled = Boolean(value);
     const showLabel = !!label || labelView === 'outer';

--- a/packages/select/src/consts.ts
+++ b/packages/select/src/consts.ts
@@ -11,3 +11,5 @@ export const SIZE_TO_CLASSNAME_MAP = {
     64: 'size-64',
     72: 'size-72',
 };
+
+export const DEFAULT_SEPARATOR = ', ';

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -246,7 +246,13 @@ export type BaseSelectProps = {
     }: {
         selected?: OptionShape;
         selectedMultiple: OptionShape[];
+        valueSeparator?: string;
     }) => ReactNode;
+
+    /**
+     * Кастомный разделитель выбранных пунктов (Работает когда не прокинут valueRenderer)
+     */
+    valueSeparator?: string;
 
     /**
      * Компонент стрелки
@@ -468,6 +474,11 @@ export type FieldProps = {
      * Кастомный рендер выбранного пункта
      */
     valueRenderer?: BaseSelectProps['valueRenderer'];
+
+    /**
+     * Кастомный разделитель выбранных пунктов
+     */
+    valueSeparator?: BaseSelectProps['valueSeparator'];
 
     /**
      * Внутренние свойства, которые должны быть установлены компоненту.

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -11,6 +11,7 @@ import {
 import { fnUtils, getDataTestId, useIsMounted } from '@alfalab/core-components-shared';
 
 import { BaseSelectProps, GroupShape, OptionShape, OptionsListProps } from './typings';
+import { DEFAULT_SEPARATOR } from './consts';
 
 export const isGroup = (item: OptionShape | GroupShape): item is GroupShape =>
     Object.prototype.hasOwnProperty.call(item, 'options');
@@ -21,9 +22,11 @@ export const isOptionShape = (item: OptionShape | string | null): item is Option
 export const joinOptions = ({
     selected,
     selectedMultiple,
+    valueSeparator = DEFAULT_SEPARATOR,
 }: {
     selected?: OptionShape;
     selectedMultiple?: OptionShape[];
+    valueSeparator?: string;
 }) => {
     const options = selectedMultiple || (selected ? [selected] : []);
 
@@ -36,7 +39,7 @@ export const joinOptions = ({
             acc.push(option.content);
         }
 
-        if (index < options.length - 1) acc.push(', ');
+        if (index < options.length - 1) acc.push(valueSeparator);
 
         return acc;
     }, []);

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -10,8 +10,8 @@ import {
 
 import { fnUtils, getDataTestId, useIsMounted } from '@alfalab/core-components-shared';
 
-import { BaseSelectProps, GroupShape, OptionShape, OptionsListProps } from './typings';
 import { DEFAULT_SEPARATOR } from './consts';
+import { BaseSelectProps, GroupShape, OptionShape, OptionsListProps } from './typings';
 
 export const isGroup = (item: OptionShape | GroupShape): item is GroupShape =>
     Object.prototype.hasOwnProperty.call(item, 'options');


### PR DESCRIPTION
В select есть параметр valueRenderer, который определяет каким образом будут отрисовываться выбранные элементы. По дефолту вместо valueRenderer прокидывается утилита joinOptions, которая разделяет элементы через ", ". В рамках доработки, добавил возможность прокинуть параметром разделитель (valueSeparator), а не определять у себя целую утилиту valueRenderer под это 

# Чек лист
- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
