### PR TITLE
hotfix(slider): починить выравнивание label по правому и левому краю [DS-17047]

### DIFF
--- a/.changeset/poor-waves-switch.md
+++ b/.changeset/poor-waves-switch.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-themes': minor
+---
+
+- Добавлены дополнительные токены темы

--- a/.changeset/tired-kings-chew.md
+++ b/.changeset/tired-kings-chew.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/core-components-slider': patch
+'@alfalab/core-components-slider-input': patch
+---
+
+- Исправлен регресс выравниваний крайних подписей (`min`/`max`) под слайдером.

--- a/packages/slider-input/src/__image_snapshots__/slider-input-dark-preview-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-dark-preview-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:611af66c35d7849985f5ff3facb2827e7e58ee2de612a8d7722c09405d2bba66
-size 13754
+oid sha256:27c9a6f4d1daafc99a2465fba936cdada47425ada1d13f8f7be0f5be1b6b6d22
+size 13882

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-default-default-state-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-default-default-state-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1762d0ff5db5682187730f6cb75d545e2faeeb67b876b9da31e62aea0042a164
+size 14517

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-default-error-and-disabled-states-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-default-error-and-disabled-states-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2ce1edacc383ab9fb6e1803dcc5cc7be42532b81b8f4d6ceed773a8a3e5a0d
+size 34373

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-mobile-default-state-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-mobile-default-state-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1762d0ff5db5682187730f6cb75d545e2faeeb67b876b9da31e62aea0042a164
+size 14517

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-mobile-error-and-disabled-states-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-mobile-error-and-disabled-states-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2ce1edacc383ab9fb6e1803dcc5cc7be42532b81b8f4d6ceed773a8a3e5a0d
+size 34373

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-site-default-state-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-site-default-state-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d500bfa64db77603377fcfc5b3c7be2df52f68ba5c89f3e02c3f73b7f9e65225
+size 14324

--- a/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-site-error-and-disabled-states-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-edge-labels-alignment-site-error-and-disabled-states-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd158b4e0a32e0a4369def0365981bdb31cb16c9488d3c1105aca81e78888624
+size 35692

--- a/packages/slider-input/src/__image_snapshots__/slider-input-preview-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-preview-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de82ce6453bbbba2e387882e6660038044bb1ab6fe0bca9d24a1aa9fe7975357
-size 14071
+oid sha256:2724df3f75db01da5b5d21a6fc77b34829d477e69585ad48e099210f4da5dbbd
+size 14057

--- a/packages/slider-input/src/__image_snapshots__/slider-input-sprite-main-props-2-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-sprite-main-props-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95982151bbeacefc4df03ebc4e95956d9bc24c2d82aad403f7a07aba74521cdb
-size 46677
+oid sha256:a35dde68a00e2b86053994e5047b7c63bb2c97f7a9c2c8119845a2a2b639d95c
+size 47770

--- a/packages/slider-input/src/__image_snapshots__/slider-input-sprite-main-props-snap.png
+++ b/packages/slider-input/src/__image_snapshots__/slider-input-sprite-main-props-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95982151bbeacefc4df03ebc4e95956d9bc24c2d82aad403f7a07aba74521cdb
-size 46677
+oid sha256:a35dde68a00e2b86053994e5047b7c63bb2c97f7a9c2c8119845a2a2b639d95c
+size 47770

--- a/packages/slider-input/src/component.screenshots.test.tsx
+++ b/packages/slider-input/src/component.screenshots.test.tsx
@@ -86,3 +86,63 @@ describe('SliderInput | sprite', () => {
 
     ['default', 'mobile'].map(testCase);
 });
