### PR TITLE
chore: исключение возможности проброса onClear на div в BaseFormControl [DS-10485]

### DIFF
--- a/.changeset/wild-experts-sleep.md
+++ b/.changeset/wild-experts-sleep.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select-with-tags': minor
+---
+
+Исключение возможности проброса onClear через компонент `SelectWithTag` в `BaseFormControl`

--- a/packages/select-with-tags/src/components/base-select-with-tags/Component.tsx
+++ b/packages/select-with-tags/src/components/base-select-with-tags/Component.tsx
@@ -148,7 +148,7 @@ export const BaseSelectWithTags = forwardRef<HTMLInputElement, BaseSelectWithTag
                 view={view}
                 ref={ref}
                 Option={Option}
-                Field={TagList as FC<FieldProps>}
+                Field={TagList as FC<Omit<FieldProps, 'onClear'>>}
                 Optgroup={Optgroup}
                 OptionsList={OptionsList}
                 Arrow={Arrow}
@@ -173,6 +173,7 @@ export const BaseSelectWithTags = forwardRef<HTMLInputElement, BaseSelectWithTag
                         ? { selectedMultiple: frozenValue.current }
                         : null),
                 }}
+                disableClear={true}
                 selected={selected}
                 autocomplete={view === 'desktop' && isAutocomplete}
                 size={size}

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -17,7 +17,7 @@ import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
 import type { FormControlProps } from '@alfalab/core-components-form-control';
-import type { FieldProps } from '@alfalab/core-components-select/shared';
+import type { FieldProps, OptionShape } from '@alfalab/core-components-select/shared';
 import { useFocus, useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
 import type { TagComponent } from '../../types';
@@ -57,7 +57,7 @@ const SIZE_TO_CLASSNAME_MAP = {
 };
 
 export const TagList: FC<
-    Partial<FieldProps> & Omit<FormControlProps, 'size'> & TagListOwnProps
+    Partial<Omit<FieldProps, 'onClear'>> & Omit<FormControlProps, 'size'> & TagListOwnProps
 > = ({
     size = 72,
     open,
@@ -240,7 +240,7 @@ export const TagList: FC<
                     })}
                     ref={contentWrapperRef}
                 >
-                    {selectedMultiple.map((option, index) =>
+                    {selectedMultiple.map((option: OptionShape, index: number) =>
                         (collapseTagList && isShowMoreEnabled) || index + 1 <= visibleElements ? (
                             <Tag
                                 checked={true}
@@ -294,3 +294,5 @@ export const TagList: FC<
         </div>
     );
 };
+
+TagList.displayName = 'TagList';

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -83,6 +83,7 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
             label,
             labelView,
             placeholder,
+            disableClear,
             fieldProps = {},
             optionsListProps = {},
             optionProps = {},
@@ -683,7 +684,7 @@ export const BaseSelect = forwardRef<unknown, ComponentProps>(
                     valueRenderer={valueRenderer}
                     className={fieldClassName}
                     clear={clear}
-                    onClear={handleFieldClear}
+                    {...(disableClear ? {} : { onClear: handleFieldClear })}
                     innerProps={{
                         onBlur: handleFieldBlur,
                         onFocus: disabled ? undefined : handleFieldFocus,

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -352,6 +352,11 @@ export type BaseSelectProps = {
     clear?: boolean;
 
     /**
+     * Флаг, отключить кнопку очистки поля
+     */
+    disableClear?: boolean;
+
+    /**
      * Хранит функцию, с помощью которой можно обновить положение поповера
      */
     updatePopover?: PopoverProps['update'];
@@ -479,7 +484,7 @@ export type FieldProps = {
         tabIndex?: number;
         id: string;
     } & RefAttributes<HTMLDivElement | HTMLInputElement> &
-        AriaAttributes;
+    AriaAttributes;
 
     /**
      * Идентификатор для систем автоматизированного тестирования
@@ -785,7 +790,7 @@ export type OptionCommonProps = {
         onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void;
         role?: string;
     } & RefAttributes<HTMLDivElement> &
-        AriaAttributes;
+    AriaAttributes;
 
     /**
      * Идентификатор для систем автоматизированного тестирования


### PR DESCRIPTION
Исключение возможности проброса onClear через компонент `SelectWithTag` в `BaseFormControl`

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало


<img width="1684" height="1040" alt="Снимок экрана 2025-08-28 в 09 40 49" src="https://github.com/user-attachments/assets/b3c953dd-767d-4e6d-8bdd-4703af227b71" />

