### PR TITLE
feat(pass-code): добавить поддержку доступности для компонента [DS-16210]

### DIFF
--- a/.changeset/afraid-jeans-lose.md
+++ b/.changeset/afraid-jeans-lose.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-vars': minor
+---
+
+- Добавлен CSS-миксин `visually-hidden` для скрытия текста визуально с сохранением доступности для screen reader.

--- a/.changeset/flat-parts-create.md
+++ b/.changeset/flat-parts-create.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-pass-code': patch
+---
+
+- Добавлена озвучка прогресса ввода для screen reader после локального ввода и удаления символов через keypad

--- a/packages/pass-code/src/Component.tsx
+++ b/packages/pass-code/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ReactNode } from 'react';
+import React, { forwardRef, type ReactNode, useState } from 'react';
 import cn from 'classnames';
 
 import { Gap } from '@alfalab/core-components-gap';
@@ -7,10 +7,11 @@ import { getDataTestId } from '@alfalab/core-components-shared';
 import { InputProgress } from './components/InputProgress';
 import { KeyPad } from './components/KeyPad';
 import { type PassCodeProps } from './typings';
+import { getAnnouncementText } from './utils';
 
 import styles from './index.module.css';
 
-export type BasePassCodeProps = {
+export interface BasePassCodeProps {
     /**
      * Код
      */
@@ -80,7 +81,7 @@ export type BasePassCodeProps = {
      * Отключает ввод и удаление кода
      */
     disabled?: boolean;
-};
+}
 
 export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
     (
@@ -101,6 +102,17 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
         ref,
     ) => {
         const passwordLen = codeLength || maxCodeLength;
+        const [liveMessage, setLiveMessage] = useState({
+            id: 0,
+            text: '',
+        });
+
+        const updateLiveMessage = (currentLength: number) => {
+            setLiveMessage((prevLiveMessage) => ({
+                id: prevLiveMessage.id + 1,
+                text: getAnnouncementText(currentLength, passwordLen),
+            }));
+        };
 
         const handleChange = (digit: number) => {
             if (disabled) {
@@ -110,6 +122,7 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
             const newValue = value.concat(digit.toString());
 
             if (newValue.length <= passwordLen) {
+                updateLiveMessage(newValue.length);
                 onChange?.(newValue);
             }
         };
@@ -120,7 +133,10 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
             }
 
             if (value.length > 0) {
-                onChange?.(value?.slice(0, -1));
+                const newValue = value.slice(0, -1);
+
+                updateLiveMessage(newValue.length);
+                onChange?.(newValue);
             }
         };
 
@@ -152,6 +168,15 @@ export const PassCode = forwardRef<HTMLDivElement, PassCodeProps>(
                     onClear={handleClear}
                     showClear={Boolean(value)}
                 />
+
+                <div
+                    role='status'
+                    aria-live='polite'
+                    aria-atomic='true'
+                    className={styles.visuallyHidden}
+                >
+                    <span key={liveMessage.id}>{liveMessage.text}</span>
+                </div>
             </div>
         );
     },

--- a/packages/pass-code/src/__snapshots__/component.test.tsx.snap
+++ b/packages/pass-code/src/__snapshots__/component.test.tsx.snap
@@ -151,6 +151,14 @@ exports[`PassCode Snapshot tests should match snapshot with code length 1`] = `
       </button>
       <div />
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="visuallyHidden"
+      role="status"
+    >
+      <span />
+    </div>
   </div>
 </div>
 `;
