### PR TITLE
fix(tooltip): кнопка в BottomSheet не наследует inverted-тему [DS-17324]

### DIFF
--- a/.changeset/rare-ravens-travel.md
+++ b/.changeset/rare-ravens-travel.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tooltip': patch
+---
+
+- Исправлен контраст кнопки в мобильной версии Tooltip при `colors="inverted"`: проп `colors` теперь передаётся в `BottomSheet` и `ButtonMobile`

--- a/packages/tooltip/src/desktop/Component.desktop.tsx
+++ b/packages/tooltip/src/desktop/Component.desktop.tsx
@@ -66,6 +66,8 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
 
     const show = forcedOpen === undefined ? visible : forcedOpen;
 
+    const popperColorClass = colorStyles[colors][view];
+
     const open = () => {
         if (!show) {
             setVisible(true);
@@ -227,7 +229,7 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
                 open={show}
                 getPortalContainer={getPortalContainer}
                 arrowClassName={cn(arrowClassName, styles.arrow, colorStyles[colors].arrow)}
-                popperClassName={cn(styles.popper, styles[view], colorStyles[colors][view], {
+                popperClassName={cn(styles.popper, styles[view], popperColorClass, {
                     [desktopStyles.popper]: view === 'tooltip',
                     [desktopStyles.hint]: view === 'hint',
                 })}

--- a/packages/tooltip/src/mobile/Component.mobile.tsx
+++ b/packages/tooltip/src/mobile/Component.mobile.tsx
@@ -22,6 +22,7 @@ export const TooltipMobile: React.FC<TooltipMobileProps> = ({
     targetTag: TargetTag = 'div',
     open: openProp,
     dataTestId,
+    colors = 'default',
     ...restProps
 }) => {
     const [visible, setVisible] = useState(!!openProp);
@@ -51,8 +52,15 @@ export const TooltipMobile: React.FC<TooltipMobileProps> = ({
         <Fragment>
             <BottomSheet
                 open={show}
+                colors={colors}
                 actionButton={
-                    <ButtonMobile view='secondary' block={true} size={56} onClick={handleClose}>
+                    <ButtonMobile
+                        view='secondary'
+                        colors={colors}
+                        block={true}
+                        size={56}
+                        onClick={handleClose}
+                    >
                         {actionButtonTitle}
                     </ButtonMobile>
                 }


### PR DESCRIPTION
- Исправлен контраст кнопки в мобильной версии Tooltip при `colors="inverted"`: проп `colors` теперь передаётся в `BottomSheet` и `ButtonMobile`

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

Было:

<img width="2824" height="1756" alt="image" src="https://github.com/user-attachments/assets/4b942d5e-0e65-4bd9-94ae-2d424969f8a6" />


Стало:

<img width="823" height="946" alt="Снимок экрана 2026-06-08 в 11 26 20" src="https://github.com/user-attachments/assets/8b632037-b99d-4c75-9f51-ed16511a4577" />

Код для песочницы:

```jsx
<Container>
    <Tooltip
        trigger='click'
        colors='inverted'
        position='right'
        view='hint'
        content={
            <div> Пример небольшого вспомогательного текста. </div>
        }
    >
        <div style={{ width: 320 }}>
            <Button block={true} view='primary'>Показать Tooltip</Button>
        </div>
    </Tooltip>
    <Gap size={16}/>
    <Tooltip content={<div>Пример подсказки</div>} position='bottom' view='hint' trigger='click'>
        <div style={{ width: 320 }}>
            <Button block={true} view='primary'>Показать Hint</Button>
        </div>
    </Tooltip>
</Container>
```
