### PR TITLE
fix(bottom-sheet): учитывать safe-area для магнитных позиций [DS-15308] version:48

### DIFF
--- a/.changeset/eighty-walls-smile.md
+++ b/.changeset/eighty-walls-smile.md
@@ -1,6 +1,5 @@
 ---
 '@alfalab/core-components-bottom-sheet': patch
-'@alfalab/core-components': patch
 ---
 
 ##### BottomSheet

--- a/.changeset/eighty-walls-smile.md
+++ b/.changeset/eighty-walls-smile.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-bottom-sheet': patch
+'@alfalab/core-components': patch
+---
+
+##### BottomSheet
+
+- Добавлена поддержка `safe-area-inset-top` в PWA standalone режиме.

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -578,12 +578,20 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         const getSwipeStyles = (): CSSProperties =>
             sheetOffset ? { transform: `translateY(${sheetOffset}px)` } : {};
 
+        const isPWA =
+            isClient() &&
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(display-mode: standalone)').matches;
+
+        const safeAreaMaxHeight = `min(${lastMagneticArea}px, calc(100vh - env(safe-area-inset-top) - ${headerOffset}px))`;
+        const maxHeight = isPWA ? safeAreaMaxHeight : `${lastMagneticArea}px`;
+
         const getHeightStyles = (): CSSProperties => ({
             height:
                 !isFirstRender && (initialHeight === 'full' || magneticAreasProp)
                     ? `${lastMagneticArea}px`
                     : 'unset',
-            maxHeight: isFirstRender ? 0 : `${lastMagneticArea}px`,
+            maxHeight: isFirstRender ? 0 : maxHeight,
             marginBottom:
                 virtualKeyboard && visualViewportSize && windowHeight > visualViewportSize.height
                     ? windowHeight - visualViewportSize.height - visualViewportSize.offsetTop

--- a/packages/bottom-sheet/src/component.tsx
+++ b/packages/bottom-sheet/src/component.tsx
@@ -21,7 +21,7 @@ import { Header, HeaderProps } from './components/header/Component';
 import { SwipeableBackdrop } from './components/swipeable-backdrop/Component';
 import { horizontalDirections } from './consts/swipeConsts';
 import { ShouldSkipSwipingParams } from './types/swipeTypes';
-import { useVisualViewportSize } from './hooks';
+import { useSafeAreaInsets, useVisualViewport } from './hooks';
 import type { BottomSheetProps } from './types';
 import {
     CLOSE_OFFSET,
@@ -117,14 +117,22 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         },
         ref,
     ) => {
+        const isPWA = isClient() && !!window.matchMedia?.('(display-mode: standalone)')?.matches;
+
+        // const isPWA = isPWA();
         const windowHeight = use100vh() ?? 0;
-        const visualViewportSize = useVisualViewportSize();
-        let fullHeight = virtualKeyboard ? visualViewportSize?.height ?? 0 : windowHeight;
+
+        const [innerHeight, viewport] = useVisualViewport({});
+        const [insets] = useSafeAreaInsets(isPWA);
+
+        let fullHeight = virtualKeyboard ? viewport?.height ?? 0 : windowHeight;
+
         // Хук use100vh рассчитывает высоту вьюпорта в useEffect, поэтому на первый рендер всегда возвращает null.
         const isFirstRender = fullHeight === 0;
 
         fullHeight = adjustContainerHeight(fullHeight);
 
+        const layoutFullHeight = isPWA ? Math.max(0, innerHeight - insets.top) : fullHeight;
         const initialIndexRef = useRef<number | undefined>(initialActiveAreaIndex);
         const prevMagneticAreasPropRef = useRef<Array<number | string> | undefined>(
             magneticAreasProp,
@@ -133,7 +141,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         const magneticAreas = useMemo(() => {
             if (magneticAreasProp) {
                 return magneticAreasProp.map((area) =>
-                    convertPercentToNumber(area, fullHeight, headerOffset),
+                    convertPercentToNumber(area, layoutFullHeight, headerOffset),
                 );
             }
             let iOSViewHeight = 0;
@@ -146,10 +154,18 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                 }
             }
 
-            const viewHeight = os.isIOS() && !virtualKeyboard ? iOSViewHeight : fullHeight;
+            const viewHeight =
+                os.isIOS() && !virtualKeyboard && !isPWA ? iOSViewHeight : layoutFullHeight;
 
-            return [0, viewHeight - headerOffset];
-        }, [fullHeight, headerOffset, magneticAreasProp, virtualKeyboard, adjustContainerHeight]);
+            return [0, isPWA ? viewHeight : viewHeight - headerOffset];
+        }, [
+            layoutFullHeight,
+            headerOffset,
+            magneticAreasProp,
+            virtualKeyboard,
+            isPWA,
+            adjustContainerHeight,
+        ]);
 
         const lastMagneticArea = magneticAreas[magneticAreas.length - 1];
 
