### PR TITLE
fix(skeleton): improve skeleton height measuring

### DIFF
--- a/.changeset/polite-terms-poke.md
+++ b/.changeset/polite-terms-poke.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-skeleton': patch
+'@alfalab/core-components': patch
+---
+
+Исправлен расчет высоты элементов текстового скелетона. Теперь размер совпадает не с fontSize, а с размером начертания глифов от базовой линии.

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-align-0-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-align-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe0b2be4039eac36b10c26b11f3bc374e805aacac82b6ac77e74299fd5ce40df
-size 38247
+oid sha256:83030a982c89a8eb8700e828dde19c60924a227b5d8fa9891a1236d878129cc2
+size 38168

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-align-1-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-align-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65494344a7727c88aae92682d3a2bfc408f98dbcd61524822a67c8db4b275388
-size 38256
+oid sha256:079d1effe8e761d478dcc08fe0b1f7fcfbbafd5b70634abeeead1d7df5d48bc0
+size 38167

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-align-2-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-align-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36a0bb5d969fd4538cb4a3fc25d01af40c342ecabc14070eebbf1b4fe70a5fa8
-size 38243
+oid sha256:f1565d17662f139654e62e83cc7526fb89893c4cd07bb821dd98cfea55eecb7e
+size 38169

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-0-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:269d7a98808bfef6a72e58d52e7281f40eb27beb4d300ed441cb56fb055f738d
-size 38226
+oid sha256:13d2215d658da218943c4f67621f7d5d9d6c476117f38ae3e3c5f707e8a7c3b8
+size 38151

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-1-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:337f04ccbe04f9e8090d62d14fd3acfaced9765bb5c330430a3144c4ee27609d
-size 38591
+oid sha256:72ae74efcdceef642661a70db7733d9125d8013add79823202ad1b4c9de1c574
+size 38491

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-2-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-rows-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:870abf26ab671c0fd4b592cd721df671b7801cdcf550094ad60bf673559fa860
-size 38928
+oid sha256:a62879221b8399e3250af584a8c480a9177a81fbf56ceff53e597e1bbe8a3895
+size 38806

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-width-0-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-width-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:269d7a98808bfef6a72e58d52e7281f40eb27beb4d300ed441cb56fb055f738d
-size 38226
+oid sha256:13d2215d658da218943c4f67621f7d5d9d6c476117f38ae3e3c5f707e8a7c3b8
+size 38151

--- a/packages/skeleton/src/__image_snapshots__/skeleton-text-width-1-snap.png
+++ b/packages/skeleton/src/__image_snapshots__/skeleton-text-width-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5681911fabc51b147ba35c6ab8d7cb6256a74c5c7a15dffccabe83e8bdff65a1
-size 38249
+oid sha256:9e7e6fa7041be88e5c089cd3cee80b185365141e80fc194a0c022e8f897cbdb5
+size 38167

--- a/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
+++ b/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
@@ -31,10 +31,25 @@ export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeleton
             const fontSize = parseInt(style.fontSize, 10);
             const lineHeight = parseInt(style.lineHeight, 10);
 
-            const padding =
+            let padding =
                 (lineHeight - fontSize) % 2 === 0
                     ? (lineHeight - fontSize) / 2
                     : (lineHeight - fontSize - 1) / 2;
+
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+
+            /**
+             * Расчет отступов с учётом размера глифа от базовой линии до верхней границы
+             * Это позволяет отображать более приближённый размер скелетона к начертанию текста
+             * @see DS-12535
+             */
+            if (context && textRef.current.textContent) {
+                context.font = style.font;
+                const metrics = context.measureText(textRef.current.textContent);
+
+                padding = (lineHeight - metrics.actualBoundingBoxAscent) / 2;
+            }
 
             const rows = skeletonProps?.rows
                 ? skeletonProps?.rows


### PR DESCRIPTION
DS-12535

Исправлен расчет высоты элементов текстового скелетона. Теперь размер совпадает не с fontSize, а с размером начертания глифов от базовой линии.

Если по какой-то причине canvas не отработает, рассчитается по старой схеме