### PR TITLE
fix(universal-modal): hug content static class

### DIFF
--- a/.changeset/hug-content-static-classes.md
+++ b/.changeset/hug-content-static-classes.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-universal-modal': patch
+---
+
+- Механизм `height="hugContent"` + `margin.top`/`margin.bottom` переведён с CSS custom properties на статически сгенерированные классы

--- a/packages/universal-modal/src/desktop/styles/common.module.css
+++ b/packages/universal-modal/src/desktop/styles/common.module.css
@@ -21,25 +21,15 @@
     }
 }
 
-:root {
-    /* stylelint-disable-next-line length-zero-no-unit */
-    --hug-content-top-gap: 0px;
-    /* stylelint-disable-next-line length-zero-no-unit */
-    --hug-content-bottom-gap: 0px;
-}
-
 .hugContent {
-    max-height: calc(100% - var(--hug-content-top-gap) - var(--hug-content-bottom-gap));
-    margin-top: var(--hug-content-top-gap);
-    margin-bottom: var(--hug-content-bottom-gap);
+    max-height: 100%;
 
     /* prettier-ignore */
-    @for $i from 0 to 128 {
-        &.topGap-$(i) {
-            --hug-content-top-gap: $(i)px;
-        }
-        &.bottomGap-$(i) {
-            --hug-content-bottom-gap: $(i)px;
+    @each $top in 0, 2, 4, 8, 12, 16, 20, 24, 32, 40, 48, 56, 64, 72, 80, 96, 128 {
+        @each $bottom in 0, 2, 4, 8, 12, 16, 20, 24, 32, 40, 48, 56, 64, 72, 80, 96, 128 {
+            &.hugGap-$(top)-$(bottom) {
+                max-height: calc(100% - $(top)px - $(bottom)px);
+            }
         }
     }
 }

--- a/packages/universal-modal/src/desktop/utils/get-hug-content-styles.ts
+++ b/packages/universal-modal/src/desktop/utils/get-hug-content-styles.ts
@@ -1,5 +1,3 @@
-import { hasOwnProperty } from '@alfalab/core-components-shared';
-
 import { type UniversalModalDesktopProps } from '../types/props';
 
 interface Params {
@@ -15,10 +13,11 @@ export const getHugContentStyles = (params: Params): Record<string, boolean> => 
         return {};
     }
 
+    const topGap = margin?.top ?? 0;
+    const bottomGap = margin?.bottom ?? 0;
+
     return {
         [styles.hugContent]: true,
-        ...(margin && hasOwnProperty(margin, 'top') && { [styles[`topGap-${margin.top}`]]: true }),
-        ...(margin &&
-            hasOwnProperty(margin, 'bottom') && { [styles[`bottomGap-${margin.bottom}`]]: true }),
+        [styles[`hugGap-${topGap}-${bottomGap}`]]: true,
     };
 };

--- a/packages/universal-modal/src/desktop/utils/tests/get-hug-content-styles.test.ts
+++ b/packages/universal-modal/src/desktop/utils/tests/get-hug-content-styles.test.ts
@@ -16,6 +16,7 @@ describe('getHugContentStyles', () => {
     it('height === hugContent, without margin', () => {
         expect(getHugContentStyles({ styles, margin: undefined, height: 'hugContent' })).toEqual({
             hugContent: true,
+            'hugGap-0-0': true,
         });
     });
 
@@ -24,8 +25,7 @@ describe('getHugContentStyles', () => {
 
         expect(getHugContentStyles({ styles, margin, height: 'hugContent' })).toEqual({
             hugContent: true,
-            'topGap-48': true,
-            'bottomGap-24': true,
+            'hugGap-48-24': true,
         });
     });
 
@@ -34,6 +34,7 @@ describe('getHugContentStyles', () => {
 
         expect(getHugContentStyles({ styles, margin, height: 'hugContent' })).toEqual({
             hugContent: true,
+            'hugGap-0-0': true,
         });
     });
 
@@ -42,6 +43,7 @@ describe('getHugContentStyles', () => {
 
         expect(getHugContentStyles({ styles, margin, height: 'hugContent' })).toEqual({
             hugContent: true,
+            'hugGap-0-0': true,
         });
     });
 });


### PR DESCRIPTION
DS-18294

- Механизм `height="hugContent"` + `margin.top`/`margin.bottom` переведён с CSS custom properties на статически сгенерированные классы