@@ -276,6 +284,14 @@ exports[`PassCode Snapshot tests should match snapshot with unknown code length 
         0
       </button>
       <div />
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="visuallyHidden"
+      role="status"
+    >
+      <span />
     </div>
   </div>
 </div>

--- a/packages/pass-code/src/components/KeyPad/Component.tsx
+++ b/packages/pass-code/src/components/KeyPad/Component.tsx
@@ -7,7 +7,7 @@ import { KeyPadButton } from '../KeyPadButton';
 
 import styles from './index.module.css';
 
-export type KeyPadProps = {
+export interface KeyPadProps {
     /**
      * Показать кнопку "очистить".
      */
@@ -42,7 +42,7 @@ export type KeyPadProps = {
      * Коллбэк очистки кода.
      */
     onClear: () => void;
-};
+}
 
 const CELL_COUNT = 12;
 const CELLS = new Array(CELL_COUNT).fill(null).map((_, i) => {

--- a/packages/pass-code/src/components/KeyPadButton/Component.tsx
+++ b/packages/pass-code/src/components/KeyPadButton/Component.tsx
@@ -5,7 +5,7 @@ import { ButtonMobile, type ButtonMobileProps } from '@alfalab/core-components-b
 
 import styles from './index.module.css';
 
-export type KeyPadButtonProps<T> = {
+export interface KeyPadButtonProps<T> {
     /**
      * Вид кнопки
      */
@@ -40,7 +40,7 @@ export type KeyPadButtonProps<T> = {
      * Заголовок кнопки
      */
     title?: string;
-};
+}
 
 export function KeyPadButton<T extends ReactNode>({
     children,

--- a/packages/pass-code/src/index.module.css
+++ b/packages/pass-code/src/index.module.css
@@ -12,3 +12,7 @@
     position: relative;
     flex: 1 0 auto;
 }
+
+.visuallyHidden {
+    @mixin visually-hidden;
+}

--- a/packages/pass-code/src/utils.ts
+++ b/packages/pass-code/src/utils.ts
@@ -1,5 +1,11 @@
 import { getDataTestId } from '@alfalab/core-components-shared';
 
+export function getAnnouncementText(currentLength: number, maxLength: number) {
+    return currentLength >= maxLength
+        ? 'Код введён полностью'
+        : `Введено символов: ${currentLength}`;
+}
+
 export function getPassCodeTestIds(dataTestId: string) {
     return {
         passCode: getDataTestId(dataTestId, 'wrapper'),

--- a/packages/vars/src/mixins.css
+++ b/packages/vars/src/mixins.css
@@ -119,3 +119,16 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
+
+@define-mixin visually-hidden {
+    /* Hack from http://stackoverflow.com/a/62107074 */
+    border: 0;
+    padding: 0;
+    margin: -1px;
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}

--- a/packages/vars/src/mixins.css
+++ b/packages/vars/src/mixins.css
@@ -121,14 +121,15 @@
 }
 
 @define-mixin visually-hidden {
-    /* Hack from http://stackoverflow.com/a/62107074 */
+    /* Hack from https://htmlacademy.ru/blog/css/short-12 */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
     border: 0;
     padding: 0;
-    margin: -1px;
-    position: absolute;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
     white-space: nowrap;
+    clip-path: inset(100%);
+    clip: rect(0 0 0 0);
+    overflow: hidden;
 }


### PR DESCRIPTION
##### PassCode

- Добавлена озвучка прогресса ввода для screen reader после локального ввода и удаления символов через keypad

##### Vars

- Добавлен CSS-миксин `visually-hidden` для скрытия текста визуально с сохранением доступности для screen reader.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

#### Кейс 1, 2

Ожидаемый результат: TalkBack озвучивает "Введено символов: X", где X - порядковый номер вводимого символа. Если всего можно ввести 4 символа, при вводе последнего символа подсказка меняется на "Код введён полностью".

Ожидаемый результат: VoiceOver озвучивает "Введено символов(X-1)", где X - порядковый номер последнего введённого символа.

https://github.com/user-attachments/assets/34347d4f-154c-4200-a1bb-cb7f342e2379

#### Кейс 3

Ожидаемый результат: VoiceOver озвучивает "1, кнопка".

https://github.com/user-attachments/assets/1baf8fc1-5527-4637-9e86-21a8ecd3c8b7

#### Кейс 4

Точка входа: экран ввода секретного кода.
Ожидаемый результат: VoiceOver озвучивает "Введено символов(X-1)", где X - порядковый номер последнего введённого символа.


https://github.com/user-attachments/assets/e4adb854-9768-4745-b29b-39a3993c18b2




