### PR TITLE
fix(list): исправить нечитаемый текст в темной теме [DS-16489]

### DIFF
--- a/.changeset/long-dots-type.md
+++ b/.changeset/long-dots-type.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-list': patch
+'@alfalab/core-components': patch
+---
+
+##### List
+
+- Убраны глобальные `:root`-переменные и форсирование `--color-light-text-primary`, из-за которых в dark theme текст мог становиться нечитаемым.

--- a/.changeset/long-dots-type.md
+++ b/.changeset/long-dots-type.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-list': patch
+---
+
+- List и List.Item больше не записывают `--color-light-text-primary` в `:root` CSS-бандла, из-за чего ломалась dark theme.

--- a/.storybook/public/global.css
+++ b/.storybook/public/global.css
@@ -417,6 +417,23 @@ select[name] {
     width: 100%;
 }
 
+/*
+ * Storybook docs theme hardcodes textColor (#0B1F35) and even-row bg (#f7fafc).
+ * Neither follows dark mode — remap via design tokens.
+ */
+.sbdocs.sbdocs-content :where(h1, h2, h3, h4, h5, h6, li, p, td, th) {
+    color: var(--color-light-text-primary);
+}
+
+.sbdocs.sbdocs-content table tr:nth-of-type(2n) {
+    background-color: var(--color-light-neutral-translucent-100);
+}
+
+.sbdocs.sbdocs-content table td,
+.sbdocs.sbdocs-content table th {
+    border-color: var(--color-light-neutral-300);
+}
+
 div.github-doc {
     display: none;
 }

--- a/packages/list/src/components/item/index.module.css
+++ b/packages/list/src/components/item/index.module.css
@@ -1,12 +1,7 @@
 @import '@alfalab/core-components-vars/src/index.css';
 
-:root {
-    --list-marker-color: var(--color-light-text-primary);
-    --list-item-margin: var(--gap-12);
-}
-
 .item {
-    margin-top: var(--list-item-margin);
+    margin-top: var(--gap-12);
     display: flex;
 
     &:first-child {
@@ -14,7 +9,7 @@
     }
 
     &.reversed:first-child {
-        margin-top: var(--list-item-margin);
+        margin-top: var(--gap-12);
     }
 
     &.reversed:last-child {
@@ -35,7 +30,7 @@
     flex-shrink: 0;
 
     &.defaultColor {
-        color: var(--list-marker-color);
+        color: currentColor;
     }
 
     &.disc {

--- a/packages/list/src/components/item/index.module.css
+++ b/packages/list/src/components/item/index.module.css
@@ -1,7 +1,7 @@
 @import '@alfalab/core-components-vars/src/index.css';
 
 :root {
-    --list-marker-color: var(--color-light-text-primary);
+    --list-marker-color: currentColor;
     --list-item-margin: var(--gap-12);
 }
 

--- a/packages/list/src/index.module.css
+++ b/packages/list/src/index.module.css
@@ -3,7 +3,7 @@
 .list {
     margin: var(--gap-0);
     padding: var(--gap-0);
-    color: var(--color-light-text-primary);
+    color: inherit;
 
     @mixin paragraph_primary_medium;
 }


### PR DESCRIPTION
##### List

- Убраны глобальные `:root`-переменные и форсирование `--color-light-text-primary`, из-за которых в dark theme текст мог становиться нечитаемым.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

https://github.com/core-ds/core-components/issues/1960

### Поправил Storybook

Было:

<img width="1030" height="982" alt="Снимок экрана — 2026-09-04 в 11 55 49" src="https://github.com/user-attachments/assets/e11cf002-0154-4040-a08b-876bb93be541" />

<img width="1030" height="919" alt="Снимок экрана — 2026-09-04 в 11 58 40" src="https://github.com/user-attachments/assets/660d8d9b-6820-439e-bcd2-d771aeb8999c" />

Стало:

<img width="1030" height="982" alt="Снимок экрана — 2026-09-04 в 11 53 01" src="https://github.com/user-attachments/assets/b99d1d51-514b-478d-a101-5a894b673ff8" />

<img width="1030" height="982" alt="Снимок экрана — 2026-09-04 в 11 54 28" src="https://github.com/user-attachments/assets/61335bb0-a971-4e84-967b-eecd9d7e36bd" />

### Fix бага

Было:

<img width="1030" height="346" alt="Снимок экрана — 2026-09-04 в 11 57 26" src="https://github.com/user-attachments/assets/0d28704b-bcc5-4a56-92a3-2d4837b1a74e" />

Стало:

https://github.com/user-attachments/assets/1d2e2def-6e44-44f2-b9cf-863f7e5173e1




