### PR TITLE
fix(checkbox): position=after у чекбокса нет отступа от текста [DS-17984]

### DIFF
--- a/.changeset/mean-cobras-sit.md
+++ b/.changeset/mean-cobras-sit.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-checkbox': patch
+---
+
+- Исправлен отступ между текстом и чекбоксом при `position="after"`

--- a/packages/checkbox/src/Component.tsx
+++ b/packages/checkbox/src/Component.tsx
@@ -232,6 +232,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
                         [colorStyle.indeterminate]: indeterminate,
                         [styles.focused]: focused,
                         [styles.block]: block,
+                        [styles['position-after']]: position === 'after',
                     },
                 )}
                 ref={mergeRefs([labelRef, ref, labelProps?.ref as Ref<HTMLLabelElement>])}

--- a/packages/checkbox/src/__image_snapshots__/checkbox-position-sprite-snap.png
+++ b/packages/checkbox/src/__image_snapshots__/checkbox-position-sprite-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1ac6cbacf220d114adbbea5acf9bafd1f77f052d025bb915cff64c81308cfcf
-size 18092
+oid sha256:1ae01f0856d4f423e324e8462f41f9a73c8e8f1e6508060c080d58def0206954
+size 17943

--- a/packages/checkbox/src/styles/index.module.css
+++ b/packages/checkbox/src/styles/index.module.css
@@ -67,12 +67,22 @@
     margin-left: var(--gap-12);
 }
 
+.position-after .content {
+    margin-left: 0;
+    margin-right: var(--gap-12);
+}
+
 .size-20 .content {
     margin-left: var(--gap-8);
 
     & .label {
         @mixin paragraph_component;
     }
+}
+
+.size-20.position-after .content {
+    margin-right: var(--gap-8);
+    margin-left: 0;
 }
 
 .label {


### PR DESCRIPTION
- Исправлен отступ между текстом и чекбоксом при `position="after"`

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

<img width="673" height="69" alt="Снимок экрана — 2026-07-31 в 11 29 11" src="https://github.com/user-attachments/assets/8362c56a-a03b-44b8-8487-82758379b692" />

