### PR TITLE
fix(stepped-progress-bar): исправить типизацию [DS-14213]

### DIFF
--- a/.changeset/vast-cloths-post.md
+++ b/.changeset/vast-cloths-post.md
@@ -1,0 +1,9 @@
+---
+'@alfalab/core-components-stepped-progress-bar': patch
+'@alfalab/core-components': patch
+---
+
+##### SteppedProgressBar
+
+- Вернули публичный экспорт `SteppedProgressBarView`, чтобы не приходилось вычислять типы через массивы.
+- Исправили тип `view`: теперь он поддерживает одиночное значение и массив цветов без `Array<Array<...>>`.

--- a/packages/stepped-progress-bar/src/Component.tsx
+++ b/packages/stepped-progress-bar/src/Component.tsx
@@ -14,7 +14,7 @@ const colorStyles = {
     inverted: invertedColors,
 };
 
-type SteppedProgressBarView =
+export type SteppedProgressBarView =
     | 'positive'
     | 'negative'
     | 'attention'
@@ -24,7 +24,8 @@ type SteppedProgressBarView =
     | 'primary'
     | 'accent';
 
-type CustomProgressBarView = { background: string };
+export type CustomProgressBarView = { background: string };
+export type SteppedProgressBarViewValue = SteppedProgressBarView | CustomProgressBarView;
 
 export interface SteppedProgressBarProps {
     /**
@@ -45,10 +46,7 @@ export interface SteppedProgressBarProps {
     /**
      * Цвет заполнения
      */
-    view?:
-        | SteppedProgressBarView
-        | Array<SteppedProgressBarView | CustomProgressBarView>
-        | CustomProgressBarView;
+    view?: SteppedProgressBarViewValue | SteppedProgressBarViewValue[];
 
     /**
      * Идентификатор для систем автоматизированного тестирования

--- a/packages/stepped-progress-bar/src/components/step-bar/Component.tsx
+++ b/packages/stepped-progress-bar/src/components/step-bar/Component.tsx
@@ -1,13 +1,13 @@
 import React, { type FC, memo } from 'react';
 import cn from 'classnames';
 
-import { type SteppedProgressBarProps } from '../../Component';
+import { type SteppedProgressBarViewValue } from '../../Component';
 
 import styles from './index.module.css';
 
 interface StepBarProps {
     isDone: boolean;
-    view?: SteppedProgressBarProps['view'];
+    view?: SteppedProgressBarViewValue;
     classNameStep?: string;
 }
 


### PR DESCRIPTION
##### SteppedProgressBar

- Вернули публичный экспорт `SteppedProgressBarView`, чтобы не приходилось вычислять типы через массивы.
- Исправили тип `view`: теперь он поддерживает одиночное значение и массив цветов без `Array<Array<...>>`.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

