### PR TITLE
fix(select): BaseOption не отображает content/children при кастомном Checkmark [DS-17206]

### DIFF
--- a/.changeset/four-frogs-matter.md
+++ b/.changeset/four-frogs-matter.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': patch
+---
+
+- Исправлено отображение `content`/`children` в `BaseOption` при передаче кастомного `Checkmark`

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -858,6 +858,23 @@ describe('Select', () => {
                 ).length,
             ).toBe(0);
         });
+
+        it('should render content with custom Checkmark', () => {
+            const CustomCheckmark = () => <span data-test-id='custom-checkmark' />;
+
+            render(
+                <BaseOption
+                    option={{ key: '1', content: 'Neptunium' }}
+                    index={0}
+                    selected={true}
+                    Checkmark={CustomCheckmark}
+                    innerProps={{ id: 'option-id', role: 'option' }}
+                />,
+            );
+
+            expect(screen.getByTestId('custom-checkmark')).toBeInTheDocument();
+            expect(screen.getByText('Neptunium')).toBeInTheDocument();
+        });
     });
 
     describe('Callback tests', () => {

--- a/packages/select/src/components/base-checkmark/Component.tsx
+++ b/packages/select/src/components/base-checkmark/Component.tsx
@@ -15,37 +15,21 @@ export const BaseCheckmark: FC<CheckmarkProps> = ({
     multiple,
     align = 'center',
     position = 'before',
-    content,
-}) => {
-    const renderCheckmarkIcon = () => (
-        <CheckmarkMIcon
-            className={cn(styles.singleIcon, styles[position], {
-                [styles.selected]: selected,
-            })}
-        />
-    );
-
-    return multiple ? (
+}) =>
+    multiple ? (
         <Checkbox
-            block={true}
             checked={selected}
             disabled={disabled}
-            contentClassName={cn({ [styles.positionAfter]: position === 'after' })}
-            className={cn(styles.checkmark, styles[align], className, {
+            className={cn(styles.checkmark, styles[position], styles[align], className, {
                 [styles.selected]: selected,
             })}
             size={24}
-            position={position}
-            label={content}
             hiddenInput={true}
         />
     ) : (
-        <div className={cn(styles.container, styles[align], className)}>
-            {position === 'before' && renderCheckmarkIcon()}
-
-            <div className={styles.content}>{content}</div>
-
-            {position === 'after' && renderCheckmarkIcon()}
-        </div>
+        <CheckmarkMIcon
+            className={cn(styles.singleIcon, styles[position], styles[align], className, {
+                [styles.selected]: selected,
+            })}
+        />
     );
-};

--- a/packages/select/src/components/base-checkmark/index.module.css
+++ b/packages/select/src/components/base-checkmark/index.module.css
@@ -5,31 +5,20 @@
     flex-shrink: 0;
     box-sizing: border-box;
 
+    &.before {
+        margin-right: var(--gap-12);
+    }
+
+    &.after {
+        margin-left: var(--gap-12);
+    }
+
     &.start {
         align-self: start;
     }
 
     &.center {
         align-self: center;
-    }
-}
-
-.positionAfter {
-    margin-left: unset;
-}
-
-.container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-
-    &.start {
-        align-items: flex-start;
-    }
-
-    &.center {
-        align-items: center;
     }
 }
 
@@ -48,8 +37,4 @@
     &.selected {
         opacity: 1;
     }
-}
-
-.content {
-    flex: 1;
 }

--- a/packages/select/src/components/base-option/Component.tsx
+++ b/packages/select/src/components/base-option/Component.tsx
@@ -27,6 +27,17 @@ export const BaseOption: FC<OptionProps> = ({
     const isTextContent = !isValidElement(content);
     const showCheckmark = Checkmark && showCheckMark;
 
+    const renderCheckmark = (position: 'before' | 'after') =>
+        showCheckmark && (
+            <Checkmark
+                disabled={disabled}
+                selected={selected}
+                multiple={multiple}
+                align={align}
+                position={position}
+            />
+        );
+
     return (
         <div
             {...innerProps}
@@ -44,18 +55,11 @@ export const BaseOption: FC<OptionProps> = ({
             data-test-id={dataTestId}
             aria-label={option?.value?.name}
         >
-            {showCheckmark ? (
-                <Checkmark
-                    disabled={disabled}
-                    selected={selected}
-                    multiple={multiple}
-                    align={align}
-                    position={checkmarkPosition}
-                    content={content}
-                />
-            ) : (
-                <div className={cn(styles.content)}>{content}</div>
-            )}
+            {checkmarkPosition === 'before' && renderCheckmark('before')}
+
+            <div className={cn(styles.content)}>{content}</div>
+
+            {checkmarkPosition === 'after' && renderCheckmark('after')}
         </div>
     );
 };


### PR DESCRIPTION

- Исправлено отображение `content`/`children` в `BaseOption` при передаче кастомного `Checkmark`

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

Было:

<img width="1341" height="1058" alt="Снимок экрана 2026-05-29 в 09 35 03" src="https://github.com/user-attachments/assets/334816ce-5361-4eb8-be36-28351d50a02f" />


Стало:

<img width="1341" height="1058" alt="Снимок экрана 2026-05-29 в 09 34 24" src="https://github.com/user-attachments/assets/1fd8d99f-bc7b-4c46-b4fa-39947fcd56a1" />


Код для песочницы:

```tsx
function ExampleBaseOptionHiddenContent() {
    return (
        <div>
             <BaseOption
                  key='some-key-1'
                  index='0'
                  Checkmark={DocumentMIcon}
                  checkmarkPosition='after'
                  option={{
                      key: 'some-key-1',
                      showCheckMark: true,
                  }}
                >
                <span>Через chidlren тоже не отображается</span>
               </BaseOption>
               <BaseOption
                    key='some-key-2'
                    index='1'
                    Checkmark={DocumentImageMIcon}
                    checkmarkPosition='before'
                    option={{
                        key: 'some-key-2',
                        content: 'Текст не видно и через content',
                        showCheckMark: true,
                    }}
                />
                <BaseOption
                    key='some-key-3'
                    index='2'
                    option={{
                        key: 'some-key-3',
                        content: 'Без checkmark текст показывается'
                    }}
                />
        </div>
    );
}
render(
    <ExampleBaseOptionHiddenContent />
)
```
