### PR TITLE
fix(select): Добавлен отступ для нижней части bottomSheet [DS-12089]

### DIFF
--- a/.changeset/dirty-boats-juggle.md
+++ b/.changeset/dirty-boats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': minor
+---
+
+Добавлен отступ для нижней части bottomSheet

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -1354,6 +1354,14 @@ exports[`Snapshots tests should display opened correctly 4`] = `
                           />
                         </div>
                       </div>
+                      <div
+                        class="optionsListFooter"
+                      >
+                        <div
+                          class="gap vertical"
+                          data-gap-size="size-16"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2470,6 +2478,14 @@ exports[`Snapshots tests should display opened correctly 6`] = `
                             style="height: 0px; display: none;"
                           />
                         </div>
+                      </div>
+                      <div
+                        class="optionsListFooter"
+                      >
+                        <div
+                          class="gap vertical"
+                          data-gap-size="size-16"
+                        />
                       </div>
                     </div>
                   </div>

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -21,6 +21,7 @@ import {
     UseMultipleSelectionState,
 } from 'downshift';
 
+import { Gap } from '@alfalab/core-components-gap';
 import { fnUtils, getDataTestId } from '@alfalab/core-components-shared';
 import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
@@ -628,6 +629,7 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
                     )}
                 >
                     <OptionsList
+                        footer={view === 'mobile' && isBottomSheet && <Gap size={16} />}
                         {...listProps}
                         ref={view === 'desktop' ? listProps.ref : scrollableContainerRef}
                         setHighlightedIndex={view === 'desktop' ? setHighlightedIndex : undefined}

--- a/packages/select/tsconfig.json
+++ b/packages/select/tsconfig.json
@@ -10,6 +10,7 @@
             "@alfalab/core-components-modal/*": ["../modal/src/*"],
             "@alfalab/core-components-form-control/*": ["../form-control/src/*"],
             "@alfalab/core-components-select/*": ["../select/src/*"],
+            "@alfalab/core-components-gap/*": ["../gap/src/*"],
             "@alfalab/core-components-*": ["../*/src"]
         }
     },
@@ -26,6 +27,7 @@
         { "path": "../mq" },
         { "path": "../scrollbar" },
         { "path": "../badge" },
-        { "path": "../shared" }
+        { "path": "../shared" },
+        { "path": "../gap" },
     ]
 }


### PR DESCRIPTION
Добавлен отступ 16px внизу bottomSheet у компонента Select

# Чек лист
- [X] Задача сформулирована и описана в JIRA
- [X] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [X] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [X] Код покрыт тестами и протестирован в различных браузерах
- [X] Добавленные пропсы добавлены в демки и описаны в документации
- [X] К реквесту добавлен changeset

Если есть визуальные изменения
- [X] Прикреплено изображение было/стало

<img width="724" height="1286" alt="Screenshot 2025-07-30 at 14 43 18" src="https://github.com/user-attachments/assets/e3131c56-ddd7-4905-91d8-fd3dc46134a6" />
<img width="722" height="1286" alt="Screenshot 2025-07-30 at 14 46 16" src="https://github.com/user-attachments/assets/eb826dae-ead0-4294-bec8-4702bfb7e58f" />

