### PR TITLE
feat/MCH-5073 (internationa-phone-input): hideCountryFlag prop

### DIFF
--- a/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
+++ b/packages/international-phone-input/src/components/base-international-phone-input/Component.tsx
@@ -38,6 +38,7 @@ export const BaseInternationalPhoneInput = forwardRef<
     (
         {
             clearableCountryCode: clearableCountryCodeFromProps = true,
+            hideCountryFlag = false,
             value,
             country: countryProp,
             filterFn,
@@ -235,13 +236,15 @@ export const BaseInternationalPhoneInput = forwardRef<
                     ...inputProps,
                     onClear: handleClear,
                     onInput: handleInput,
-                    leftAddons: renderCountrySelect(view === 'mobile'),
+                    leftAddons: hideCountryFlag ? null : renderCountrySelect(view === 'mobile'),
                 }}
                 fieldProps={{
                     ...(restProps.fieldProps as AnyObject),
                     className: inputProps.className,
                     addonsClassName: inputProps.addonsClassName,
-                    ...(view === 'mobile' ? { leftAddons: renderCountrySelect() } : null),
+                    ...(view === 'mobile'
+                        ? { leftAddons: hideCountryFlag ? null : renderCountrySelect() }
+                        : null),
                 }}
             />
         ) : (
@@ -249,7 +252,7 @@ export const BaseInternationalPhoneInput = forwardRef<
                 {...restProps}
                 {...inputProps}
                 onClear={inputProps.clear ? handleClear : undefined}
-                leftAddons={renderCountrySelect()}
+                leftAddons={hideCountryFlag ? null : renderCountrySelect()}
                 size={size}
                 onInput={handleInput}
                 value={value}

--- a/packages/international-phone-input/src/docs/Component.stories.tsx
+++ b/packages/international-phone-input/src/docs/Component.stories.tsx
@@ -48,6 +48,7 @@ export const international_phone_input: Story = {
                     )}
                     clear={boolean('clear', false)}
                     success={boolean('success', false)}
+                    hideCountryFlag={boolean('options', true)}
                 />
             </div>
         );

--- a/packages/international-phone-input/src/docs/description.mdx
+++ b/packages/international-phone-input/src/docs/description.mdx
@@ -64,12 +64,13 @@ render(() => {
 
 ## Инпут без пикера страны
 
-При необходимости можно отключить возможность явно выбирать код страны через селект. Инпут сам определит страну после ввода её кода.
+При необходимости можно отключить возможность явно выбирать код страны через селект, или спрятать элемент флажка. Инпут сам определит страну после ввода её кода.
 
 ```jsx live mobileHeight={640}
 render(() => {
     const [value, setValue] = React.useState('');
     const [selectedCountry, setSelectedCountry] = React.useState();
+    const [hideCountryFlag, setHideCountryFlag] = React.useState(false);
 
     const handleChange = (phone) => setValue(phone);
 
@@ -84,11 +85,20 @@ render(() => {
                 onCountryChange={setSelectedCountry}
                 block={true}
                 countrySelectProps={{ hideCountrySelect: true }}
+                hideCountryFlag={hideCountryFlag}
             />
             <Gap size='m' />
             <Typography.Text color='secondary'>
                 Код выбранной страны: {selectedCountry && selectedCountry.iso2}
             </Typography.Text>
+            <Gap size='m' />
+            <Switch
+                checked={hideCountryFlag}
+                label='Спрятать флажок'
+                onChange={() => {
+                    setHideCountryFlag((prevState) => !prevState);
+                }}
+            />
         </div>
     );
 });

--- a/packages/international-phone-input/src/types.ts
+++ b/packages/international-phone-input/src/types.ts
@@ -48,6 +48,12 @@ export type CommonPhoneInputProps = {
     clearableCountryCode?: boolean | 'preserve';
 
     /**
+     * Скрывает компонент селекта
+     * @default false
+     */
+    hideCountryFlag?: boolean;
+
+    /**
      *  Свойства селекта выбора стран
      */
     countrySelectProps?: SharedCountrySelectProps;


### PR DESCRIPTION
Кратко сформулируйте суть доработки
Нужна возможность вообще скрыть флажок выбора страны. У бизнеса требование - не отображать флаг для стран с кодом +7 (казахстан, россия, южная осетия, абхазия) в многошаге, по аналогии с АМ. Компонент phone-input жестко захардкожен только на +7 для России и имеет множество ограничений которые вскрылись на тестировании.
Пока выкладываю ПР чтобы ваши разрабы посмотрели, когда "окните", добавлю тесты и changeset
Отчет о тестировании: https://confluence.moscow.alfaintra.net/pages/viewpage.action?pageId=2908432147

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [-] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [-] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

Было: 
<img width="406" height="96" alt="PhoneInputBasicInternational-desktop" src="https://github.com/user-attachments/assets/b9398509-bd3b-4505-9b5f-d216ce122be0" />

Стало:
<img width="406" height="96" alt="PhoneInputBasicRussian-desktop" src="https://github.com/user-attachments/assets/a8941e26-d097-4401-94d1-e6e3f18c2160" />

