### PR TITLE
fix(select): Исправить конфликт CSP-политики в компоненте Select [DS-12034]

### DIFF
--- a/.changeset/unlucky-yaks-glow.md
+++ b/.changeset/unlucky-yaks-glow.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': patch
+---
+
+- Исправлена проблема совместимости с CSP-директивами: заменён метод setAttribute('style', '') на removeAttribute('style') для удаления инлайн-стилей

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -487,7 +487,7 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
                     ? rootRef.current.getBoundingClientRect().width
                     : 0;
 
-                listRef.current.setAttribute('style', '');
+                listRef.current.removeAttribute('style');
                 listRef.current.style[widthAttr] = `${optionsListMinWidth}px`;
             }
         }, [view, optionsListWidth]);


### PR DESCRIPTION
- Исправлена проблема совместимости с CSP-директивами: заменён метод setAttribute('style', '') на removeAttribute('style') для удаления инлайн-стилей

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset
