### PR TITLE
fix(bottom-sheet): учитывать safe-area для магнитных позиций [DS-15308]

### DIFF
--- a/.changeset/fast-boats-knock.md
+++ b/.changeset/fast-boats-knock.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-bottom-sheet': patch
+---
+
+- Добавлена поддержка `safe-area-inset-top` в PWA standalone режиме.

--- a/packages/bottom-sheet/package.json
+++ b/packages/bottom-sheet/package.json
@@ -18,6 +18,7 @@
         "@alfalab/core-components-navigation-bar-private": "^2.0.13",
         "@alfalab/core-components-shared": "^2.2.3",
         "@alfalab/core-components-types": "^2.0.1",
+        "@alfalab/hooks": "^1.17.0",
         "classnames": "^2.5.1",
         "react-div-100vh": "^0.7.0",
         "react-merge-refs": "^1.1.0",

--- a/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
+++ b/packages/bottom-sheet/src/__snapshots__/component.test.tsx.snap
@@ -39,6 +39,10 @@ exports[`Bottom sheet Snapshots tests should match snapshot 1`] = `
                 class="wrapper"
               >
                 <div
+                  aria-hidden="true"
+                  class="satProbe"
+                />
+                <div
                   class="component component"
                   style="height: unset; max-height: 744px;"
                 >
@@ -134,6 +138,10 @@ exports[`Bottom sheet Snapshots tests should match snapshot with action button 1
               <div
                 class="wrapper"
               >
+                <div
+                  aria-hidden="true"
+                  class="satProbe"
+                />
                 <div
                   class="component component"
                   style="height: unset; max-height: 744px;"

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -20,6 +20,7 @@ import cn from 'classnames';
 
 import { BaseModal, unlockScroll } from '@alfalab/core-components-base-modal';
 import { fnUtils, getDataTestId, isClient, isIOS } from '@alfalab/core-components-shared';
+import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
 
 import { Footer } from './components/footer/Component';
 import { Header, type HeaderProps } from './components/header/Component';
@@ -145,10 +146,24 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
             magneticAreasProp,
         );
 
+        const satProbeRef = useRef<HTMLDivElement>(null);
+        const [safeAreaInsetTop, setSafeAreaInsetTop] = useState(0);
+
+        useLayoutEffect_SAFE_FOR_SSR(() => {
+            const measure = () => setSafeAreaInsetTop(satProbeRef.current?.offsetHeight ?? 0);
+
+            measure();
+            window.addEventListener('resize', measure);
+
+            return () => window.removeEventListener('resize', measure);
+        }, [open]);
+
+        const resolvedHeaderOffset = headerOffset + safeAreaInsetTop;
+
         const magneticAreas = useMemo(() => {
             if (magneticAreasProp) {
                 return magneticAreasProp.map((area) =>
-                    convertPercentToNumber(area, fullHeight, headerOffset),
+                    convertPercentToNumber(area, fullHeight, resolvedHeaderOffset),
                 );
             }
             let iOSViewHeight = 0;
@@ -163,8 +178,14 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
 
             const viewHeight = isIOS() && !virtualKeyboard ? iOSViewHeight : fullHeight;
 
-            return [0, viewHeight - headerOffset];
-        }, [fullHeight, headerOffset, magneticAreasProp, virtualKeyboard, adjustContainerHeight]);
+            return [0, viewHeight - resolvedHeaderOffset];
+        }, [
+            fullHeight,
+            resolvedHeaderOffset,
+            magneticAreasProp,
+            virtualKeyboard,
+            adjustContainerHeight,
+        ]);
 
         const lastMagneticArea = magneticAreas[magneticAreas.length - 1];
 
