### PR TITLE
DS-12105 Lock code-input on error

### DIFF
--- a/.changeset/eight-carrots-wash.md
+++ b/.changeset/eight-carrots-wash.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-code-input': minor
+---
+
+Теперь инпут невозможно изменить в состоянии ошибки до истечения тайм-аута `errorVisibleDuration`, если `clearCodeOnError` в значении `true`

--- a/.changeset/eight-carrots-wash.md
+++ b/.changeset/eight-carrots-wash.md
@@ -1,5 +1,6 @@
 ---
 '@alfalab/core-components-code-input': minor
+'@alfalab/core-components': minor
 ---
 
 Теперь инпут невозможно изменить в состоянии ошибки до истечения тайм-аута `errorVisibleDuration`, если `clearCodeOnError` в значении `true`

--- a/packages/code-input/src/component.test.tsx
+++ b/packages/code-input/src/component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, getByTestId, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CodeInputDesktop as CodeInput } from './desktop';
@@ -212,39 +212,104 @@ describe('CodeInput', () => {
             expect(queryByDisplayValue('1')).not.toBeInTheDocument();
         });
 
-        it('should lock input on error if clearCodeOnError is true', async () => {
-            const handleChange = jest.fn();
+        describe('lock input on error tests', () => {
+            beforeEach(() => {
+                jest.useFakeTimers();
+            });
 
-            const { container, getByDisplayValue, rerender, queryByDisplayValue } = render(
-                <CodeInput
-                    clearCodeOnError={true}
-                    errorVisibleDuration={1000}
-                    onChange={handleChange}
-                />,
-            );
+            afterEach(() => {
+                jest.useRealTimers();
+            });
 
-            const input = getInput(container, 0);
+            it('should lock input on error if clearCodeOnError is true', async () => {
+                const handleChange = jest.fn();
+                const user = userEvent.setup({
+                    delay: null,
+                    advanceTimers: jest.advanceTimersByTime,
+                });
 
-            await userEvent.type(input, '1234');
+                const { container, getByDisplayValue, rerender, queryByDisplayValue } = render(
+                    <CodeInput
+                        clearCodeOnError={true}
+                        onChange={handleChange}
+                        dataTestId={'code-input'}
+                    />,
+                );
 
-            expect(getByDisplayValue('1')).toBeInTheDocument();
-            expect(getByDisplayValue('2')).toBeInTheDocument();
-            expect(getByDisplayValue('3')).toBeInTheDocument();
-            expect(getByDisplayValue('4')).toBeInTheDocument();
+                const input = getInput(container, 0);
 
-            rerender(
-                <CodeInput
-                    clearCodeOnError={true}
-                    error={true}
-                    errorVisibleDuration={1000}
-                    onChange={handleChange}
-                />,
-            );
+                await user.type(input, '1234');
 
-            await userEvent.type(container, '5');
+                expect(getByDisplayValue('1')).toBeInTheDocument();
+                expect(getByDisplayValue('2')).toBeInTheDocument();
+                expect(getByDisplayValue('3')).toBeInTheDocument();
+                expect(getByDisplayValue('4')).toBeInTheDocument();
 
-            expect(handleChange).toHaveBeenCalledTimes(4);
-            expect(queryByDisplayValue('5')).not.toBeInTheDocument();
+                rerender(
+                    <CodeInput
+                        clearCodeOnError={true}
+                        error={true}
+                        onChange={handleChange}
+                        dataTestId={'code-input'}
+                    />,
+                );
+
+                //TODO: коллбеки состояния анимации не работают в тестах, issues не нашел, но когда починят - можно будет убрать
+                fireEvent.animationStart(getByTestId(container, 'code-input'));
+                await user.type(input, '5');
+
+                expect(handleChange).toHaveBeenCalledTimes(4);
+                expect(queryByDisplayValue('5')).not.toBeInTheDocument();
+
+                act(() => jest.advanceTimersByTime(300));
+                // TODO: аналогично комменту выше, выкидываю руками, потому что на изменение инпута это не происходит
+                fireEvent.animationEnd(getByTestId(container, 'code-input'));
+                act(() => jest.advanceTimersByTime(2000));
+
+                await user.type(input, '6');
+                expect(handleChange).toHaveBeenCalledTimes(5);
+                expect(queryByDisplayValue('6')).toBeInTheDocument();
+            });
+
+            it('code input should not be cleared on error if clearCodeOnError is false', async () => {
+                const user = userEvent.setup({
+                    delay: null,
+                    advanceTimers: jest.advanceTimersByTime,
+                });
+                const handleChange = jest.fn();
+
+                const { container, getByDisplayValue, rerender, queryByDisplayValue } = render(
+                    <CodeInput
+                        clearCodeOnError={false}
+                        onChange={handleChange}
+                        dataTestId={'code-input'}
+                    />,
+                );
+
+                const input = getInput(container, 0);
+
+                await user.type(input, '1234');
+
+                expect(getByDisplayValue('1')).toBeInTheDocument();
+                expect(getByDisplayValue('2')).toBeInTheDocument();
+                expect(getByDisplayValue('3')).toBeInTheDocument();
+                expect(getByDisplayValue('4')).toBeInTheDocument();
+
+                rerender(
+                    <CodeInput
+                        clearCodeOnError={false}
+                        error={true}
+                        onChange={handleChange}
+                        dataTestId={'code-input'}
+                    />,
+                );
+
+                fireEvent.animationStart(getByTestId(container, 'code-input'));
+                await user.type(input, '5');
+
+                expect(handleChange).toHaveBeenCalledTimes(5);
+                expect(getByDisplayValue('5')).toBeInTheDocument();
+            });
         });
     });
 });

--- a/packages/code-input/src/component.test.tsx
+++ b/packages/code-input/src/component.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 
 import { CodeInputDesktop as CodeInput } from './desktop';
 
@@ -211,6 +210,41 @@ describe('CodeInput', () => {
             expect(queryByDisplayValue('3')).not.toBeInTheDocument();
             expect(queryByDisplayValue('2')).not.toBeInTheDocument();
             expect(queryByDisplayValue('1')).not.toBeInTheDocument();
+        });
+
+        it('should lock input on error if clearCodeOnError is true', async () => {
+            const handleChange = jest.fn();
+
+            const { container, getByDisplayValue, rerender, queryByDisplayValue } = render(
+                <CodeInput
+                    clearCodeOnError={true}
+                    errorVisibleDuration={1000}
+                    onChange={handleChange}
+                />,
+            );
+
+            const input = getInput(container, 0);
+
+            await userEvent.type(input, '1234');
+
+            expect(getByDisplayValue('1')).toBeInTheDocument();
+            expect(getByDisplayValue('2')).toBeInTheDocument();
+            expect(getByDisplayValue('3')).toBeInTheDocument();
+            expect(getByDisplayValue('4')).toBeInTheDocument();
+
+            rerender(
+                <CodeInput
+                    clearCodeOnError={true}
+                    error={true}
+                    errorVisibleDuration={1000}
+                    onChange={handleChange}
+                />,
+            );
+
+            await userEvent.type(container, '5');
+
+            expect(handleChange).toHaveBeenCalledTimes(4);
+            expect(queryByDisplayValue('5')).not.toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
Теперь инпут невозможно изменить в состоянии ошибки до истечения тайм-аута `errorVisibleDuration`, если `clearCodeOnError` в значении `true`

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] К реквесту добавлен changeset


https://github.com/user-attachments/assets/85477490-8c46-4bd9-b42f-4146789ecf83

