### PR TITLE
chore: update @alfalab/data

### DIFF
--- a/.changeset/swift-roses-yawn.md
+++ b/.changeset/swift-roses-yawn.md
@@ -1,0 +1,7 @@
+---
+'@alfalab/core-components-amount': patch
+'@alfalab/core-components-amount-input': patch
+'@alfalab/core-components-pure-cell': patch
+---
+
+Версия пакета @alfalab/data обновлена до 1.9.2

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         ]
     },
     "dependencies": {
-        "@alfalab/data": "^1.9.1",
+        "@alfalab/data": "^1.9.2",
         "@alfalab/hooks": "^1.13.1",
         "@alfalab/icons-glyph": "^2.210.0",
         "@alfalab/icons-logo": "^1.39.0",

--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@alfalab/core-components-input": "^15.6.2",
         "@alfalab/core-components-with-suffix": "^4.2.20",
-        "@alfalab/data": "^1.9.1",
+        "@alfalab/data": "^1.9.2",
         "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0",

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -12,7 +12,7 @@
     },
     "sideEffects": false,
     "dependencies": {
-        "@alfalab/data": "^1.9.1",
+        "@alfalab/data": "^1.9.2",
         "@alfalab/utils": "^1.18.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0"

--- a/packages/pure-cell/package.json
+++ b/packages/pure-cell/package.json
@@ -22,7 +22,7 @@
         "@alfalab/core-components-comment": "^2.4.15",
         "@alfalab/core-components-shared": "^0.18.0",
         "@alfalab/hooks": "^1.13.1",
-        "@alfalab/data": "^1.9.1",
+        "@alfalab/data": "^1.9.2",
         "classnames": "^2.5.1",
         "react-merge-refs": "1.1.0",
         "tslib": "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@alfalab/data/-/data-1.7.0.tgz#87e1525d2b653b9312d5b008df62b13193d1dc0c"
   integrity sha512-aw1zL8TktUn3wCLcHVns2ndHypmMqINmqAc6E2nL90FFnh4ieWzw9gRRfUesNmbFNTRnkdp9VpI0ASS7l4kyEQ==
 
-"@alfalab/data@^1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@alfalab/data/-/data-1.9.1.tgz#1bb3dcf5dd062ddb3aa458022bbf81c0c0ef6b0c"
-  integrity sha512-RJQjs01k0MYtv9UwWxz5rL5XiOCsRO1gfrgQxZj8CqQShyLNfBuNTxcvKKY/5uuY2rBv9kN1PZrW57Fsc/DyGg==
+"@alfalab/data@^1.9.1", "@alfalab/data@^1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@alfalab/data/-/data-1.9.2.tgz#666e9b2b593256473329ebb026b7b59f4d6542f7"
+  integrity sha512-43KMYYerK5HS2MgaCRNU2Q3kaYskG1UmZDckmFmiM9dTbiyGN+7YQ1ZyEOsLrbXm6SxkHg65Gf8tYVKnSiLYwQ==
 
 "@alfalab/hooks@^1.13.0":
   version "1.13.0"
@@ -9082,13 +9082,13 @@ d3-timer@^3.0.1:
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+d@1, d@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.2.tgz#2aefd554b81981e7dccf72d6842ae725cb17e5de"
+  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
   dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
+    es5-ext "^0.10.64"
+    type "^2.7.2"
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -9974,9 +9974,9 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@0.10.53, es5-ext@^0.10.35, es5-ext@^0.10.50:
+es5-ext@0.10.53, es5-ext@^0.10.35, es5-ext@^0.10.64:
   version "0.10.53"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
   dependencies:
     es6-iterator "~2.0.3"
@@ -9985,20 +9985,20 @@ es5-ext@0.10.53, es5-ext@^0.10.35, es5-ext@^0.10.50:
 
 es6-iterator@~2.0.3:
   version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
   dependencies:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.4.tgz#f4e7d28013770b4208ecbf3e0bf14d3bcb557b8c"
+  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
   dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
+    d "^1.0.2"
+    ext "^1.7.0"
 
 esbuild-plugin-alias@^0.2.1:
   version "0.2.1"
@@ -10596,12 +10596,12 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
+ext@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
   dependencies:
-    type "^2.0.0"
+    type "^2.7.2"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -15402,8 +15402,8 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.2:
 
 next-tick@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -21171,15 +21171,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/type/-/type-1.2.0.tgz"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/type/-/type-2.1.0.tgz"
-  integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
+type@^2.7.2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.3.tgz#436981652129285cc3ba94f392886c2637ea0486"
+  integrity sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==
 
 typed-array-length@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
В данным момент, имеется расхождение в символах для китайского юяня в arui-private и core-components.
arui-private использует правильный символ: https://git.moscow.alfaintra.net/projects/EF/repos/arui-private/browse/src/lib/currency-codes/currency-codes.ts#23
https://en.wikipedia.org/wiki/Yen_and_yuan_sign
Тем временем как core-components использует символ казахского алфавита, который берёт из @alfalab/data
https://en.wikipedia.org/wiki/Kazakh_Short_U

Данный ПР обновляет @alfalab/data до последней версии, где эта проблема была исправлена https://git.moscow.alfaintra.net/projects/EF/repos/utils/pull-requests/35/overview

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

Было:
![image](https://github.com/user-attachments/assets/09f86f99-8537-4d72-a93f-2570cd620a44)

Стало:
![image](https://github.com/user-attachments/assets/7f7f90cf-f54a-4e40-99af-85d6a14ccb19)
