### PR TITLE
Gallery: улучшена обработка ошибок при шаринге изображений

### DIFF
--- a/.changeset/ninety-crews-collect.md
+++ b/.changeset/ninety-crews-collect.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-gallery': patch
+---
+
+добавлен fallback шаринга по ссылке для изображений из других источников

--- a/packages/gallery/src/components/header-mobile/Component.tsx
+++ b/packages/gallery/src/components/header-mobile/Component.tsx
@@ -63,7 +63,7 @@ export const HeaderMobile = () => {
             };
 
             // Попробуем поделиться файлом
-            if (navigator.canShare?.(shareData)) {
+            if (navigator.canShare?.(shareData) && response.ok) {
                 await navigator.share(shareData);
             } else {
                 // Fallback: делимся только ссылкой
@@ -74,15 +74,10 @@ export const HeaderMobile = () => {
                 });
             }
         } catch {
-            // Последний fallback — просто делимся ссылкой
-            try {
-                await navigator.share({
-                    title,
-                    url,
-                });
-            } catch {
-                /* empty */
-            }
+            await navigator.share({
+                title,
+                url,
+            });
         }
     };
 

--- a/packages/gallery/src/components/header-mobile/Component.tsx
+++ b/packages/gallery/src/components/header-mobile/Component.tsx
@@ -28,29 +28,41 @@ export const HeaderMobile = () => {
     const showDownloadButton = !meta?.broken && canDownload;
 
     const handleShareClick = async () => {
-        if (!currentImage) return;
+        if (!currentImage || !navigator.share) return;
 
         const title = currentImage.name ?? new Date().toISOString().split('T')[0];
 
-        const image = await fetch(currentImage.src);
-        const blob = await image.blob();
+        if (!isVideo(currentImage.src)) {
+            try {
+                const image = await fetch(currentImage.src);
+                const blob = await image.blob();
 
-        const filesArray = [
-            new File([blob], title, {
-                type: blob.type,
-                lastModified: new Date().getTime(),
-            }),
-        ];
+                const filesArray = [
+                    new File([blob], title, {
+                        type: blob.type,
+                        lastModified: new Date().getTime(),
+                    }),
+                ];
 
-        const shareData = {
-            files: filesArray,
-        };
+                const shareData: ShareData = {
+                    files: filesArray,
+                    title,
+                };
 
-        if (navigator.canShare(shareData) && !isVideo(currentImage.src)) {
-            await navigator.share(shareData);
-        } else {
-            await navigator.share({ url: currentImage.src, title });
+                if (navigator.canShare && navigator.canShare(shareData)) {
+                    await navigator.share(shareData);
+
+                    return;
+                }
+            } catch {
+                /* empty */
+            }
         }
+
+        await navigator.share({
+            url: currentImage.src,
+            title,
+        });
     };
 
     return (

--- a/packages/gallery/src/components/image-viewer/component.tsx
+++ b/packages/gallery/src/components/image-viewer/component.tsx
@@ -105,12 +105,12 @@ export const ImageViewer: FC = () => {
     const swiperAspectRatio = swiperWidth / swiperHeight;
 
     return (
-        /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
         <div
             className={cn(styles.component, {
                 [styles.mobile]: isMobile,
                 [styles.mobileVideo]: isMobile && isVideo(currentImage?.src),
             })}
+            aria-hidden={true}
             onClick={handleWrapperClick}
         >
             {showControls && (

--- a/packages/gallery/src/docs/Component.stories.tsx
+++ b/packages/gallery/src/docs/Component.stories.tsx
@@ -94,6 +94,10 @@ export const gallery: Story = {
                             src: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUwIiBoZWlnaHQ9IjE1MCIgdmlld0JveD0iMCAwIDE1MCAxNTAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIxNTAiIGhlaWdodD0iMTUwIiBmaWxsPSIjNDU0Nzc4Ii8+Cjwvc3ZnPgo=',
                         },
                         {
+                            name: 'Photo.jpg',
+                            src: 'https://pixabay.com/images/download/people-2944065_640.jpg?attachment',
+                        },
+                        {
                             name: 'Alfa promo.m3u8',
                             src: 'https://alfavideo.servicecdn.ru/videos/101064_31s0hnwZaamhbwE/master.m3u8',
                             bottomButton: {


### PR DESCRIPTION
Была проблема в том, что при нажатии на кнопку "Поделиться", если изображение имело src из другого источника валился exeption с CORS политикой. Обернул в try, catch для того чтоб не срабатывал return в блоке с navigation.share, где качается изображение, а просто шел шаринг через ссылку без скачивания