### PR TITLE
fix(shared): mapping for transparent color

### DIFF
--- a/.changeset/wild-cups-camp.md
+++ b/.changeset/wild-cups-camp.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-shared': patch
+---
+
+- Обновлён маппинг для цвета transparent на актуальный transparent-default

--- a/packages/shared/src/get-color-var/color-mapper.ts
+++ b/packages/shared/src/get-color-var/color-mapper.ts
@@ -1339,7 +1339,7 @@ export const colorMapper: TColorMapper = {
     textColorTertiaryInvertedTransparent: getWithThemeValue('text-tertiary-inverted-transparent'),
     textColorTertiaryPress: getWithThemeValue('text-tertiary-press'),
     textColorTertiaryTransparent: getWithThemeValue('text-tertiary-transparent'),
-    transparent: getWithoutThemeValue('dynamic-nulled'),
+    transparent: getWithThemeValue('transparent-default'),
     transparentColorDefault: getWithThemeValue('transparent-default'),
     transparentColorDefaultHover: getWithThemeValue('transparent-default-hover'),
     transparentColorDefaultInvertedHover: getWithThemeValue('transparent-default-inverted-hover'),

--- a/packages/shared/src/get-color-var/get-color-var.test.ts
+++ b/packages/shared/src/get-color-var/get-color-var.test.ts
@@ -67,6 +67,10 @@ describe('getColorVar', () => {
             expected: 'var(--color-light-status-muted-positive)',
         },
         {
+            color: 'transparent',
+            expected: 'var(--color-light-transparent-default)',
+        },
+        {
             color: '#44ddAA',
             expected: '#44ddAA',
         },

--- a/packages/shared/src/get-color-var/translatecolors.ts
+++ b/packages/shared/src/get-color-var/translatecolors.ts
@@ -34,8 +34,7 @@ const notStandardNames = [
          */
         colorIn: 'transparent',
         // На выходе
-        colorOut: 'dynamic-nulled',
-        withTheme: false,
+        colorOut: 'transparent-default',
     },
 ];
 
@@ -63,10 +62,6 @@ export const translateColors = (colorName: string): ColorValue => {
             value = `${rule.colorPrefixOut}${endStr}`;
         } else if (rule.colorIn === colorNameLow) {
             value = rule.colorOut;
-        }
-
-        if (value && rule.withTheme === false) {
-            withThemeSetting = false;
         }
     }
 


### PR DESCRIPTION
Обновлён маппинг для цвета transparent на актуальный transparent-default

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало
