### PR TITLE
fix(system-message): исправить отображение внутри SystemMessage.Controls кнопок обернутых во Fragment [DS-13170]

### DIFF
--- a/.changeset/ready-facts-peel.md
+++ b/.changeset/ready-facts-peel.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-system-message': patch
+'@alfalab/core-components': patch
+---
+
+- `SystemMessage.Controls` корректно применяет `direction="column" | "row"`, даже если кнопки передаются внутри `React.Fragment`.

--- a/packages/system-message/src/components/controls/Component.tsx
+++ b/packages/system-message/src/components/controls/Component.tsx
@@ -6,6 +6,8 @@ import { type PaddingType } from '@alfalab/core-components-types';
 
 import { SystemMessageContext } from '../../Context';
 
+import { hasMultipleChildren } from './utils';
+
 import styles from './index.module.css';
 
 type ControlsProps = {
@@ -43,7 +45,7 @@ export const Controls: React.FC<ControlsProps> = ({
     const { dataTestId, view } = useContext(SystemMessageContext);
     const defaultDirection = view === 'mobile' ? 'column' : 'row';
     const direction = directionProp || defaultDirection;
-    const isMultipleElements = React.Children.toArray(children).length > 1;
+    const isMultipleElements = hasMultipleChildren(children);
     const isColumn = isMultipleElements && direction === 'column';
     const padding =
         paddingProp ?? (view === 'mobile' ? DEFAULT_MOBILE_PADDING : DEFAULT_DESKTOP_PADDING);

--- a/packages/system-message/src/components/controls/utils.test.tsx
+++ b/packages/system-message/src/components/controls/utils.test.tsx
@@ -1,0 +1,99 @@
+import React, { Fragment, type ReactNode } from 'react';
+
+import { hasMultipleChildren } from './utils';
+
+describe('Unit/utility/function/hasMultipleChildren', () => {
+    describe('SUCCESS CASES', () => {
+        it.each`
+            label                    | input
+            ${'two simple elements'} | ${[<div key='a' />, <button key='b' />]}
+            ${'elements inside Fragment'} | ${(
+    <Fragment>
+        <div />
+        <button />
+    </Fragment>
+)}
+        `('returns true for $label', ({ input }) => {
+            expect(hasMultipleChildren(input as ReactNode)).toBe(true);
+        });
+
+        it.each`
+            label                   | input
+            ${'single element div'} | ${(<div />)}
+        `('returns false for $label', ({ input }) => {
+            expect(hasMultipleChildren(input as ReactNode)).toBe(false);
+        });
+    });
+
+    describe('EDGE CASES', () => {
+        it.each`
+            label                  | input
+            ${'null'}              | ${null}
+            ${'undefined'}         | ${undefined}
+            ${'empty array'}       | ${[]}
+            ${'only falsy values'} | ${[null, undefined, false]}
+            ${'one non-falsy'}     | ${[null, false, <div key='x' />]}
+        `('returns false for $label', ({ input }) => {
+            expect(hasMultipleChildren(input as ReactNode)).toBe(false);
+        });
+
+        it.each`
+            label                         | input
+            ${'text node with element'}   | ${['text', <div key='d' />]}
+            ${'number node with element'} | ${[0, <div key='n' />]}
+        `('returns true for $label', ({ input }) => {
+            expect(hasMultipleChildren(input as ReactNode)).toBe(true);
+        });
+
+        it('handles deep nested Fragments correctly', () => {
+            const result = hasMultipleChildren(
+                <Fragment>
+                    <Fragment>
+                        <span />
+                    </Fragment>
+                    <Fragment>
+                        <>text</>
+                    </Fragment>
+                </Fragment>,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('returns false for deep nested single element inside Fragments', () => {
+            const result = hasMultipleChildren(
+                <Fragment>
+                    <Fragment>
+                        <Fragment>
+                            <span />
+                        </Fragment>
+                    </Fragment>
+                </Fragment>,
+            );
+
+            expect(result).toBe(false);
+        });
+
+        it('returns false for Fragment with only falsy children', () => {
+            const result = hasMultipleChildren(
+                <Fragment>
+                    {null}
+                    {false}
+                    {undefined}
+                </Fragment>,
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('ERROR CASES', () => {
+        it('does not throw for arbitrary value (Symbol)', () => {
+            const value = Symbol('child');
+
+            const call = () => hasMultipleChildren(value as unknown as ReactNode);
+
+            expect(call).not.toThrow();
+        });
+    });
+});

--- a/packages/system-message/src/components/controls/utils.ts
+++ b/packages/system-message/src/components/controls/utils.ts
@@ -1,0 +1,25 @@
+import React, { Fragment, type ReactNode } from 'react';
+
+export const hasMultipleChildren = (nodes: ReactNode): boolean => {
+    let count = 0;
+
+    const walk = (node: ReactNode) => {
+        if (count > 1) return;
+
+        const array = React.Children.toArray(node);
+
+        for (const child of array) {
+            if (count > 1) return;
+
+            if (React.isValidElement(child) && child.type === Fragment) {
+                walk(child.props.children);
+            } else {
+                count += 1;
+            }
+        }
+    };
+
+    walk(nodes);
+
+    return count > 1;
+};


### PR DESCRIPTION
- `SystemMessage.Controls` корректно применяет `direction="column" | "row"`, даже если кнопки передаются внутри `React.Fragment`.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

https://github.com/user-attachments/assets/eb215471-0f73-4762-91c5-dbd699306c26
