### PR TITLE
feat(status): добавить возможность прокидывать правый аддон [DS-17688]

### DIFF
--- a/.changeset/smart-chairs-try.md
+++ b/.changeset/smart-chairs-try.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-status': minor
+---
+
+- Добавлена возможность прокидывать правый аддон через проп `rightAddons`

--- a/packages/status/src/Component.test.tsx
+++ b/packages/status/src/Component.test.tsx
@@ -91,12 +91,20 @@ describe('Status', () => {
         });
     });
 
-    it('should set rightAddons', () => {
+    it('should set leftAddons', () => {
         render(<Status leftAddons={<div data-test-id='left-addons-id'>leftAddons</div>} />);
 
         const leftAddon = screen.queryByTestId('left-addons-id');
 
         expect(leftAddon).toBeInTheDocument();
+    });
+
+    it('should set rightAddons', () => {
+        render(<Status rightAddons={<div data-test-id='right-addons-id'>rightAddons</div>} />);
+
+        const rightAddon = screen.queryByTestId('right-addons-id');
+
+        expect(rightAddon).toBeInTheDocument();
     });
 
     it('should unmount without errors', () => {

--- a/packages/status/src/Component.tsx
+++ b/packages/status/src/Component.tsx
@@ -56,6 +56,11 @@ export type StatusProps = {
      * Слот слева
      */
     leftAddons?: ReactNode;
+
+    /**
+     * Слот справа
+     */
+    rightAddons?: ReactNode;
 };
 
 const logWarning = () => {
@@ -82,6 +87,7 @@ export const Status: FC<StatusProps> = ({
     shape = 'rectangular',
     uppercase = true,
     leftAddons,
+    rightAddons,
 }) => {
     if (view === 'soft') {
         logWarning();
@@ -99,12 +105,14 @@ export const Status: FC<StatusProps> = ({
                 {
                     [styles.uppercase]: uppercase,
                     [styles.withLeftAddons]: leftAddons,
+                    [styles.withRightAddons]: rightAddons,
                 },
             )}
             data-test-id={dataTestId}
         >
             {leftAddons && <span className={styles.leftAddons}>{leftAddons}</span>}
             <span className={styles.ellipsis}>{children}</span>
+            {rightAddons && <span className={styles.rightAddons}>{rightAddons}</span>}
         </span>
     );
 };

--- a/packages/status/src/__image_snapshots__/status-right-addons-prop-sprite-snap.png
+++ b/packages/status/src/__image_snapshots__/status-right-addons-prop-sprite-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8074bc9d78bc2487c83717c66d97dc6e9aa73db2f7613d7b201a01a83f3abc49
+size 13856

--- a/packages/status/src/component.screenshots.test.tsx
+++ b/packages/status/src/component.screenshots.test.tsx
@@ -121,3 +121,31 @@ describe(
         },
     }),
 );
+
+describe(
+    'Status | rightAddons prop',
+    screenshotTesting({
+        cases: [
+            [
+                'sprite',
+                createSpriteStorybookUrl({
+                    componentName: 'Status',
+                    knobs: {
+                        children: 'Label',
+                        uppercase: false,
+                        rightAddons: 'right',
+                        size: [...SIZES],
+                    },
+                }),
+            ],
+        ],
+        screenshotOpts: {
+            clip: {
+                x: 0,
+                y: 0,
+                width: 1024,
+                height: 200,
+            },
+        },
+    }),
+);

--- a/packages/status/src/docs/Component.stories.tsx
+++ b/packages/status/src/docs/Component.stories.tsx
@@ -24,6 +24,7 @@ export const status: Story = {
             <DiamondsMIcon width={16} height={16} />
         );
         const leftAddons = boolean('leftAddons', false) && leftAddonIcon;
+        const rightAddons = boolean('rightAddons', false) && leftAddonIcon;
 
         return (
             <Status
@@ -33,6 +34,7 @@ export const status: Story = {
                 shape={select('shape', ['rectangular', 'rounded'], 'rectangular')}
                 uppercase={boolean('uppercase', true)}
                 leftAddons={leftAddons}
+                rightAddons={rightAddons}
             >
                 {text('children', 'Label')}
             </Status>

--- a/packages/status/src/index.module.css
+++ b/packages/status/src/index.module.css
@@ -11,7 +11,8 @@
     text-align: center;
     text-transform: initial;
 
-    & .leftAddons {
+    & .leftAddons,
+    & .rightAddons {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -90,6 +91,28 @@
         &.size-40 {
             gap: var(--gap-6);
             padding-left: var(--gap-16);
+        }
+    }
+
+    &.withRightAddons {
+        &.size-20 {
+            gap: 3px;
+            padding-right: var(--gap-6);
+        }
+
+        &.size-24 {
+            gap: var(--gap-4);
+            padding-right: var(--gap-8);
+        }
+
+        &.size-32 {
+            gap: var(--gap-6);
+            padding-right: var(--gap-12);
+        }
+
+        &.size-40 {
+            gap: var(--gap-6);
+            padding-right: var(--gap-16);
         }
     }
 }


### PR DESCRIPTION
### Status

- Добавлена возможность прокидывать правый аддон через проп `rightAddons`

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

<img width="252" height="147" alt="Снимок экрана — 2026-07-09 в 00 12 52" src="https://github.com/user-attachments/assets/0f90a3f9-689f-4d31-9be4-aede6be340ed" />