@@ -581,14 +602,14 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         useEffect(() => {
             if (!sheetRef.current) return;
 
-            const maxOffset = fullHeight - headerOffset;
+            const maxOffset = fullHeight - resolvedHeaderOffset;
 
             const offset = open ? sheetOffset : maxOffset;
 
             const percent = (offset / maxOffset) * 100;
 
             onOffsetChange?.(offset, percent);
-        }, [fullHeight, headerOffset, onOffsetChange, open, sheetOffset]);
+        }, [fullHeight, resolvedHeaderOffset, onOffsetChange, open, sheetOffset]);
 
         useImperativeHandle(bottomSheetInstanceRef, () => ({
             scrollToArea,
@@ -686,6 +707,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                     })}
                     onTransitionEnd={setSheetHeight}
                 >
+                    <div ref={satProbeRef} className={styles.satProbe} aria-hidden={true} />
                     {outerAddons && (
                         <div
                             className={cn(styles.outerClassName, outerClassName)}

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -24,6 +24,13 @@
     transition: border-radius 0.3s ease;
 }
 
+.satProbe {
+    position: fixed;
+    padding-top: env(safe-area-inset-top, 0px);
+    visibility: hidden;
+    pointer-events: none;
+}
+
 .outerClassName {
     pointer-events: all;
 }

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -26,7 +26,7 @@
 
 .satProbe {
     position: fixed;
-    padding-top: env(safe-area-inset-top, 0px);
+    padding-top: env(safe-area-inset-top, 0);
     visibility: hidden;
     pointer-events: none;
 }

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -26,7 +26,7 @@
 
 .satProbe {
     position: fixed;
-    padding-top: env(safe-area-inset-top, 0);
+    padding-top: var(--sat);
     visibility: hidden;
     pointer-events: none;
 }

--- a/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input-autocomplete/src/__snapshots__/Component.test.tsx.snap
@@ -122,6 +122,10 @@ exports[`InputAutocompleteMobile Snapshots tests should match snapshot in open s
                 class="wrapper"
               >
                 <div
+                  aria-hidden="true"
+                  class="satProbe"
+                />
+                <div
                   class="component component sheet"
                   style="height: 744px; max-height: 744px;"
                 >

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -337,6 +337,10 @@ exports[`Snapshots tests should display opened correctly 4`] = `
               class="wrapper"
             >
               <div
+                aria-hidden="true"
+                class="satProbe"
+              />
+              <div
                 class="component component sheet"
                 style="height: unset; max-height: 744px;"
               >
@@ -850,6 +854,10 @@ exports[`Snapshots tests should display opened correctly 6`] = `
             <div
               class="wrapper"
             >
+              <div
+                aria-hidden="true"
+                class="satProbe"
+              />
               <div
                 class="component component sheet"
                 style="height: unset; max-height: 744px;"

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,7 @@ __metadata:
     "@alfalab/core-components-navigation-bar-private": "npm:^2.0.13"
     "@alfalab/core-components-shared": "npm:^2.2.3"
     "@alfalab/core-components-types": "npm:^2.0.1"
+    "@alfalab/hooks": "npm:^1.17.0"
     classnames: "npm:^2.5.1"
     react-div-100vh: "npm:^0.7.0"
     react-merge-refs: "npm:^1.1.0"


### PR DESCRIPTION
##### BottomSheet

- Добавлена поддержка `safe-area-inset-top` в PWA standalone режиме.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

Было: 

<img width="892" height="993" alt="image" src="https://github.com/user-attachments/assets/c4a7935a-c329-48a3-8679-d381d1ce3f09" />


Стало:

Фикс через props `adjustContainerHeight` в репозитории с багом.

<img width="489" height="983" alt="Снимок экрана 2026-02-27 в 00 29 19" src="https://github.com/user-attachments/assets/6134a8eb-9159-4294-a662-ed45a683fd0b" />

Фикс через PR:

<img width="487" height="962" alt="Снимок экрана — 2026-09-07 в 10 37 32" src="https://github.com/user-attachments/assets/55aff5e0-9281-4c6d-b862-5b3e775ab8e6" />


