### PR TITLE
фик бесконечный цикл обновлений в некоторых компонентах

### DIFF
--- a/.changeset/calm-mirrors-fix.md
+++ b/.changeset/calm-mirrors-fix.md
@@ -1,0 +1,12 @@
+---
+'@alfalab/core-components-with-suffix': patch
+'@alfalab/core-components-tooltip': patch
+'@alfalab/core-components-masked-input': patch
+'@alfalab/core-components-popover': patch
+'@alfalab/core-components-textarea': patch
+'@alfalab/core-components-calendar': patch
+'@alfalab/core-components-amount-input': patch
+'@alfalab/core-components': patch
+---
+
+Исправлена ошибка `Maximum update depth exceeded` для react v18: нестабильный `mergeRefs` вместе с `setState` в callback ref больше не будет уходить бесконечный цикл для `with-suffix`, `tooltip`, `masked-input`, `popover`, `textarea`, `calendar`, `amount-input`

--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -338,6 +338,15 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
             </Fragment>
         );
 
+        /*
+         * для react v18 сохраняем ref функцию между рендерами
+         * иначе react каждый раз вызывает старую с null и новую с DOM узлом
+         */
+        const inputMergedRef = useMemo(
+            () => mergeRefs([ref, inputRef, maskitoRef]),
+            [ref, inputRef, maskitoRef],
+        );
+
         return (
             <div
                 className={cn(styles.container, {
@@ -385,7 +394,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
                     onBlur={handleBlur}
                     inputMode={numberParams.maximumFractionDigits ? 'decimal' : 'numeric'}
                     dataTestId={dataTestId}
-                    ref={mergeRefs([ref, inputRef, maskitoRef])}
+                    ref={inputMergedRef}
                     breakpoint={breakpoint}
                     client={client}
                     fieldClassName={cn(

--- a/packages/masked-input/src/Component.tsx
+++ b/packages/masked-input/src/Component.tsx
@@ -3,6 +3,7 @@ import React, {
     type MouseEvent,
     useCallback,
     useEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react';
@@ -136,6 +137,24 @@ export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
             setTextHidden(false);
         }, []);
 
+        /*
+         * для react v18 сохраняем ref функцию между рендерами
+         * если она меняется, react вызовет старую с null, этот null в state не сохраняем,
+         * иначе снова ререндер и бесконечный цикл.
+         */
+        const handleInputNodeRef = useCallback((node: HTMLInputElement | null) => {
+            if (node === null) {
+                return;
+            }
+
+            setInputNode((current) => (current === node ? current : node));
+        }, []);
+
+        const inputMergedRef = useMemo(
+            () => mergeRefs([ref, handleInputNodeRef]),
+            [ref, handleInputNodeRef],
+        );
+
         return (
             <Input
                 {...restProps}
@@ -143,7 +162,7 @@ export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
                 value={inputValue}
                 onChange={handleInputChange}
                 onClear={handleClear}
-                ref={mergeRefs([ref, inputNodeRef])}
+                ref={inputMergedRef}
             />
         );
     },

--- a/packages/popover/src/Component.test.tsx
+++ b/packages/popover/src/Component.test.tsx
@@ -104,4 +104,47 @@ describe('Render tests', () => {
 
         expect(unmount).not.toThrow();
     });
+
+    it('should not throw Maximum update depth on mount and parent rerenders with unstable ref', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const Parent = ({ tick }: { tick: number }) => (
+            <Popover
+                // нестабильный callback ref каждый рендер родителя (React >= v18)
+                ref={() => {
+                    void tick;
+                }}
+                open={true}
+                anchorElement={document.body}
+                dataTestId='popover'
+            >
+                <div>I am popover</div>
+            </Popover>
+        );
+
+        let rerender: ReturnType<typeof render>['rerender'];
+        let getByTestId: ReturnType<typeof render>['getByTestId'];
+
+        await act(async () => {
+            ({ rerender, getByTestId } = render(<Parent tick={0} />));
+        });
+
+        expect(getByTestId!('popover')).toBeInTheDocument();
+
+        await expect(
+            act(async () => {
+                rerender!(<Parent tick={1} />);
+                rerender!(<Parent tick={2} />);
+                rerender!(<Parent tick={3} />);
+            }),
+        ).resolves.not.toThrow();
+
+        const updateDepthErrors = consoleError.mock.calls.filter((args) =>
+            String(args[0]).includes('Maximum update depth'),
+        );
+
+        expect(updateDepthErrors).toHaveLength(0);
+
+        consoleError.mockRestore();
+    });
 });

--- a/packages/popover/src/Component.tsx
+++ b/packages/popover/src/Component.tsx
@@ -3,6 +3,7 @@ import React, {
     forwardRef,
     type MutableRefObject,
     type ReactNode,
+    useCallback,
     useEffect,
     useMemo,
     useRef,
@@ -350,9 +351,27 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             return noop;
         }, [anchorElement, useAnchorWidth]);
 
