### PR TITLE
feat(universal-modal): migrate from type to interface (Core 48)

### DIFF
--- a/.changeset/short-fans-visit.md
+++ b/.changeset/short-fans-visit.md
@@ -1,6 +1,5 @@
 ---
 '@alfalab/core-components-universal-modal': patch
-'@alfalab/core-components': patch
 ---
 
-Исправлено наследование пропса `onClose`. Теперь из аргументов callback функции можно получить event и reason без ts ошибки.
+Исправлена типизация. Типы переведены на компоненты.

--- a/packages/universal-modal/src/Component.responsive.tsx
+++ b/packages/universal-modal/src/Component.responsive.tsx
@@ -7,7 +7,7 @@ import { FooterResponsive } from './components/footer';
 import { HeaderResponsive } from './components/header';
 import { UniversalModalDesktop } from './desktop';
 import { UniversalModalMobile } from './mobile';
-import { UniversalModalResponsiveProps } from './typings';
+import type { UniversalModalResponsiveProps } from './typings';
 
 export const UniversalModal = forwardRef<HTMLDivElement, UniversalModalResponsiveProps>(
     ({ children, breakpoint, defaultMatchMediaValue, dataTestId, ...restProps }, ref) => {

--- a/packages/universal-modal/src/components/content/base-content/base-content.tsx
+++ b/packages/universal-modal/src/components/content/base-content/base-content.tsx
@@ -7,7 +7,7 @@ import { ModalContext } from '../../../Context';
 
 import styles from './index.module.css';
 
-export type ContentProps = {
+export interface ContentProps {
     /**
      * Контент
      */
@@ -22,7 +22,7 @@ export type ContentProps = {
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
-};
+}
 
 export const BaseContent: FC<ContentProps> = ({ children, className, dataTestId }) => {
     const { contentRef } = useContext(ModalContext);

--- a/packages/universal-modal/src/components/content/desktop/Component.desktop.tsx
+++ b/packages/universal-modal/src/components/content/desktop/Component.desktop.tsx
@@ -6,12 +6,12 @@ import { BaseContent, ContentProps } from '../base-content/base-content';
 
 import styles from './desktop.module.css';
 
-export type ContentDesktopProps = ContentProps & {
+export interface ContentDesktopProps extends ContentProps {
     /**
      * Размер (только для desktop версии компонента)
      */
     size?: 's' | 500;
-};
+}
 
 export const ContentDesktop: FC<ContentDesktopProps> = ({ className, ...restProps }) => {
     const { hasHeader, hasFooter } = useContext(UniversalModalContext);

--- a/packages/universal-modal/src/components/content/mobile/Component.mobile.tsx
+++ b/packages/universal-modal/src/components/content/mobile/Component.mobile.tsx
@@ -2,7 +2,7 @@ import React, { FC, useContext } from 'react';
 import cn from 'classnames';
 
 import { ModalContext } from '../../../Context';
-import { BaseContent, ContentProps } from '../base-content/base-content';
+import { type ContentProps, BaseContent } from '../base-content/base-content';
 
 import styles from './mobile.module.css';
 

--- a/packages/universal-modal/src/components/content/responsive/Component.responsive.tsx
+++ b/packages/universal-modal/src/components/content/responsive/Component.responsive.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react';
 
 import { useIsDesktop } from '@alfalab/core-components-mq';
 
-import { ContentDesktop, ContentDesktopProps } from '../desktop/Component.desktop';
-import { ContentMobile, ContentMobileProps } from '../mobile/Component.mobile';
+import { type ContentDesktopProps, ContentDesktop } from '../desktop/Component.desktop';
+import { type ContentMobileProps, ContentMobile } from '../mobile/Component.mobile';
 
-export type ContentResponsiveProps = ContentDesktopProps | ContentMobileProps;
+export interface ContentResponsiveProps extends ContentDesktopProps, ContentMobileProps {}
 
 export const ContentResponsive: FC<ContentResponsiveProps> = ({ ...restProps }) => {
     const isDesktop = useIsDesktop();

--- a/packages/universal-modal/src/components/footer/base-footer/base-footer.tsx
+++ b/packages/universal-modal/src/components/footer/base-footer/base-footer.tsx
@@ -7,7 +7,7 @@ import { ModalContext } from '../../../Context';
 
 import styles from './index.module.css';
 
-export type FooterProps = {
+export interface FooterProps {
     /**
      * Контент футера
      */
@@ -37,7 +37,7 @@ export type FooterProps = {
      * Отбивка бордером
      */
     isHighlighted?: boolean;
-};
+}
 
 export const BaseFooter = forwardRef<HTMLDivElement, FooterProps>((props, ref) => {
     const { children, className, sticky, dataTestId, isHighlighted } = props;

--- a/packages/universal-modal/src/components/footer/desktop/Component.desktop.tsx
+++ b/packages/universal-modal/src/components/footer/desktop/Component.desktop.tsx
@@ -3,17 +3,17 @@ import cn from 'classnames';
 
 import { UniversalModalContext } from '../../../context/universal-modal-context';
 import { FOOTER_MEDIUM_BREAKPOINT } from '../../../desktop/constants';
-import { BaseFooter, FooterProps } from '../base-footer/base-footer';
+import { type FooterProps, BaseFooter } from '../base-footer/base-footer';
 
 import styles from './desktop.module.css';
 import layoutStyles from './layout.module.css';
 
-export type FooterDesktopProps = FooterProps & {
+export interface FooterDesktopProps extends FooterProps {
     /**
      * Размер (только для desktop версии компонента)
      */
     size?: 's' | 500;
-};
+}
 
 export const FooterDesktop = forwardRef<HTMLDivElement, FooterDesktopProps>((props, ref) => {
     const { className, sticky, layout = 'start', ...restProps } = props;

--- a/packages/universal-modal/src/components/footer/mobile/Component.mobile.tsx
+++ b/packages/universal-modal/src/components/footer/mobile/Component.mobile.tsx
@@ -2,7 +2,7 @@ import React, { FC, useContext } from 'react';
 import cn from 'classnames';
 
 import { ModalContext } from '../../../Context';
-import { BaseFooter, FooterProps } from '../base-footer/base-footer';
+import { type FooterProps, BaseFooter } from '../base-footer/base-footer';
 
 import layoutStylesMobile from './layout.mobile.module.css';
 import styles from './mobile.module.css';

--- a/packages/universal-modal/src/components/footer/responsive/Component.responsive.tsx
+++ b/packages/universal-modal/src/components/footer/responsive/Component.responsive.tsx
@@ -2,10 +2,10 @@ import React, { forwardRef } from 'react';
 
 import { useIsDesktop } from '@alfalab/core-components-mq';
 
-import { FooterDesktop, FooterDesktopProps } from '../desktop/Component.desktop';
-import { FooterMobile, FooterMobileProps } from '../mobile/Component.mobile';
+import { type FooterDesktopProps, FooterDesktop } from '../desktop/Component.desktop';
+import { type FooterMobileProps, FooterMobile } from '../mobile/Component.mobile';
 
-export type FooterResponsiveProps = FooterDesktopProps | FooterMobileProps;
+export interface FooterResponsiveProps extends FooterDesktopProps, FooterMobileProps {}
 
 export const FooterResponsive = forwardRef<HTMLDivElement, FooterResponsiveProps>((props, ref) => {
     const isDesktop = useIsDesktop();

--- a/packages/universal-modal/src/components/header/desktop/Component.desktop.tsx
+++ b/packages/universal-modal/src/components/header/desktop/Component.desktop.tsx
@@ -13,16 +13,17 @@ import { UniversalModalContext } from '../../../context/universal-modal-context'
 import styles from '../base-header/index.module.css';
 import desktopStyles from './desktop.module.css';
 
-export type HeaderDesktopProps = Omit<
-    NavigationBarPrivateProps,
-    'size' | 'view' | 'parentRef' | 'titleSize' | 'subtitle'
-> & {
+export interface HeaderDesktopProps
+    extends Omit<
+        NavigationBarPrivateProps,
+        'size' | 'view' | 'parentRef' | 'titleSize' | 'subtitle'
+    > {
     /**
      * Заголовок в шапке крупного размера
      * @default false
      */
     bigTitle?: boolean;
-};
+}
 
 export const HeaderDesktop = forwardRef<HTMLDivElement, HeaderDesktopProps>((props, ref) => {
     const {

--- a/packages/universal-modal/src/components/header/responsive/Component.responsive.tsx
+++ b/packages/universal-modal/src/components/header/responsive/Component.responsive.tsx
@@ -5,7 +5,7 @@ import { useIsDesktop } from '@alfalab/core-components-mq';
 import { HeaderDesktop, HeaderDesktopProps } from '../desktop/Component.desktop';
 import { HeaderMobile, HeaderMobileProps } from '../mobile/Component.mobile';
 
-export type HeaderResponsiveProps = HeaderDesktopProps | HeaderMobileProps;
+export interface HeaderResponsiveProps extends HeaderDesktopProps, HeaderMobileProps {}
 
 export const HeaderResponsive = forwardRef<HTMLDivElement, HeaderResponsiveProps>((props, ref) => {
     const isDesktop = useIsDesktop();

--- a/packages/universal-modal/src/desktop/Component.desktop.tsx
+++ b/packages/universal-modal/src/desktop/Component.desktop.tsx
@@ -4,11 +4,11 @@ import { ContentDesktop } from '../components/content';
 import { FooterDesktop } from '../components/footer';
 import { HeaderDesktop } from '../components/header';
 import { UniversalModalContext } from '../context/universal-modal-context';
-import { UniversalModalContextType } from '../typings';
+import type { UniversalModalContextType } from '../typings';
 
 import { CenterModal } from './components/center-modal';
 import { SideModal } from './components/side-modal';
-import { UniversalModalDesktopProps } from './types/props';
+import type { UniversalModalDesktopProps } from './types/props';
 import { checkHeaderAndFooter } from './utils/check-header-and-footer';
 
 export const UniversalModalDesktopComponent = forwardRef<

--- a/packages/universal-modal/src/desktop/components/buttons/arrow-button/arrow-button.tsx
+++ b/packages/universal-modal/src/desktop/components/buttons/arrow-button/arrow-button.tsx
@@ -6,9 +6,9 @@ import { ArrowLeftMediumMIcon } from '@alfalab/icons-glyph/ArrowLeftMediumMIcon'
 
 import styles from './arrow-button.module.css';
 
-type ArrowButtonDesktopProps = {
+interface ArrowButtonDesktopProps {
     onClick?: (e: MouseEvent) => void;
-};
+}
 
 export const ArrowButtonDesktop: FC<ArrowButtonDesktopProps> = (props) => {
     const { onClick } = props;

--- a/packages/universal-modal/src/desktop/components/buttons/cross-button/cross-button.tsx
+++ b/packages/universal-modal/src/desktop/components/buttons/cross-button/cross-button.tsx
@@ -5,9 +5,9 @@ import { CrossMediumMIcon } from '@alfalab/icons-glyph/CrossMediumMIcon';
 
 import styles from './cross-button.module.css';
 
-type CrossButtonProps = {
+interface CrossButtonProps {
     onClick?: () => void;
-};
+}
 
 export const CrossButtonDesktop: FC<CrossButtonProps> = (props) => {
     const { onClick } = props;

--- a/packages/universal-modal/src/desktop/components/center-modal/center-modal.tsx
+++ b/packages/universal-modal/src/desktop/components/center-modal/center-modal.tsx
@@ -5,7 +5,7 @@ import { BaseModal } from '@alfalab/core-components-base-modal';
 import { browser, os } from '@alfalab/core-components-shared';
 
 import { useModalWheel } from '../../hooks/useModalWheel';
-import { UniversalModalDesktopProps } from '../../types/props';
+import type { UniversalModalDesktopProps } from '../../types/props';
 import { getFullSizeModalTransitions } from '../../utils/get-full-size-modal-transitions';
 import { getHeightStyle } from '../../utils/get-height-style';
 import { getMarginStyles } from '../../utils/get-margin-styles';

--- a/packages/universal-modal/src/desktop/components/modal-content/modal-content.tsx
+++ b/packages/universal-modal/src/desktop/components/modal-content/modal-content.tsx
@@ -8,15 +8,16 @@ import { Scrollbar } from '@alfalab/core-components-scrollbar';
 import { useModalHighlighted } from '../../hooks/use-modal-highlighted';
 import { useOutsideScroll } from '../../hooks/use-outside-scroll';
 import { useSetScrollbarHeight } from '../../hooks/use-set-scrollbar-height';
-import { UniversalModalDesktopProps } from '../../types/props';
+import type { UniversalModalDesktopProps } from '../../types/props';
 import { setFooterAndHeaderRefs } from '../../utils/set-footer-and-header-refs';
 
 import styles from './modal-content.module.css';
 
-type Props = Pick<BaseModalProps, 'children'> &
-    Pick<UniversalModalDesktopProps, 'height' | 'scrollableContainerRef'> & {
-        wheelDeltaY: number;
-    };
+interface Props
+    extends Pick<BaseModalProps, 'children'>,
+        Pick<UniversalModalDesktopProps, 'height' | 'scrollableContainerRef'> {
+    wheelDeltaY: number;
+}
 
 export const ModalContent: FC<Props> = (props) => {
     const { children, wheelDeltaY, height, scrollableContainerRef = null } = props;

--- a/packages/universal-modal/src/desktop/components/side-modal/get-default-transition-props.ts
+++ b/packages/universal-modal/src/desktop/components/side-modal/get-default-transition-props.ts
@@ -1,13 +1,13 @@
 import cn from 'classnames';
 
-import { UniversalModalDesktopProps } from '../../types/props';
+import type { UniversalModalDesktopProps } from '../../types/props';
 
 import transitions from './transitions/transitions.module.css';
 
-type Params = {
+interface Params {
     horizontalAlign: UniversalModalDesktopProps['horizontalAlign'];
     margin: UniversalModalDesktopProps['margin'];
-};
+}
 
 export const getDefaultTransitionProps = (params: Params) => {
     const { horizontalAlign, margin } = params;

--- a/packages/universal-modal/src/desktop/components/side-modal/side-modal.tsx
+++ b/packages/universal-modal/src/desktop/components/side-modal/side-modal.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames';
 import { BaseModal } from '@alfalab/core-components-base-modal';
 
 import { useModalWheel } from '../../hooks/useModalWheel';
-import { UniversalModalDesktopProps } from '../../types/props';
+import type { UniversalModalDesktopProps } from '../../types/props';
 import { getFullSizeModalTransitions } from '../../utils/get-full-size-modal-transitions';
 import { getHeightStyle } from '../../utils/get-height-style';
 import { getMarginStyles } from '../../utils/get-margin-styles';

--- a/packages/universal-modal/src/desktop/hooks/use-modal-highlighted.tsx
+++ b/packages/universal-modal/src/desktop/hooks/use-modal-highlighted.tsx
@@ -4,10 +4,10 @@ import { ScrollbarProps } from '@alfalab/core-components-scrollbar';
 
 import { UniversalModalContext } from '../../context/universal-modal-context';
 
-type Params = {
+interface Params {
     scrollbarContentNodeRef: RefObject<HTMLDivElement>;
     scrollableNodeRef: RefObject<HTMLDivElement>;
-};
+}
 
 /**
  * Расчет overlap состояния

--- a/packages/universal-modal/src/desktop/hooks/use-outside-scroll.tsx
+++ b/packages/universal-modal/src/desktop/hooks/use-outside-scroll.tsx
@@ -1,9 +1,9 @@
 import { RefObject, useEffect } from 'react';
 
-type Params = {
+interface Params {
     scrollableNodeRef: RefObject<HTMLDivElement>;
     wheelDeltaY: number;
-};
+}
 
 /** Изменение позиции скролла */
 export const useOutsideScroll = (params: Params) => {

--- a/packages/universal-modal/src/desktop/hooks/use-set-scrollbar-height.tsx
+++ b/packages/universal-modal/src/desktop/hooks/use-set-scrollbar-height.tsx
@@ -2,12 +2,12 @@ import { RefObject, useEffect } from 'react';
 
 import { SCROLLBAR_DEFAULT_GAP } from '../constants';
 
-type Params = {
+interface Params {
     scrollbarRef: RefObject<HTMLDivElement>;
     verticalBarRef: RefObject<HTMLDivElement>;
     headerElementRef: RefObject<HTMLDivElement>;
     footerElementRef: RefObject<HTMLDivElement>;
-};
+}
 
 /** Устанавливает размер полосы прокрутки в зависимости от наличия хедера и футера */
 export const useSetScrollbarHeight = (params: Params) => {

--- a/packages/universal-modal/src/desktop/types/props.ts
+++ b/packages/universal-modal/src/desktop/types/props.ts
@@ -1,10 +1,10 @@
 import type { RefObject } from 'react';
 
-import { BaseModalProps } from '@alfalab/core-components-base-modal';
+import type { BaseModalProps } from '@alfalab/core-components-base-modal';
 
-import { TMargin } from '../../typings/margin-type';
+import type { TMargin } from '../../typings/margin-type';
 
-export type BaseUniversalModalProps = {
+export interface BaseUniversalModalProps {
     /**
      * Расположение по горизонтали и сторона с которой модал “выезжает” при открытии
      * @default center
@@ -44,26 +44,27 @@ export type BaseUniversalModalProps = {
      * Устанавливает отступы модального окна
      */
     margin?: TMargin;
-};
+}
 
-export type UniversalModalDesktopProps = BaseUniversalModalProps &
-    Pick<BaseModalProps, 'open'> &
-    Partial<
-        Pick<
-            BaseModalProps,
-            | 'children'
-            | 'dataTestId'
-            | 'className'
-            | 'wrapperClassName'
-            | 'onUnmount'
-            | 'transitionProps'
-            | 'backdropProps'
-            | 'disableBackdropClick'
-            | 'onClose'
-        >
-    > & {
-        /**
-         * Реф контейнера на котором происходит scroll
-         */
-        scrollableContainerRef?: RefObject<HTMLDivElement>;
-    };
+export interface UniversalModalDesktopProps
+    extends BaseUniversalModalProps,
+        Pick<BaseModalProps, 'open'>,
+        Partial<
+            Pick<
+                BaseModalProps,
+                | 'children'
+                | 'dataTestId'
+                | 'className'
+                | 'wrapperClassName'
+                | 'onUnmount'
+                | 'transitionProps'
+                | 'backdropProps'
+                | 'disableBackdropClick'
+                | 'onClose'
+            >
+        > {
+    /**
+     * Реф контейнера на котором происходит scroll
+     */
+    scrollableContainerRef?: RefObject<HTMLDivElement>;
+}

--- a/packages/universal-modal/src/desktop/utils/get-full-size-modal-transitions.ts
+++ b/packages/universal-modal/src/desktop/utils/get-full-size-modal-transitions.ts
@@ -3,24 +3,24 @@ import { TransitionProps } from 'react-transition-group/Transition';
 import { BackdropProps } from '@alfalab/core-components-backdrop';
 import { exhaustiveCheck } from '@alfalab/core-components-shared';
 
-import { UniversalModalDesktopProps } from '../types/props';
+import type { UniversalModalDesktopProps } from '../types/props';
 
 import fullSizeBackdropTransitions from '../styles/transitions/full-size-backdrop-transitions.module.css';
 import fullSizeVerticalBottomTransitions from '../styles/transitions/full-size-vertical-bottom-transitions.module.css';
 import fullSizeVerticalCenterTransitions from '../styles/transitions/full-size-vertical-center-transitions.module.css';
 import fullSizeVerticalTopTransitions from '../styles/transitions/full-size-vertical-top-transitions.module.css';
 
-type Params = {
+interface Params {
     verticalAlign: Exclude<UniversalModalDesktopProps['verticalAlign'], undefined>;
     width: UniversalModalDesktopProps['width'];
     height: UniversalModalDesktopProps['height'];
-};
+}
 
-type ReturnType = {
+interface ReturnType {
     isFullSizeModal: boolean;
     backdropTransitions: Partial<BackdropProps>;
     componentTransitions: Partial<TransitionProps>;
-};
+}
 
 export const getFullSizeModalTransitions = (params: Params): ReturnType => {
     const { verticalAlign, width, height } = params;

--- a/packages/universal-modal/src/desktop/utils/get-height-style.ts
+++ b/packages/universal-modal/src/desktop/utils/get-height-style.ts
@@ -1,6 +1,6 @@
 import { hasOwnProperty, isClient } from '@alfalab/core-components-shared';
 
-import { UniversalModalDesktopProps } from '../types/props';
+import type { UniversalModalDesktopProps } from '../types/props';
 
 export const getHeightStyle = (
     height: Exclude<UniversalModalDesktopProps['height'], undefined>,

--- a/packages/universal-modal/src/desktop/utils/get-margin-styles.ts
+++ b/packages/universal-modal/src/desktop/utils/get-margin-styles.ts
@@ -1,11 +1,11 @@
 import { hasOwnProperty } from '@alfalab/core-components-shared';
 
-import { UniversalModalDesktopProps } from '../types/props';
+import type { UniversalModalDesktopProps } from '../types/props';
 
-type Params = {
+interface Params {
     styles: Record<string, string>;
     margin: UniversalModalDesktopProps['margin'];
-};
+}
 
 export const getMarginStyles = (params: Params): Record<string, boolean> => {
     const { margin, styles } = params;

--- a/packages/universal-modal/src/desktop/utils/get-max-height-style.ts
+++ b/packages/universal-modal/src/desktop/utils/get-max-height-style.ts
@@ -1,6 +1,6 @@
 import { hasOwnProperty } from '@alfalab/core-components-shared';
 
-import { UniversalModalDesktopProps } from '../types/props';
+import type { UniversalModalDesktopProps } from '../types/props';
 
 export const getMaxHeightStyle = (margin: UniversalModalDesktopProps['margin']) => {
     const marginTop = (margin && hasOwnProperty(margin, 'top') && margin.top) || 0;

--- a/packages/universal-modal/src/desktop/utils/get-width-style.ts
+++ b/packages/universal-modal/src/desktop/utils/get-width-style.ts
@@ -1,6 +1,6 @@
 import { hasOwnProperty, isClient } from '@alfalab/core-components-shared';
 
-import { UniversalModalDesktopProps } from '../types/props';
+import type { UniversalModalDesktopProps } from '../types/props';
 
 export const getWidthStyle = (
     width: Exclude<UniversalModalDesktopProps['width'], undefined>,

--- a/packages/universal-modal/src/desktop/utils/set-footer-and-header-refs.tsx
+++ b/packages/universal-modal/src/desktop/utils/set-footer-and-header-refs.tsx
@@ -15,11 +15,11 @@ import { HeaderDesktop } from '../../components/header';
 import { isFooterNode } from './isFooterNode';
 import { isHeaderNode } from './isHeaderNode';
 
-type Params = {
+interface Params {
     children: ReactNode;
     headerElementRef: RefObject<HTMLDivElement>;
     footerElementRef: RefObject<HTMLDivElement>;
-};
+}
 
 /** Устанавливает рефы в хедер и футер если они переданы в модалку (необходимы для дальнейшего расчета высоты кастомного скроллбара) */
 export const setFooterAndHeaderRefs = (params: Params) => {

--- a/packages/universal-modal/src/mobile/Component.mobile.tsx
+++ b/packages/universal-modal/src/mobile/Component.mobile.tsx
@@ -7,7 +7,7 @@ import { ContentMobile } from '../components/content';
 import { FooterMobile } from '../components/footer';
 import { HeaderMobile } from '../components/header';
 
-import { UniversalModalMobileProps } from './types/props';
+import type { UniversalModalMobileProps } from './types/props';
 
 import styles from './mobile.module.css';
 import rightSideTransitions from './transitions/right-side-transitions.mobile.module.css';

--- a/packages/universal-modal/src/mobile/components/buttons/arrow-button/arrow-button.tsx
+++ b/packages/universal-modal/src/mobile/components/buttons/arrow-button/arrow-button.tsx
@@ -5,9 +5,9 @@ import { ChevronLeftMIcon } from '@alfalab/icons-glyph/ChevronLeftMIcon';
 
 import styles from './arrow-button.module.css';
 
-type ArrowButtonDesktopProps = {
+interface ArrowButtonDesktopProps {
     onClick?: (e: MouseEvent) => void;
-};
+}
 
 export const ArrowButtonMobile: FC<ArrowButtonDesktopProps> = (props) => {
     const { onClick } = props;

--- a/packages/universal-modal/src/mobile/components/buttons/cross-button/cross-button.tsx
+++ b/packages/universal-modal/src/mobile/components/buttons/cross-button/cross-button.tsx
@@ -5,9 +5,9 @@ import { CrossMIcon } from '@alfalab/icons-glyph/CrossMIcon';
 
 import styles from './cross-button.module.css';
 
-type CrossButtonProps = {
+interface CrossButtonProps {
     onClick?: () => void;
-};
+}
 
 export const CrossButtonMobile: FC<CrossButtonProps> = (props) => {
     const { onClick } = props;

--- a/packages/universal-modal/src/mobile/types/props.ts
+++ b/packages/universal-modal/src/mobile/types/props.ts
@@ -1,21 +1,22 @@
 import { BaseModalProps } from '@alfalab/core-components-base-modal';
 
-export type BaseUniversalModalMobileProps = {
+export interface BaseUniversalModalMobileProps {
     /** Сторона с которой будет появляться модальное окно */
     appearance?: 'bottom' | 'right';
-};
+}
 
-export type UniversalModalMobileProps = BaseUniversalModalMobileProps &
-    Pick<BaseModalProps, 'open'> &
-    Partial<
-        Pick<
-            BaseModalProps,
-            | 'children'
-            | 'dataTestId'
-            | 'className'
-            | 'wrapperClassName'
-            | 'onUnmount'
-            | 'transitionProps'
-            | 'onClose'
-        >
-    >;
+export interface UniversalModalMobileProps
+    extends BaseUniversalModalMobileProps,
+        Pick<BaseModalProps, 'open'>,
+        Partial<
+            Pick<
+                BaseModalProps,
+                | 'children'
+                | 'dataTestId'
+                | 'className'
+                | 'wrapperClassName'
+                | 'onUnmount'
+                | 'transitionProps'
+                | 'onClose'
+            >
+        > {}

--- a/packages/universal-modal/src/typings/index.ts
+++ b/packages/universal-modal/src/typings/index.ts
@@ -1,7 +1,7 @@
 import { UniversalModalDesktopProps } from '../desktop';
 import { UniversalModalMobileProps } from '../mobile';
 
-export type UniversalModalContextType = {
+export interface UniversalModalContextType {
     modalWidth: UniversalModalDesktopProps['width'];
     modalHeaderHighlighted?: boolean;
     modalFooterHighlighted?: boolean;
@@ -9,18 +9,19 @@ export type UniversalModalContextType = {
     hasFooter: boolean;
     setModalHeaderHighlighted?: (value: boolean) => void;
     setModalFooterHighlighted?: (value: boolean) => void;
-};
+}
 
-export type UniversalModalResponsiveProps = UniversalModalDesktopProps &
-    UniversalModalMobileProps & {
-        /**
-         * Контрольная точка, с нее начинается desktop версия
-         * @default 1024
-         */
-        breakpoint?: number;
+export interface UniversalModalResponsiveProps
+    extends UniversalModalDesktopProps,
+        UniversalModalMobileProps {
+    /**
+     * Контрольная точка, с нее начинается desktop версия
+     * @default 1024
+     */
+    breakpoint?: number;
 
-        /**
-         * Значение по-умолчанию для хука useMatchMedia
-         */
-        defaultMatchMediaValue?: boolean | (() => boolean);
-    };
+    /**
+     * Значение по-умолчанию для хука useMatchMedia
+     */
+    defaultMatchMediaValue?: boolean | (() => boolean);
+}

--- a/packages/universal-modal/src/typings/margin-type.ts
+++ b/packages/universal-modal/src/typings/margin-type.ts
@@ -1,8 +1,8 @@
 type TMarginSize = 0 | 2 | 4 | 8 | 12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64 | 72 | 80 | 96 | 128;
 
-export type TMargin = {
+export interface TMargin {
     top?: TMarginSize;
     right?: TMarginSize;
     bottom?: TMarginSize;
     left?: TMarginSize;
-};
+}


### PR DESCRIPTION
(cherry picked from commit b3104f631d4b68928cbadc43cba3bbe61c5c21b4) - Фикс из 49 версии
Перевод с типов на интерфейсы (исправляет сборку типов)
Аналогичный фикс в 49ю версию https://github.com/core-ds/core-components/pull/1838
