### PR TITLE
fix(tabs): исправлена проблема с появлением значения класса undefined у элементов span [DS-10938]

### DIFF
--- a/.changeset/sixty-singers-refuse.md
+++ b/.changeset/sixty-singers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tabs': patch
+---
+
+- Исправлена проблема с появлением значения класса "undefined" у элементов span внутри компонента Tabs

--- a/packages/tabs/src/components/title/Component.tsx
+++ b/packages/tabs/src/components/title/Component.tsx
@@ -40,10 +40,9 @@ export const Title = forwardRef<HTMLButtonElement, Props>(
     ) => {
         const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-        const titleClassName = {
-            [styles.content]: true,
+        const titleClassName = cn(styles.content, {
             [styles.focused]: focused,
-        };
+        });
 
         useEffect(() => {
             const resizeObserver = new ResizeObserver(() => {
@@ -93,7 +92,7 @@ export const Title = forwardRef<HTMLButtonElement, Props>(
                         {title}
                     </Skeleton>
                 ) : (
-                    <span className={cn(titleClassName)}>{title}</span>
+                    <span className={titleClassName}>{title}</span>
                 )}
 
                 {rightAddons && (


### PR DESCRIPTION
- Исправлена проблема с появлением значения класса "undefined" у элементов span внутри компонента Tabs

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
