### PR TITLE
feat(calendar): Добавить флаг для слайдера периода "hideDisabledArrows"

### DIFF
--- a/.changeset/orange-tips-notice.md
+++ b/.changeset/orange-tips-notice.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-calendar': minor
+---
+
+Для компонента 'CalendarDesktop' с видом (selectorView='month-only') добавлен параметр 'hideDisabledArrows', позволяющий управлять видимостью кнопок.

--- a/packages/calendar/src/desktop/Component.desktop.tsx
+++ b/packages/calendar/src/desktop/Component.desktop.tsx
@@ -174,6 +174,12 @@ export type CalendarDesktopProps = {
     showCurrentYearSelector?: boolean;
 
     /**
+     * Скрывает заблокированные кнопки в периоде, если selectorView 'month-only'
+     * @default true
+     */
+    hideDisabledArrows?: boolean;
+
+    /**
      * CalendarDesktop используется в мобильной и десктопной версии
      * Пропс позволяет определить платформу
      */
@@ -212,6 +218,7 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
             dayAddons,
             shape = 'rounded',
             showCurrentYearSelector = false,
+            hideDisabledArrows = true,
             mobile,
         },
         ref,
@@ -379,7 +386,7 @@ export const CalendarDesktop = forwardRef<HTMLDivElement, CalendarDesktopProps>(
                                 periodType='month'
                                 prevArrowDisabled={!canSetPrevMonth}
                                 nextArrowDisabled={!canSetNextMonth}
-                                hideDisabledArrows={true}
+                                hideDisabledArrows={hideDisabledArrows}
                                 showCurrentYearSelector={showCurrentYearSelector}
                                 onPrevArrowClick={handlePrevArrowClick}
                                 onNextArrowClick={handleNextArrowClick}


### PR DESCRIPTION
Необходимо дать возможно не скрывать стрелки смены периода при блокировке в календаре.

# Чек лист
- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [ ] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [ ] К реквесту добавлен changeset

Если есть визуальные изменения
- [ ] Прикреплено изображение было/стало
