### PR TITLE
fix(popover): настройка для корректировки высоты popover в зависимости от высоты viewport [DS-9450]

### DIFF
--- a/.changeset/blue-suns-tickle.md
+++ b/.changeset/blue-suns-tickle.md
@@ -5,4 +5,4 @@
 
 ##### Popover
 
-- Позиционирование Popper теперь использует `strategy: 'fixed'`, чтобы поповер с большим контентом не увеличивал `documentElement.scrollHeight` и не ломал скролл страницы.
+- Позиционирование Popover теперь использует `strategy: 'fixed'`, чтобы поповер с большим контентом не увеличивал `documentElement.scrollHeight` и не ломал скролл страницы.

--- a/.changeset/blue-suns-tickle.md
+++ b/.changeset/blue-suns-tickle.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-popover': patch
+'@alfalab/core-components': patch
+---
+
+##### Popover
+
+- Позиционирование Popper теперь использует `strategy: 'fixed'`, чтобы поповер с большим контентом не увеличивал `documentElement.scrollHeight` и не ломал скролл страницы.

--- a/packages/custom-picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/custom-picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`Snapshots tests should display opened correctly 2`] = `
     data-popper-escaped="true"
     data-popper-placement="bottom-start"
     data-popper-reference-hidden="true"
-    style="z-index: 50; position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+    style="z-index: 50; position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <div
       class="inner popoverInner cc-picker-button optionsPopover"
@@ -681,7 +681,7 @@ exports[`Snapshots tests should display opened correctly 4`] = `
     data-popper-escaped="true"
     data-popper-placement="bottom-start"
     data-popper-reference-hidden="true"
-    style="z-index: 50; position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+    style="z-index: 50; position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <div
       class="inner popoverInner cc-picker-button optionsPopover"
@@ -1141,7 +1141,7 @@ exports[`Snapshots tests should display opened correctly 6`] = `
     data-popper-escaped="true"
     data-popper-placement="bottom-start"
     data-popper-reference-hidden="true"
-    style="z-index: 50; position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+    style="z-index: 50; position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <div
       class="inner popoverInner cc-picker-button optionsPopover"

--- a/packages/popover/src/Component.tsx
+++ b/packages/popover/src/Component.tsx
@@ -297,6 +297,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         } = usePopper(referenceElement, popperElement, {
             placement: position,
             modifiers: popperModifiers,
+            strategy: 'fixed',
         });
 
         if (updatePopper) {

--- a/packages/popover/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/popover/src/__snapshots__/Component.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Display tests should display correctly 1`] = `
         data-popper-escaped="true"
         data-popper-placement="left"
         data-popper-reference-hidden="true"
-        style="z-index: 50; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
+        style="z-index: 50; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
       >
         <div
           class="inner"
@@ -96,7 +96,7 @@ exports[`Render tests should render without Transition of withTransition is fals
         data-popper-escaped="true"
         data-popper-placement="left"
         data-popper-reference-hidden="true"
-        style="z-index: 50; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
+        style="z-index: 50; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
       >
         <div
           class="inner"

--- a/packages/toast/src/__snapshots__/component.test.tsx.snap
+++ b/packages/toast/src/__snapshots__/component.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Toast Snapshots tests should math snapshot when prop \`anchorElement\` 
       data-popper-escaped="true"
       data-popper-placement="left"
       data-popper-reference-hidden="true"
-      style="z-index: 1000; width: 0px; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
+      style="z-index: 1000; width: 0px; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
     >
       <div
         class="inner popoverInner"
@@ -116,7 +116,7 @@ exports[`Toast Snapshots tests should math snapshot when prop \`anchorElement\` 
       data-popper-escaped="true"
       data-popper-placement="left"
       data-popper-reference-hidden="true"
-      style="z-index: 1000; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
+      style="z-index: 1000; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(0px, 0px);"
     >
       <div
         class="inner popoverInner"

--- a/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`Display tests should display correctly if tooltip open 1`] = `
         data-popper-escaped="true"
         data-popper-placement="left"
         data-popper-reference-hidden="true"
-        style="z-index: 50; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(-16px, 0px);"
+        style="z-index: 50; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(-16px, 0px);"
       >
         <div
           class="inner popper tooltip tooltip popper"
@@ -200,7 +200,7 @@ exports[`Display tests should display correctly if tooltip open with view \`hint
         data-popper-escaped="true"
         data-popper-placement="left"
         data-popper-reference-hidden="true"
-        style="z-index: 50; position: absolute; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(-16px, 0px);"
+        style="z-index: 50; position: fixed; left: auto; top: 0px; right: 0px; bottom: auto; transform: translate(-16px, 0px);"
       >
         <div
           class="inner popper hint hint hint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20115,6 +20115,14 @@ react-remove-scroll-bar@^2.3.3:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
 react-remove-scroll@2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
@@ -20125,6 +20133,17 @@ react-remove-scroll@2.5.5:
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
+
+react-remove-scroll@^2.5.5:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
 
 react-scripts@^5.0.1:
   version "5.0.1"
@@ -20217,6 +20236,14 @@ react-style-singleton@^2.2.1:
   dependencies:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
     tslib "^2.0.0"
 
 react-swipeable@^7.0.0:
@@ -23540,6 +23567,13 @@ use-callback-ref@^1.3.2:
   dependencies:
     tslib "^2.0.0"
 
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
 use-composed-ref@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.3.0.tgz#3d8104db34b7b264030a9d916c5e94fbe280dbda"
@@ -23568,6 +23602,14 @@ use-sidecar@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
   integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"


### PR DESCRIPTION
##### Popover

- Позиционирование Popover теперь использует `strategy: 'fixed'`, чтобы поповер с большим контентом не увеличивал `documentElement.scrollHeight` и не ломал скролл страницы.

# Чек лист
- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения
- [x] Прикреплено изображение было/стало

https://github.com/user-attachments/assets/778cb4a4-9f96-4256-8153-ec89a26be51c
