### PR TITLE
fix/DS-16161_markdown_link

### DIFF
--- a/.changeset/famous-keys-judge.md
+++ b/.changeset/famous-keys-judge.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-markdown': patch
+'@alfalab/core-components': patch
+---
+
+##### Markdown
+
+- Исправлен вид ссылок. Теперь они синего цвета, без подчёркивания

--- a/packages/markdown/src/__image_snapshots__/markdown-snap.png
+++ b/packages/markdown/src/__image_snapshots__/markdown-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65d7d594c727b682a9d2cec7b9f487f3daf581c111b0aa0f2cadc23d43fbb04e
-size 89836
+oid sha256:f84c52aa95ba885f2a88651f873499a2970ebb43ed250e3b77ef44bdc9169f30
+size 89832

--- a/packages/markdown/src/components/base-markdown/use-overrides.tsx
+++ b/packages/markdown/src/components/base-markdown/use-overrides.tsx
@@ -78,7 +78,14 @@ export const useOverrides = (platform?: PlatformType, font?: FontType): Override
                 </TypographyText>
             ),
             a: ({ children, href }) => (
-                <Link className='a' target='_blank' rel='noopener noreferrer' href={href}>
+                <Link
+                    view='default'
+                    underline={false}
+                    className='a'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={href}
+                >
                     {children}
                 </Link>
             ),


### PR DESCRIPTION
DS-16161

##### Markdown

- Исправлен вид ссылок. Теперь они синего цвета, без подчёркивания