+
+describe('SliderInput | edge labels alignment', () => {
+    const testCase = (theme: string) =>
+        screenshotTesting({
+            cases: [
+                [
+                    `${theme} | default state`,
+                    createSpriteStorybookUrl({
+                        componentName: 'SliderInput',
+                        knobs: {
+                            label: 'Label',
+                            value: 15000,
+                            sliderValue: 15000,
+                            min: 10000,
+                            max: 30000,
+                            step: 100,
+                            size: 56,
+                            pips: JSON.stringify({
+                                mode: 'values',
+                                values: [10000, 20000, 30000],
+                            }),
+                        },
+                        size: { width: 380, height: 140 },
+                    }),
+                ],
+                [
+                    `${theme} | error and disabled states`,
+                    createSpriteStorybookUrl({
+                        componentName: 'SliderInput',
+                        knobs: {
+                            label: 'Label',
+                            value: 15000,
+                            sliderValue: 15000,
+                            min: 10000,
+                            max: 30000,
+                            step: 100,
+                            size: 56,
+                            error: ['', 'Ошибка'],
+                            disabled: [false, true],
+                            pips: JSON.stringify({
+                                mode: 'values',
+                                values: [10000, 20000, 30000],
+                            }),
+                        },
+                        size: { width: 380, height: 140 },
+                    }),
+                ],
+            ],
+            screenshotOpts: {
+                fullPage: true,
+            },
+            viewport: {
+                width: 900,
+                height: 420,
+            },
+            theme,
+        })();
+
+    ['default', 'mobile', 'site'].map(testCase);
+});

--- a/packages/slider-input/src/index.module.css
+++ b/packages/slider-input/src/index.module.css
@@ -16,6 +16,8 @@
     --slider-input-progress-hover-bg-color: var(--color-light-neutral-700);
     --slider-input-origin-width: calc(100% - 16px);
     --slider-input-origin-right: var(--gap-8);
+    --slider-input-edge-value-margin: -50%;
+    --slider-input-pips-margin: var(--gap-6) var(--gap-6) 0;
 }
 
 .component {
@@ -56,8 +58,39 @@
     }
 
     & :global(.noUi-origin) {
-        width: var(--slider-input-origin-width);
-        right: var(--slider-input-origin-right);
+        width: calc(100% - var(--gap-12));
+        right: var(--gap-6);
+    }
+
+    & :global(.noUi-pips) {
+        margin: var(--slider-input-pips-margin);
+        width: initial;
+    }
+
+    & :global(.noUi-value) {
+        &:nth-child(2) {
+            transform: translateX(var(--slider-input-edge-value-margin));
+        }
+
+        &:last-child {
+            transform: translateX(calc(-100% - var(--slider-input-edge-value-margin)));
+        }
+    }
+
+    & :global(.noUi-marker-large),
+    & :global(.noUi-marker-sub) {
+        top: calc(var(--gap-6-neg) - 1px);
+    }
+
+    & :global(.noUi-marker-large) {
+        &:first-child {
+            transform: translateX(var(--slider-input-edge-value-margin)) translateY(-50%);
+        }
+
+        &:nth-last-child(2) {
+            transform: translateX(calc(-100% - var(--slider-input-edge-value-margin)))
+                translateY(-50%);
+        }
     }
 
     /* TODO исправить на 6px когда слайдеру добавят position: absolute */

--- a/packages/slider/src/__image_snapshots__/slider-dots-alignment-by-size-size-2-snap.png
+++ b/packages/slider/src/__image_snapshots__/slider-dots-alignment-by-size-size-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a674d5282f0d7179a9b3ee42876e6de3d043ca7f753aa12f3baaa72924b41c3
+size 8670

--- a/packages/slider/src/__image_snapshots__/slider-dots-alignment-by-size-size-4-snap.png
+++ b/packages/slider/src/__image_snapshots__/slider-dots-alignment-by-size-size-4-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af5ac2c1673a4c0e510df5d7d2c1eec426a7d3b19d948ed08fdfd2df78a6565d
+size 8642

--- a/packages/slider/src/__image_snapshots__/slider-edge-labels-alignment-large-edge-values-snap.png
+++ b/packages/slider/src/__image_snapshots__/slider-edge-labels-alignment-large-edge-values-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:180f40da9f01ae26efe168b693991ff8cd65da5e13fc3ee08e2b6db8285babfb
+size 8365

--- a/packages/slider/src/component.screenshots.test.tsx
+++ b/packages/slider/src/component.screenshots.test.tsx
@@ -159,3 +159,90 @@ describe(
         },
     }),
 );
