### PR TITLE
fix: add safe-area

### DIFF
--- a/.changeset/mighty-impalas-impress.md
+++ b/.changeset/mighty-impalas-impress.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tab-bar': patch
+---
+
+Добавлен нижний safe-area отступ для standalone мода

--- a/packages/tab-bar/src/index.module.css
+++ b/packages/tab-bar/src/index.module.css
@@ -1,4 +1,5 @@
 @import '../../vars/src/index.css';
+@import '../../vars/src/safe-area.css';
 
 .component {
     display: flex;
@@ -15,6 +16,10 @@
 
     &.modal-bg-alt-primary {
         background-color: var(--color-light-base-bg-alt-primary);
+    }
+
+    @media (display-mode: standalone) {
+        padding-bottom: var(--sab);
     }
 }
 


### PR DESCRIPTION
DS-11324
Добавлен нижний safe-area отступ для standalone мода
https://www.npmjs.com/package/@alfalab/core-components/v/48.29.0-beta.1

- [x] Прикреплено изображение было/стало
<img width="453" height="901" alt="Снимок экрана 2025-07-14 в 15 09 27" src="https://github.com/user-attachments/assets/8aba9c7a-e901-4b4e-b745-96ca50f91665" />
<img width="452" height="907" alt="Снимок экрана 2025-07-14 в 15 15 33" src="https://github.com/user-attachments/assets/1e99d6f3-b03e-48b9-9317-cf097afafd26" />

