### PR TITLE
fix(slider-input): insert customInputProps prop in end of Input

### DIFF
--- a/.changeset/cute-islands-camp.md
+++ b/.changeset/cute-islands-camp.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components': patch
+'@alfalab/core-components-slider-input': patch
+---
+
+Исправлено переопределние пропсов Input с помощью customInputProps

--- a/packages/slider-input/src/Component.tsx
+++ b/packages/slider-input/src/Component.tsx
@@ -266,7 +266,6 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
             >
                 <Input
                     {...restProps}
-                    {...customInputProps}
                     ref={ref}
                     value={value.toString()}
                     onChange={handleInputChange}
@@ -320,6 +319,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                             </Fragment>
                         )
                     }
+                    {...customInputProps}
                 />
                 {/* eslint-disable react/no-array-index-key */}
                 {steps.length > 0 && !error && (


### PR DESCRIPTION
- Исправлено переопределние пропсов Input с помощью customInputProps

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset
