### PR TITLE
fix(side-panel): add unmount footer setState

### DIFF
--- a/.changeset/orange-jars-shake.md
+++ b/.changeset/orange-jars-shake.md
@@ -1,4 +1,5 @@
 ---
+'@alfalab/core-components': patch
 '@alfalab/core-components-side-panel': patch
 ---
 

--- a/.changeset/orange-jars-shake.md
+++ b/.changeset/orange-jars-shake.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-side-panel': patch
+---
+
+Исправлен баг, при котором hasFooter не сбрасывался в false при размонтировании компонента

--- a/packages/side-panel/src/components/footer/Component.tsx
+++ b/packages/side-panel/src/components/footer/Component.tsx
@@ -54,6 +54,10 @@ export const Footer: FC<FooterProps> = ({
 
     useEffect(() => {
         setHasFooter(true);
+
+        return () => {
+            setHasFooter(false);
+        };
     }, [setHasFooter]);
 
     return (


### PR DESCRIPTION
Исправлен баг, при котором hasFooter не сбрасывался в false при размонтировании компонента

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] К реквесту добавлен changeset