@@ -546,7 +562,15 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
 
                     setSheetOffset(isNil(idx) ? 0 : lastMagneticArea - magneticAreas[idx]);
                     setActiveAreaIdx(isNil(idx) ? magneticAreas.length - 1 : idx);
+                    /*
+                     * } else if (magneticAreasPropChanged) {
+                     *     setSheetOffset(activeArea ? lastMagneticArea - activeArea : 0);
+                     */
                 } else {
+                    /*
+                     * При show/hide клавиатуры в PWA высота viewport меняется.
+                     * Держим sheetOffset синхронизированным с активной магнитной областью.
+                     */
                     setSheetOffset(activeArea ? lastMagneticArea - activeArea : 0);
                 }
 
@@ -562,14 +586,14 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         useEffect(() => {
             if (!sheetRef.current) return;
 
-            const maxOffset = fullHeight - headerOffset;
+            const maxOffset = lastMagneticArea;
 
             const offset = open ? sheetOffset : maxOffset;
 
-            const percent = (offset / maxOffset) * 100;
+            const percent = maxOffset > 0 ? (offset / maxOffset) * 100 : 0;
 
             onOffsetChange?.(offset, percent);
-        }, [fullHeight, headerOffset, onOffsetChange, open, sheetOffset]);
+        }, [lastMagneticArea, onOffsetChange, open, sheetOffset]);
 
         useImperativeHandle(bottomSheetInstanceRef, () => ({
             scrollToArea,
@@ -578,13 +602,17 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         const getSwipeStyles = (): CSSProperties =>
             sheetOffset ? { transform: `translateY(${sheetOffset}px)` } : {};
 
-        const isPWA =
-            isClient() &&
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(display-mode: standalone)').matches;
+        const maxHeight = `${lastMagneticArea}px`;
 
-        const safeAreaMaxHeight = `min(${lastMagneticArea}px, calc(100vh - env(safe-area-inset-top) - ${headerOffset}px))`;
-        const maxHeight = isPWA ? safeAreaMaxHeight : `${lastMagneticArea}px`;
+        const isKeyboardVisible = virtualKeyboard && viewport && windowHeight > viewport.height;
+
+        const pwaMarginBottom = isKeyboardVisible && isPWA ? viewport.height : undefined;
+        const defaultMarginBottom =
+            isKeyboardVisible && !isPWA
+                ? windowHeight - viewport.height - viewport.offsetTop
+                : undefined;
+
+        const keyboardMarginBottom = pwaMarginBottom ?? defaultMarginBottom;
 
         const getHeightStyles = (): CSSProperties => ({
             height:
@@ -592,10 +620,7 @@ export const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
                     ? `${lastMagneticArea}px`
                     : 'unset',
             maxHeight: isFirstRender ? 0 : maxHeight,
-            marginBottom:
-                virtualKeyboard && visualViewportSize && windowHeight > visualViewportSize.height
-                    ? windowHeight - visualViewportSize.height - visualViewportSize.offsetTop
-                    : undefined,
+            marginBottom: keyboardMarginBottom,
         });
 
         const renderMarker = () => {

--- a/packages/bottom-sheet/src/hooks/index.ts
+++ b/packages/bottom-sheet/src/hooks/index.ts
@@ -1,1 +1,6 @@
-export { useVisualViewportSize, useVisibleViewportSize } from './use-visualviewport-size';
+export {
+    useVisualViewportSize,
+    useVisualViewport,
+    useVisibleViewportSize,
+    useSafeAreaInsets,
+} from './use-visualviewport-size';

--- a/packages/bottom-sheet/src/hooks/use-visualviewport-size.ts
+++ b/packages/bottom-sheet/src/hooks/use-visualviewport-size.ts
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useState } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
 import { isClient, isNullable, noop } from '@alfalab/core-components-shared';
@@ -7,15 +8,27 @@ type VisualViewportSize = Pick<
     'height' | 'offsetLeft' | 'offsetTop' | 'pageLeft' | 'pageTop' | 'scale' | 'width'
 >;
 
-let visualViewportSize = isClient() ? getVisualViewportSize() : null;
+let visualViewportSize = isClient() ? clientGetVisualViewportSize() : serverGetVisualViewportSize();
 
 let listeners: Array<() => void> = [];
 
-function getVisualViewportSize(): VisualViewportSize | null {
+function serverGetVisualViewportSize(): VisualViewportSize {
+    return {
+        height: 0,
+        offsetLeft: 0,
+        offsetTop: 0,
+        pageLeft: 0,
+        pageTop: 0,
+        scale: 0,
+        width: 0,
+    };
+}
+
+function clientGetVisualViewportSize(): VisualViewportSize {
     const { visualViewport } = window;
 
     if (isNullable(visualViewport)) {
-        return null;
+        return serverGetVisualViewportSize();
     }
 
     const { height, offsetLeft, offsetTop, pageLeft, pageTop, scale, width } = visualViewport;
@@ -24,7 +37,7 @@ function getVisualViewportSize(): VisualViewportSize | null {
 }
 
 function callback() {
-    visualViewportSize = getVisualViewportSize();
+    visualViewportSize = clientGetVisualViewportSize();
 
     listeners.forEach((listener) => {
         listener();
@@ -60,7 +73,7 @@ function getSnapshot() {
 }
 
 function getServerSnapshot() {
-    return null;
+    return null; // serverGetVisualViewportSize ?
 }
 
 export function useVisualViewportSize() {
@@ -74,4 +87,126 @@ export function useVisibleViewportSize(enabled = false) {
     const size = useVisualViewportSize();
 
     return enabled ? size : null;
+}
+
+type UseVisualViewport = {
+    visualViewport?: VisualViewportSize;
+};
+
+export function useVisualViewport({
+    visualViewport: defaultVisualViewport = visualViewportSize,
+}: UseVisualViewport): [number, VisualViewportSize] {
+    const [height, setHeight] = useState(() => (isClient() ? window.innerHeight : 0));
+    const [viewport, setViewport] = useState<VisualViewportSize>(() => defaultVisualViewport);
+
+    useLayoutEffect(() => {
+        const listener = () => {
+            setHeight(() => window.innerHeight);
+            setViewport(clientGetVisualViewportSize());
+        };
+
+        listener();
+
+        const { visualViewport } = window;
+
+        visualViewport?.addEventListener('resize', listener);
+        visualViewport?.addEventListener('scroll', listener);
+
+        return () => {
+            visualViewport?.removeEventListener('resize', listener);
+            visualViewport?.removeEventListener('scroll', listener);
+        };
+    }, []);
+
+    return [height, viewport];
+}
+
+type SafeAreaInsets = {
+    /** Верхний отступ в px (вырез, Dynamic Island или статус-бар) */
+    top: number;
+    /** Нижний отступ в px (индикатор «домой» на устройствах с Face ID) */
+    bottom: number;
+    /** Левый отступ в px (скругления в альбомной ориентации) */
+    left: number;
+    /** Правый отступ в px (скругления в альбомной ориентации) */
+    right: number;
+};
+
+const SAFE_AREA: Record<string, string> = {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '0',
+    height: '0',
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    paddingTop: 'env(safe-area-inset-top, 0px)',
+    paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+    paddingLeft: 'env(safe-area-inset-left, 0px)',
+    paddingRight: 'env(safe-area-inset-right, 0px)',
+};
+
+function getInsets(el: HTMLElement): SafeAreaInsets {
+    const style = window.getComputedStyle(el);
+
+    const top = parseFloat(style.getPropertyValue('padding-top')) || 0;
+    const bottom = parseFloat(style.getPropertyValue('padding-bottom')) || 0;
+    const left = parseFloat(style.getPropertyValue('padding-left')) || 0;
+    const right = parseFloat(style.getPropertyValue('padding-right')) || 0;
+
+    return { top, bottom, left, right };
+}
+
+/**
+ * Возвращает актуальные значения env(safe-area-inset-*) в px.
+ * Измерение выполняется через скрытый элемент и обновляется по ResizeObserver.
+ *
+ * @param enabled Когда `false`, измерение не запускается и хук возвращает нулевые insets.
+ * @see https://github.com/toss/react-simplikit/blob/main/packages/mobile/src/utils/getSafeAreaInset/getSafeAreaInset.md
+ */
+export function useSafeAreaInsets(enabled = true): [SafeAreaInsets] {
+    const [insets, setInsets] = useState<SafeAreaInsets>({
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+    });
+
+    useLayoutEffect(() => {
+        if (!enabled || !isClient()) {
+            return undefined;
+        }
+
+        const el = document.createElement('div');
+
+        el.setAttribute('aria-hidden', 'true');
+        Object.assign(el.style, SAFE_AREA);
+        document.body.appendChild(el);
+
+        const listener = () => setInsets(getInsets(el));
+
+        listener();
+
+        let observer: ResizeObserver | null = null;
+
+        if (typeof ResizeObserver !== 'undefined') {
+            observer = new ResizeObserver(listener);
+
+            // наблюдаем border-box, чтобы колбек срабатывал при изменении padding
+            observer.observe(el, { box: 'border-box' });
+        }
+
+        window.visualViewport?.addEventListener('resize', listener);
+        window.addEventListener('orientationchange', listener);
+
+        return () => {
+            observer?.disconnect();
+            el.remove();
+
+            window.visualViewport?.removeEventListener('resize', listener);
+            window.removeEventListener('orientationchange', listener);
+        };
+    }, [enabled]);
+
+    return [insets];
 }

--- a/packages/bottom-sheet/src/index.module.css
+++ b/packages/bottom-sheet/src/index.module.css
@@ -29,7 +29,7 @@
 }
 
 .fullscreen {
-    border-radius: 0;
+    border-radius: var(--border-radius-0);
 }
 
 .component {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,3 +15,4 @@ export * from './object';
 export * from './type-checks';
 export * from './get-color-var';
 export * from './mask';
+export * from './isPWA';

--- a/packages/shared/src/isPWA.ts
+++ b/packages/shared/src/isPWA.ts
@@ -1,0 +1,4 @@
+import { isClient } from './isClient';
+
+export const isPWA = (): boolean =>
+    isClient() && !!window.matchMedia?.('(display-mode: standalone)')?.matches;


### PR DESCRIPTION
Оригинальный PR: https://github.com/core-ds/core-components/pull/2091

##### BottomSheet

- Добавлена поддержка `safe-area-inset-top` в PWA standalone режиме.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Было:


Стало:

1. Реализован адаптивный safe-area для различных раскладок


2. При клике на триггер появления виртуальной клавиатуры, клавиатура вытесняет контент, оставляя инпут в зоне видимости ввода


