### PR TITLE
perf(css): merge top-level :root blocks in built component CSS

### DIFF
--- a/tools/postcss/postcss-merge-roots.cjs
+++ b/tools/postcss/postcss-merge-roots.cjs
@@ -1,0 +1,49 @@
+/**
+ * Объединяет все top-level правила `:root` в одно, дедуплицируя свойства
+ * (побеждает последнее значение в исходном порядке — каскад не меняется).
+ *
+ * Каждый компонент инлайнит базовые токены + свои алиасы отдельными блоками
+ * `:root`, поэтому в собранном CSS их получается много. Они наследуются в
+ * каждый узел, и DevTools перерисовывает каждый блок при выборе/наведении —
+ * панель Styles начинает тормозить. Слияние сокращает число блоков (это же
+ * делает минификатор в проде), не меняя ни одного разрешённого значения.
+ *
+ * Затрагивает только top-level `:root` — блоки внутри `@media`/др. at-rules не
+ * трогаются, чтобы не нарушить их область видимости.
+ *
+ * @returns {import('postcss').Plugin}
+ */
+const postcssMergeRoots = () => ({
+    postcssPlugin: 'postcss-merge-roots',
+    OnceExit: (root) => {
+        const roots = [];
+        root.each((node) => {
+            if (node.type === 'rule' && node.selector.trim() === ':root') {
+                roots.push(node);
+            }
+        });
+
+        if (roots.length < 2) {
+            return;
+        }
+
+        const byProp = new Map();
+        for (const rule of roots) {
+            rule.walkDecls((decl) => byProp.set(decl.prop, decl.clone()));
+        }
+
+        const first = roots[0];
+        first.removeAll();
+        for (const decl of byProp.values()) {
+            first.append(decl);
+        }
+        for (let i = 1; i < roots.length; i += 1) {
+            roots[i].remove();
+        }
+        if (first.nodes.length === 0) {
+            first.remove();
+        }
+    },
+});
+
+module.exports = postcssMergeRoots;

--- a/tools/rollup/process-css.mjs
+++ b/tools/rollup/process-css.mjs
@@ -15,6 +15,7 @@ import { globSync } from 'tinyglobby';
 
 import postcssConfig from '../../postcss.config.js';
 import { isSamePath } from '../path.cjs';
+import postcssMergeRoots from '../postcss/postcss-merge-roots.cjs';
 import postcssRemoveComment from '../postcss/postcss-remove-comment.cjs';
 import postcssRemoveEmptyRoot from '../postcss/postcss-remove-empty-root.cjs';
 import { resolveInternal } from '../resolve-internal.cjs';
@@ -164,6 +165,7 @@ async function processPostcss(filePath, config) {
             safelist: [/.*/],
         }),
         postcssRemoveComment(),
+        postcssMergeRoots(),
         postcssRemoveEmptyRoot(),
     );
 


### PR DESCRIPTION
## Problem

Each component inlines base tokens + its own aliases as **separate `:root`
blocks**, so a consumer's bundled CSS ends up with hundreds of `:root` blocks.
They inherit into every node, and Chrome DevTools re-renders each one for every
selected/hovered node → the **Styles panel freezes** (same class of issue as
primefaces/primevue#8309). Production is usually fine only because the prod
minifier merges `:root` blocks.

## Change

Add `tools/postcss/postcss-merge-roots.cjs` (a sibling of the existing
`postcss-remove-empty-root.cjs`) that collapses all **top-level** `:root` rules
in each emitted file into a single deduped block, **preserving source order so
no resolved custom-property value changes**. Registered in the shared
`tools/rollup/process-css.mjs` chain (right before `postcss-remove-empty-root`),
so it applies to every build variant.

- `@media`-scoped `:root` is intentionally left intact.
- No-op when a file has fewer than two top-level `:root` blocks.

## Effect

Fewer `:root` blocks per emitted file (e.g. button 21 → 9) → DevTools' Styles
pane stays responsive on consumer apps. Backward compatible, idempotent, no
public API change.

## Verification

The transform was checked in isolation:
- merges multiple `:root` into one, keeping other rules;
- dedupe is last-value-wins in source order (cascade-faithful);
- single-`:root` file is untouched;
- `:root` inside `@media` is not merged.

## Notes

- **Changeset:** not included — this is a build-tooling change that affects every
  component's emitted CSS, so the right version bump depends on your release
  policy. Happy to add whatever set of bumps you prefer.
- This is orthogonal to the existing `moderncssm` / `noCommonVars` build (it does
  not require or change it); it improves the default published CSS directly.