+
+describe(
+    'Slider | edge labels alignment',
+    screenshotTesting({
+        cases: [
+            [
+                'large edge values',
+                createSpriteStorybookUrl({
+                    componentName: 'Slider',
+                    knobs: {
+                        min: 10000,
+                        max: 30000,
+                        step: 100,
+                        value: 25000,
+                        size: 4,
+                        dots: true,
+                        pips: JSON.stringify({
+                            mode: 'values',
+                            values: [10000, 20000, 30000],
+                        }),
+                    },
+                    size: { width: 420, height: 130 },
+                }),
+            ],
+        ],
+        screenshotOpts: {
+            fullPage: true,
+        },
+        viewport: {
+            width: 520,
+            height: 170,
+        },
+    }),
+);
+
+describe(
+    'Slider | dots alignment by size',
+    screenshotTesting({
+        cases: [
+            [
+                'size-2',
+                createSpriteStorybookUrl({
+                    componentName: 'Slider',
+                    knobs: {
+                        min: 1,
+                        max: 8,
+                        step: 1,
+                        value: 3,
+                        size: 2,
+                        dots: true,
+                        pips: JSON.stringify({
+                            mode: 'values',
+                            values: [1, 2, 3, 4, 5, 6, 7, 8],
+                        }),
+                    },
+                    size: { width: 560, height: 130 },
+                }),
+            ],
+            [
+                'size-4',
+                createSpriteStorybookUrl({
+                    componentName: 'Slider',
+                    knobs: {
+                        min: 1,
+                        max: 8,
+                        step: 1,
+                        value: 3,
+                        size: 4,
+                        dots: true,
+                        pips: JSON.stringify({
+                            mode: 'values',
+                            values: [1, 2, 3, 4, 5, 6, 7, 8],
+                        }),
+                    },
+                    size: { width: 560, height: 130 },
+                }),
+            ],
+        ],
+        screenshotOpts: {
+            fullPage: true,
+        },
+        viewport: {
+            width: 660,
+            height: 200,
+        },
+    }),
+);

--- a/packages/slider/src/index.module.css
+++ b/packages/slider/src/index.module.css
@@ -100,7 +100,7 @@
 
     & :global(.noUi-marker-large) {
         position: absolute;
-        top: -12px;
+        top: var(--gap-12-neg);
         transform: translateY(-50%);
 
         &:first-child {
@@ -122,7 +122,7 @@
 
     & :global(.noUi-marker-sub) {
         position: absolute;
-        top: -12px;
+        top: var(--gap-12-neg);
         transform: translateY(-50%);
 
         &:global([data-current='true']) {
@@ -162,14 +162,6 @@
         text-align: center;
         top: var(--gap-0);
         transform: translateX(-50%);
-
-        &:nth-child(2) {
-            transform: translateX(-50%);
-        }
-
-        &:last-child {
-            transform: translateX(-50%);
-        }
     }
 
     &.disabled {
@@ -204,7 +196,7 @@
 .size-2 {
     & :global(.noUi-marker-large),
     & :global(.noUi-marker-sub) {
-        top: -13px;
+        top: calc(var(--gap-12-neg) - 1px);
     }
 
     & :global(.noUi-base) {

--- a/packages/themes/src/mixins/slider-input/site.css
+++ b/packages/themes/src/mixins/slider-input/site.css
@@ -10,4 +10,6 @@
     --slider-input-progress-hover-bg-color: var(--color-light-neutral-500);
     --slider-input-origin-width: 100%;
     --slider-input-origin-right: var(--gap-0);
+    --slider-input-edge-value-margin: 2px;
+    --slider-input-pips-margin: var(--gap-6) 0 0;
 }


### PR DESCRIPTION
- Исправлен регресс выравниваний крайних подписей (`min`/`max`) под слайдером.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

### Slider

<img width="1080" height="670" alt="Снимок экрана 2026-05-21 в 08 41 53" src="https://github.com/user-attachments/assets/31df787e-d9f8-42e1-9dd3-6a7ceda30bb5" />

### SliderInput [others-themes]

<img width="1080" height="670" alt="Снимок экрана 2026-05-21 в 08 42 09" src="https://github.com/user-attachments/assets/05a0bc4e-cf07-4b59-b4c2-116ddabef76a" />

### SliderInput [site-theme]

<img width="1080" height="670" alt="Снимок экрана 2026-05-21 в 08 42 05" src="https://github.com/user-attachments/assets/198b6341-8240-4ce2-a654-e689ca3c0862" />