+        /*
+         * для react v18 сохраняем ref функцию между рендерами
+         * если она меняется, react вызовет старую с null, этот null в state не сохраняем,
+         * иначе снова ререндер и бесконечный цикл.
+         */
+        const handlePopperElementRef = useCallback((node: HTMLElement | null) => {
+            if (node === null) {
+                return;
+            }
+
+            setPopperElement((current) => (current === node ? current : node));
+        }, []);
+
+        const popperMergedRef = useMemo(
+            () => mergeRefs([ref, popperRef, handlePopperElementRef]),
+            [ref, popperRef, handlePopperElementRef],
+        );
+
         const renderContent = (computedZIndex: number) => (
             <div
-                ref={mergeRefs([ref, popperRef, popperElementRef])}
+                ref={popperMergedRef}
                 style={{
                     zIndex: computedZIndex,
                     [widthProp]: useAnchorWidth ? anchorElement?.offsetWidth : undefined,

--- a/packages/textarea/src/Component.test.tsx
+++ b/packages/textarea/src/Component.test.tsx
@@ -256,4 +256,38 @@ describe('Textarea', () => {
 
         expect(unmount).not.toThrow();
     });
+
+    it('should not throw Maximum update depth on mount and parent rerenders with unstable ref', () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const Parent = ({ tick }: { tick: number }) => (
+            <Textarea
+                // нестабильный callback ref каждый рендер родителя (React >= v18)
+                ref={() => {
+                    void tick;
+                }}
+                value='value'
+                onChange={jest.fn()}
+                dataTestId='textarea'
+            />
+        );
+
+        const { rerender, getByTestId } = render(<Parent tick={0} />);
+
+        expect(getByTestId('textarea')).toBeInTheDocument();
+
+        expect(() => {
+            rerender(<Parent tick={1} />);
+            rerender(<Parent tick={2} />);
+            rerender(<Parent tick={3} />);
+        }).not.toThrow();
+
+        const updateDepthErrors = consoleError.mock.calls.filter((args) =>
+            String(args[0]).includes('Maximum update depth'),
+        );
+
+        expect(updateDepthErrors).toHaveLength(0);
+
+        consoleError.mockRestore();
+    });
 });

--- a/packages/textarea/src/Component.tsx
+++ b/packages/textarea/src/Component.tsx
@@ -1,4 +1,12 @@
-import React, { forwardRef, Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+    forwardRef,
+    Fragment,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import mergeRefs from 'react-merge-refs';
 import TextareaAutosize from 'react-textarea-autosize';
 import cn from 'classnames';
@@ -169,6 +177,24 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             textareaClassName,
         );
 
+        /*
+         * для react v18 сохраняем ref функцию между рендерами
+         * если она меняется, react вызовет старую с null, этот null в state не сохраняем,
+         * иначе снова ререндер и бесконечный цикл.
+         */
+        const handleTextareaNodeRef = useCallback((node: HTMLTextAreaElement | null) => {
+            if (node === null) {
+                return;
+            }
+
+            setTextareaNode((current) => (current === node ? current : node));
+        }, []);
+
+        const textareaMergedRef = useMemo(
+            () => mergeRefs([ref, handleTextareaNodeRef]),
+            [ref, handleTextareaNodeRef],
+        );
+
         const textareaProps = {
             ...restProps,
             className: textareaClassNameCalc,
@@ -180,7 +206,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             onChange: handleTextareaChange,
             value: uncontrolled ? stateValue : value,
             rows,
-            ref: mergeRefs([ref, textareaNodeRef]),
+            ref: textareaMergedRef,
             'data-test-id': dataTestId,
             onScroll: handleTeaxtareaScroll,
         };

--- a/packages/tooltip/src/Component.test.tsx
+++ b/packages/tooltip/src/Component.test.tsx
@@ -1,5 +1,6 @@
 import React, { ForwardRefRenderFunction, SyntheticEvent } from 'react';
 import {
+    act,
     render,
     screen,
     fireEvent,
@@ -449,5 +450,47 @@ describe('Props test', () => {
         expect(onTargetClick).toHaveBeenCalledTimes(1);
 
         expect(onTargetClick).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('should not throw Maximum update depth on mount and parent rerenders with unstable targetRef', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const Parent = ({ tick }: { tick: number }) => (
+            <Tooltip
+                // нестабильный callback ref каждый рендер родителя (React >= v18)
+                targetRef={() => {
+                    void tick;
+                }}
+                content={<div>content</div>}
+                open={true}
+            >
+                <div data-test-id='tooltip-trigger'>trigger</div>
+            </Tooltip>
+        );
+
+        let rerender: ReturnType<typeof render>['rerender'];
+        let getByTestId: ReturnType<typeof render>['getByTestId'];
+
+        await act(async () => {
+            ({ rerender, getByTestId } = render(<Parent tick={0} />));
+        });
+
+        expect(getByTestId!('tooltip-trigger')).toBeInTheDocument();
+
+        await expect(
+            act(async () => {
+                rerender!(<Parent tick={1} />);
+                rerender!(<Parent tick={2} />);
+                rerender!(<Parent tick={3} />);
+            }),
+        ).resolves.not.toThrow();
+
+        const updateDepthErrors = consoleError.mock.calls.filter((args) =>
+            String(args[0]).includes('Maximum update depth'),
+        );
+
+        expect(updateDepthErrors).toHaveLength(0);
+
+        consoleError.mockRestore();
     });
 });

