### PR TITLE
fix(popup-sheet): исправлена работа touch событий version/48 [DS-12251]

### DIFF
--- a/.changeset/pink-eyes-ring.md
+++ b/.changeset/pink-eyes-ring.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-popup-sheet': patch
+---
+
+-  Исправлена работа touch событий в PopupSheet. Обработчики useSwipeable теперь навешиваются на правильный элемент, что решает проблемы с перехватом touchmove на мобильных устройствах.

--- a/packages/popup-sheet/package.json
+++ b/packages/popup-sheet/package.json
@@ -21,6 +21,7 @@
         "@alfalab/core-components-shared": "^0.18.0",
         "@alfalab/core-components-navigation-bar-private": "^0.8.8",
         "react-swipeable": "^7.0.0",
+        "react-merge-refs": "^1.1.0",
         "classnames": "^2.5.1",
         "tslib": "^2.4.0"
     },

--- a/packages/popup-sheet/src/Component.tsx
+++ b/packages/popup-sheet/src/Component.tsx
@@ -6,6 +6,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
+import mergeRefs from 'react-merge-refs';
 import { SwipeCallback, useSwipeable } from 'react-swipeable';
 import cn from 'classnames';
 
@@ -187,6 +188,9 @@ export const PopupSheet = forwardRef<HTMLDivElement, PopupSheetProps>(
             delta: 5,
         });
 
+        const { ref: swipeRef, ...swipeHandlers } = sheetSwipeableHandlers;
+        const componentRef = mergeRefs([sheetRef, swipeRef]);
+
         return (
             <BaseModal
                 {...restProps}
@@ -216,13 +220,13 @@ export const PopupSheet = forwardRef<HTMLDivElement, PopupSheetProps>(
                     onExited: handleExited,
                 }}
                 componentDivProps={{
-                    ref: sheetRef,
+                    ref: componentRef,
                     style: getSwipeStyles(),
+                    ...(swipeable ? swipeHandlers : {}),
                 }}
                 contentProps={{
                     style: createPaddingStyle(padding),
                     ...contentProps,
-                    ...sheetSwipeableHandlers,
                     className: cn(styles.content, contentProps?.className),
                 }}
             >


### PR DESCRIPTION
-  Исправлена работа touch событий в PopupSheet. Обработчики useSwipeable теперь навешиваются на правильный элемент, что решает проблемы с перехватом touchmove на мобильных устройствах.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset
