### PR TITLE
fix(skeleton): Добавить состояние по умолчанию для useSkeleton [DS-14170]

### DIFF
--- a/.changeset/floppy-places-happen.md
+++ b/.changeset/floppy-places-happen.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-skeleton': patch
+---
+
+- Скелетон текста рендерится на SSR по fallback-параметрам, без ожидания layout-effect.

--- a/packages/skeleton/src/docs/Component.stories.tsx
+++ b/packages/skeleton/src/docs/Component.stories.tsx
@@ -118,7 +118,9 @@ export const skeleton_text: Story = {
         // дополнительные преобразования нужны для скриншот-тестирования, так как все кнобсы в этом случае приходят в виде строки
         const getRows = () => {
             if (typeof rows === 'string') {
-                return Number(rows);
+                const parsed = Number(rows);
+
+                return Number.isFinite(parsed) ? parsed : undefined;
             }
 
             return rows;

--- a/packages/skeleton/src/hooks/use-skeleton/use-skeleton.test.tsx
+++ b/packages/skeleton/src/hooks/use-skeleton/use-skeleton.test.tsx
@@ -22,6 +22,10 @@ Object.defineProperty(window, 'getComputedStyle', {
 });
 
 describe('useSkeleton tests', () => {
+    it('should not throw when rows is NaN', () => {
+        expect(() => render(<Skeleton rows={Number('undefined')} />)).not.toThrow();
+    });
+
     it('should set `wrapperClassName`', () => {
         const wrapperClassName = 'wrapperClassName';
         const { container } = render(<Skeleton wrapperClassName={wrapperClassName} rows={10} />);

--- a/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
+++ b/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
@@ -19,8 +19,16 @@ type SkeletonProps = {
     dataTestId?: string;
 };
 
+const getFallbackSkeletonParams = (skeletonProps?: TextSkeletonProps): TextSkeletonParams => ({
+    height: 16,
+    padding: '4px 0',
+    rows: skeletonProps?.rows ?? 1,
+});
+
 export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeletonProps) {
-    const [skeletonParams, setSkeletonParams] = useState<TextSkeletonParams>();
+    const [skeletonParams, setSkeletonParams] = useState<TextSkeletonParams | undefined>(() =>
+        showSkeleton ? getFallbackSkeletonParams(skeletonProps) : undefined,
+    );
     const textRef = useRef<HTMLElement>(null);
 
     useLayoutEffect_SAFE_FOR_SSR(() => {
@@ -60,6 +68,8 @@ export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeleton
                 padding: `${padding}px 0`,
                 rows,
             });
+        } else if (showSkeleton) {
+            setSkeletonParams(getFallbackSkeletonParams(skeletonProps));
         } else {
             setSkeletonParams(undefined);
         }

--- a/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
+++ b/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
@@ -19,8 +19,17 @@ type SkeletonProps = {
     dataTestId?: string;
 };
 
+/** Fallback для SSR. */
+const getFallbackSkeletonParams = (skeletonProps?: TextSkeletonProps): TextSkeletonParams => ({
+    height: 16,
+    padding: '4px 0',
+    rows: skeletonProps?.rows ?? 1,
+});
+
 export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeletonProps) {
-    const [skeletonParams, setSkeletonParams] = useState<TextSkeletonParams>();
+    const [skeletonParams, setSkeletonParams] = useState<TextSkeletonParams | undefined>(() =>
+        showSkeleton ? getFallbackSkeletonParams(skeletonProps) : undefined,
+    );
     const textRef = useRef<HTMLElement>(null);
 
     useLayoutEffect_SAFE_FOR_SSR(() => {
@@ -60,6 +69,8 @@ export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeleton
                 padding: `${padding}px 0`,
                 rows,
             });
+        } else if (showSkeleton) {
+            setSkeletonParams(getFallbackSkeletonParams(skeletonProps));
         } else {
             setSkeletonParams(undefined);
         }

--- a/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
+++ b/packages/skeleton/src/hooks/use-skeleton/use-skeleton.tsx
@@ -23,7 +23,7 @@ type SkeletonProps = {
 const getFallbackSkeletonParams = (skeletonProps?: TextSkeletonProps): TextSkeletonParams => ({
     height: 16,
     padding: '4px 0',
-    rows: skeletonProps?.rows ?? 1,
+    rows: skeletonProps?.rows || 1,
 });
 
 export function useSkeleton(showSkeleton?: boolean, skeletonProps?: TextSkeletonProps) {

--- a/packages/typography/src/text/component.ssr.test.tsx
+++ b/packages/typography/src/text/component.ssr.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { Text } from './index';
+
+describe('Text SSR', () => {
+    describe('Success cases', () => {
+        it('should render skeleton if `showSkeleton` is true', () => {
+            const html = renderToString(
+                <Text
+                    dataTestId='text-skeleton'
+                    showSkeleton={true}
+                    skeletonProps={{ rows: 1, width: '100%' }}
+                >
+                    Content
+                </Text>,
+            );
+
+            expect(html).toContain('data-test-id="text-skeleton"');
+            expect(html).toContain('skeletonText');
+            expect(html).toContain('width:100%');
+            expect(html).not.toContain('Content');
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should render fallback skeleton without `skeletonProps`', () => {
+            const html = renderToString(
+                <Text dataTestId='text-skeleton' showSkeleton={true}>
+                    Content
+                </Text>,
+            );
+
+            expect(html).toContain('data-test-id="text-skeleton"');
+            expect(html).toContain('skeletonText');
+            expect(html).toContain('padding:4px 0');
+            expect(html).toContain('height:16px');
+            expect(html).not.toContain('Content');
+        });
+
+        it('should render content if `showSkeleton` is false', () => {
+            const html = renderToString(
+                <Text dataTestId='text-skeleton' showSkeleton={false}>
+                    Content
+                </Text>,
+            );
+
+            expect(html).toContain('data-test-id="text-skeleton"');
+            expect(html).toContain('Content');
+            expect(html).not.toContain('skeletonText');
+        });
+    });
+
+    describe('Error cases', () => {
+        it('should not throw without DOM APIs if `showSkeleton` is true', () => {
+            expect(() => {
+                renderToString(
+                    <Text dataTestId='text-skeleton' showSkeleton={true}>
+                        Content
+                    </Text>,
+                );
+            }).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
##### hooks/useSkeleton

Добавлено дефолтное состояние в `useSkeleton`, чтобы SSR сразу отдавал текстовый скелетон без мерцания.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

Было:

https://github.com/user-attachments/assets/13f1141a-cbf2-45c2-ae8d-382d2743ef61


Стало:

https://github.com/user-attachments/assets/fd8336a6-7cf0-4e1e-9086-16ddfa5bfcfc