--- a/packages/tooltip/src/desktop/Component.desktop.tsx
+++ b/packages/tooltip/src/desktop/Component.desktop.tsx
@@ -4,6 +4,7 @@ import React, {
     type HTMLAttributes,
     useCallback,
     useEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react';
@@ -217,9 +218,27 @@ export const TooltipDesktop: FC<TooltipDesktopProps> = ({
         }
     };
 
+    /*
+     * для react v18 сохраняем ref функцию между рендерами
+     * если она меняется, react вызовет старую с null, этот null в state не сохраняем,
+     * иначе снова ререндер и бесконечный цикл.
+     */
+    const setTargetStable = useCallback((node: HTMLElement | null) => {
+        if (node === null) {
+            return;
+        }
+
+        setTarget((current) => (current === node ? current : node));
+    }, []);
+
+    const targetMergedRef = useMemo(
+        () => mergeRefs([targetRef, setTargetStable]),
+        [targetRef, setTargetStable],
+    );
+
     return (
         <Fragment>
-            <TargetTag ref={mergeRefs([targetRefFromProps, targetRef])} {...getTargetProps()}>
+            <TargetTag ref={targetMergedRef} {...getTargetProps()}>
                 {children.props.disabled && <div className={styles.overlap} />}
                 {children}
             </TargetTag>

--- a/packages/with-suffix/src/Component.test.tsx
+++ b/packages/with-suffix/src/Component.test.tsx
@@ -71,4 +71,38 @@ describe('withSuffix', () => {
 
         expect(unmount).not.toThrow();
     });
+
+    it('should not throw Maximum update depth on mount and parent rerenders with unstable ref', () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const Parent = ({ tick }: { tick: number }) => (
+            <SuffixInput
+                // нестабильный callback ref каждый рендер родителя (React >= v18)
+                ref={() => {
+                    void tick;
+                }}
+                value='10'
+                suffix=' лет'
+                dataTestId='suffix-input'
+            />
+        );
+
+        const { rerender, getByTestId } = render(<Parent tick={0} />);
+
+        expect(getByTestId('suffix-input')).toBeInTheDocument();
+
+        expect(() => {
+            rerender(<Parent tick={1} />);
+            rerender(<Parent tick={2} />);
+            rerender(<Parent tick={3} />);
+        }).not.toThrow();
+
+        const updateDepthErrors = consoleError.mock.calls.filter((args) =>
+            String(args[0]).includes('Maximum update depth'),
+        );
+
+        expect(updateDepthErrors).toHaveLength(0);
+
+        consoleError.mockRestore();
+    });
 });

--- a/packages/with-suffix/src/Component.tsx
+++ b/packages/with-suffix/src/Component.tsx
@@ -5,6 +5,7 @@ import React, {
     type ReactNode,
     type RefAttributes,
     useCallback,
+    useMemo,
     useState,
 } from 'react';
 import mergeRefs from 'react-merge-refs';
@@ -90,10 +91,28 @@ export const withSuffix = (Input: FC<InputProps & RefAttributes<HTMLInputElement
 
             const isInverted = restProps.colors === 'inverted';
 
+            /*
+             * для react v18 сохраняем ref функцию между рендерами
+             * если она меняется, react вызовет старую с null, этот null в state не сохраняем,
+             * иначе снова ререндер и бесконечный цикл.
+             */
+            const handleInputNodeRef = useCallback((node: HTMLInputElement | null) => {
+                if (node === null) {
+                    return;
+                }
+
+                setInputNode((current) => (current === node ? current : node));
+            }, []);
+
+            const inputMergedRef = useMemo(
+                () => mergeRefs([ref, handleInputNodeRef]),
+                [ref, handleInputNodeRef],
+            );
+
             return (
                 <Fragment>
                     <Input
-                        ref={mergeRefs([ref, inputNodeRef])}
+                        ref={inputMergedRef}
                         value={visibleValue}
                         disabled={disabled}
                         readOnly={readOnly}


### PR DESCRIPTION
На React v18 нестабильный mergeRefs вместе с setState в callback ref вызывает бесконечный цикл обновлений и выстреливает ошибка "Maximum update depth exceeded"

Что сделано:
для компонентов with-suffix, tooltip, masked-input, popover, textarea, calendar и amount-input:
- мемоизизируем ref между рендерами
- не пишем null в state, когда react вызывает старый callback ref с null

Это убирает цикл `attach -> setState-> ререндер -> новый ref -> detach(null) -> setState`