### PR TITLE
fix(icon-view): исправить обрезание svg-формы в safari при масштабировании [DS-14146]

### DIFF
--- a/.changeset/sweet-toys-search.md
+++ b/.changeset/sweet-toys-search.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-icon-view': patch
+'@alfalab/core-components': patch
+---
+
+##### IconView
+
+- Исправлено обрезание SVG-форм в Safari при масштабировании страницы.

--- a/packages/icon-view/src/components/base-shape/index.module.css
+++ b/packages/icon-view/src/components/base-shape/index.module.css
@@ -14,7 +14,9 @@
 
 .component {
     position: relative;
-    overflow: hidden;
+
+    /* Hack from https://stackoverflow.com/questions/39155167 */
+    overflow: visible;
     width: 100%;
     height: 100%;
     color: var(--icon-view-color);


### PR DESCRIPTION

##### IconView

- Исправлено обрезание SVG-форм в Safari при масштабировании страницы.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

Код для песочницы:

```jsx
function Example() {
    return (
        <div style={{ padding: 40, fontSize: 48, lineHeight: '56px' }}>
    {[16, 20, 24, 32].map((size) => (
        <div key={size} style={{ marginBottom: 24 }}>
            <Link
                href='#'
                leftAddons={
                    <Circle size={size} backgroundColor='#1f2025'>
                        <InformationCompactSIcon style={{ color: '#fff' }} />
                    </Circle>
                }
            >
                О сервисе size {size}
            </Link>
        </div>
    ))}
</div>
    );
}
render(<Example />);
```

Было:

<img width="981" height="323" alt="Снимок экрана 2026-05-05 в 11 53 42" src="https://github.com/user-attachments/assets/9e2475ff-eb20-4a73-9390-5567a6a0b3e4" />

___

<img width="867" height="570" alt="Снимок экрана 2026-05-06 в 09 54 55" src="https://github.com/user-attachments/assets/4ddd07d7-8489-4a9e-a610-89418491415f" />

___
___

Стало:

<img width="867" height="797" alt="Снимок экрана 2026-05-06 в 10 47 46" src="https://github.com/user-attachments/assets/bb03a538-f670-4ad6-88e2-f839085f2c39" />

