### PR TITLE
fix(useselectwithapply): при выборе в списке options  'Выбрать все' н…

### DIFF
--- a/.changeset/fast-rats-beg.md
+++ b/.changeset/fast-rats-beg.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select': minor
+---
+
+При клике 'Выбрать все' выбираются все значения кроме `disabled`

--- a/.changeset/fast-rats-beg.md
+++ b/.changeset/fast-rats-beg.md
@@ -1,5 +1,5 @@
 ---
-'@alfalab/core-components-select': minor
+'@alfalab/core-components-select': patch
 ---
 
-При клике 'Выбрать все' выбираются все значения кроме `disabled`
+- При клике 'Выбрать все' выбираются все значения кроме `disabled`

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -1133,4 +1133,88 @@ describe('Select', () => {
             });
         });
     });
+
+    describe('useSelectWithApply', () => {
+        const optionsWithDisabled = [
+            { key: '1', content: 'Neptunium' },
+            { key: '2', content: 'Plutonium', disabled: true },
+            { key: '3', content: 'Americium' },
+        ];
+
+        const enabledOptions = [optionsWithDisabled[0], optionsWithDisabled[2]];
+
+        function SelectWithApplyDisabled({
+            onChange = jest.fn(),
+            selected = [] as typeof optionsWithDisabled,
+            showHeaderWithSelectAll = false,
+            showSelectAll = false,
+        }) {
+            const selectProps = useSelectWithApply({
+                options: optionsWithDisabled,
+                selected,
+                onChange,
+                showHeaderWithSelectAll,
+                showSelectAll,
+            });
+
+            return <Select open={true} {...selectProps} dataTestId='select' />;
+        }
+
+        it('does not select disabled options via header "Select all" and does not pass them to onChange', () => {
+            const onChange = jest.fn();
+            const { getByTestId, getByText } = render(
+                <SelectWithApplyDisabled onChange={onChange} showHeaderWithSelectAll={true} />,
+            );
+
+            fireEvent.click(getByText('Выбрать все'));
+            fireEvent.click(getByTestId(getSelectTestIds('select').applyButton));
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    selectedMultiple: enabledOptions,
+                    name: 'apply-footer',
+                }),
+            );
+            expect(onChange.mock.calls[0][0].selectedMultiple).not.toContainEqual(
+                optionsWithDisabled[1],
+            );
+        });
+
+        it('does not select disabled options via list "Select all" and does not pass them to onChange', () => {
+            const onChange = jest.fn();
+            const { getByTestId, getByText } = render(
+                <SelectWithApplyDisabled onChange={onChange} showSelectAll={true} />,
+            );
+
+            fireEvent.click(getByText('Выбрать все'));
+            fireEvent.click(getByTestId(getSelectTestIds('select').applyButton));
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    selectedMultiple: enabledOptions,
+                    name: 'apply-footer',
+                }),
+            );
+            expect(onChange.mock.calls[0][0].selectedMultiple).not.toContainEqual(
+                optionsWithDisabled[1],
+            );
+        });
+
+        it('does not select disabled option on click', () => {
+            const onChange = jest.fn();
+            const { getByTestId, getByText } = render(
+                <SelectWithApplyDisabled onChange={onChange} />,
+            );
+
+            fireEvent.click(getByText('Plutonium'));
+            fireEvent.click(getByTestId(getSelectTestIds('select').applyButton));
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    selectedMultiple: [],
+                    name: 'apply-footer',
+                }),
+            );
+        });
+    });
 });

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -1175,9 +1175,6 @@ describe('Select', () => {
                     name: 'apply-footer',
                 }),
             );
-            expect(onChange.mock.calls[0][0].selectedMultiple).not.toContainEqual(
-                optionsWithDisabled[1],
-            );
         });
 
         it('does not select disabled options via list "Select all" and does not pass them to onChange', () => {
@@ -1194,9 +1191,6 @@ describe('Select', () => {
                     selectedMultiple: enabledOptions,
                     name: 'apply-footer',
                 }),
-            );
-            expect(onChange.mock.calls[0][0].selectedMultiple).not.toContainEqual(
-                optionsWithDisabled[1],
             );
         });
 

--- a/packages/select/src/presets/useSelectWithApply/hook.test.ts
+++ b/packages/select/src/presets/useSelectWithApply/hook.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { type OptionShape } from '../../typings';
+
+import { useSelectWithApply } from './hook';
+
+const options: OptionShape[] = [
+    { key: '1', content: 'Auurum' },
+    { key: '2', content: 'Bercelium' },
+    { key: '3', content: 'Curium', disabled: true },
+    { key: '4', content: 'Neptunium' },
+];
+
+const enabledOptions = [options[0], options[1], options[3]];
+const disabledOption = options[2];
+
+describe('useSelectWithApply', () => {
+    describe('disabled options', () => {
+        it('selects only enabled options on "Select all" click', () => {
+            const onSelectAllClick = jest.fn();
+
+            const { result } = renderHook(() =>
+                useSelectWithApply({
+                    options,
+                    selected: [],
+                    onChange: jest.fn(),
+                    onSelectAllClick,
+                    showHeaderWithSelectAll: true,
+                }),
+            );
+
+            act(() => {
+                result.current.optionsListProps.headerProps?.onChange?.();
+            });
+
+            expect(onSelectAllClick).toHaveBeenCalledWith(enabledOptions);
+            expect(result.current.optionsListProps.selectedDraft).toEqual(enabledOptions);
+            expect(result.current.optionsListProps.selectedDraft).not.toContainEqual(
+                disabledOption,
+            );
+            expect(result.current.optionsListProps.headerProps?.checked).toBe(true);
+            expect(result.current.optionsListProps.headerProps?.indeterminate).toBe(false);
+        });
+
+        it('does not pass disabled options to onChange on "Apply"', () => {
+            const onChange = jest.fn();
+
+            const { result } = renderHook(() =>
+                useSelectWithApply({
+                    options,
+                    selected: [disabledOption],
+                    onChange,
+                    showHeaderWithSelectAll: true,
+                }),
+            );
+
+            expect(result.current.optionsListProps.selectedDraft).toEqual([]);
+
+            act(() => {
+                result.current.optionsListProps.onApply?.();
+            });
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    selected: undefined,
+                    selectedMultiple: [],
+                    name: 'apply-footer',
+                }),
+            );
+        });
+
+        it('shows indeterminate state when only some selectable options are selected', () => {
+            const { result } = renderHook(() =>
+                useSelectWithApply({
+                    options,
+                    selected: [options[0]],
+                    onChange: jest.fn(),
+                    showHeaderWithSelectAll: true,
+                }),
+            );
+
+            expect(result.current.optionsListProps.headerProps?.checked).toBe(false);
+            expect(result.current.optionsListProps.headerProps?.indeterminate).toBe(true);
+        });
+
+        it('does not add disabled option to selection draft', () => {
+            const { result } = renderHook(() =>
+                useSelectWithApply({
+                    options,
+                    selected: [],
+                    onChange: jest.fn(),
+                    showHeaderWithSelectAll: true,
+                }),
+            );
+
+            act(() => {
+                result.current.onChange({
+                    selected: disabledOption,
+                    selectedMultiple: [disabledOption],
+                    initiator: disabledOption,
+                });
+            });
+
+            expect(result.current.optionsListProps.selectedDraft).toEqual([]);
+        });
+    });
+});

--- a/packages/select/src/presets/useSelectWithApply/hook.ts
+++ b/packages/select/src/presets/useSelectWithApply/hook.ts
@@ -158,9 +158,12 @@ export function useSelectWithApply({
 
     const selectedKeys = useMemo(() => selectedDraft.map(({ key }) => key), [selectedDraft]);
 
-    const allSelectableSelected =
-        selectableOptions.length > 0 &&
-        selectableOptions.every(({ key }) => selectedKeys.includes(key));
+    const allSelectableSelected = useMemo(
+        () =>
+            selectableOptions.length > 0 &&
+            selectableOptions.every(({ key }) => selectedKeys.includes(key)),
+        [selectableOptions, selectedKeys],
+    );
 
     const handleApply = () => {
         onChange({

--- a/packages/select/src/presets/useSelectWithApply/hook.ts
+++ b/packages/select/src/presets/useSelectWithApply/hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import reactFastCompare from 'react-fast-compare';
 
 import { SELECT_ALL_KEY } from '../../consts';
@@ -90,6 +90,8 @@ export type UseSelectWithApplyProps = {
 
 const selectAllOption = { key: SELECT_ALL_KEY, content: 'Выбрать все' };
 
+const isSelectable = (option: OptionShape) => !option.disabled;
+
 export function useSelectWithApply({
     options,
     selected,
@@ -141,9 +143,24 @@ export function useSelectWithApply({
             ),
         [options, selected, showSearch, filterGroup, filterFn, accessor, search, groupAccessor],
     );
-    const [selectedDraft, setSelectedDraft] = useState<OptionShape[]>(selectedOptions);
+
+    const selectableOptions = useMemo(() => flatOptions.filter(isSelectable), [flatOptions]);
+
+    const [selectedDraft, setSelectedDraftState] = useState<OptionShape[]>(() =>
+        selectedOptions.filter(isSelectable),
+    );
+
+    const setSelectedDraft = useCallback((items: OptionShape[]) => {
+        setSelectedDraftState(items.filter(isSelectable));
+    }, []);
 
     const selectedOptionsRef = useRef<OptionShape[]>(selectedOptions);
+
+    const selectedKeys = useMemo(() => selectedDraft.map(({ key }) => key), [selectedDraft]);
+
+    const allSelectableSelected =
+        selectableOptions.length > 0 &&
+        selectableOptions.every(({ key }) => selectedKeys.includes(key));
 
     const handleApply = () => {
         onChange({
@@ -165,21 +182,27 @@ export function useSelectWithApply({
     };
 
     const handleToggleAll = () => {
-        const optionsToSet = flatOptions.length === selectedDraft.length ? [] : flatOptions;
+        const optionsToSet = allSelectableSelected ? [] : selectableOptions;
 
         onSelectAllClick(optionsToSet);
         setSelectedDraft(optionsToSet);
     };
 
-    const selectedKeys = useMemo(() => selectedDraft.map(({ key }) => key), [selectedDraft]);
-
     const handleChange: Required<BaseSelectProps>['onChange'] = ({ initiator, ...restArgs }) => {
         if (!initiator) {
+            const selectedMultiple = (restArgs.selectedMultiple ?? []).filter(isSelectable);
+
             onChange({
                 initiator: null,
                 ...restArgs,
+                selected: selectedMultiple[0] ?? null,
+                selectedMultiple,
             });
 
+            return;
+        }
+
+        if (!isSelectable(initiator)) {
             return;
         }
 
@@ -187,12 +210,10 @@ export function useSelectWithApply({
             selectedDraft.some(
                 (selectedDraftOption) => selectedDraftOption.key === initiator.key,
             ) ||
-            (initiator.key === SELECT_ALL_KEY &&
-                (selectedDraft.length === flatOptions.length ||
-                    flatOptions.every(({ key }) => selectedKeys.includes(key))));
+            (initiator.key === SELECT_ALL_KEY && allSelectableSelected);
 
         if (initiator.key === SELECT_ALL_KEY) {
-            setSelectedDraft(initiatorSelected ? [] : flatOptions);
+            setSelectedDraft(initiatorSelected ? [] : selectableOptions);
         } else {
             setSelectedDraft(
                 initiatorSelected
@@ -210,7 +231,7 @@ export function useSelectWithApply({
             setSelectedDraft(selectedOptions);
         }
         selectedOptionsRef.current = selectedOptions;
-    }, [selectedOptions]);
+    }, [selectedOptions, setSelectedDraft]);
 
     const memoizedOptions = useMemo(
         () =>
@@ -234,10 +255,8 @@ export function useSelectWithApply({
             showHeaderWithSelectAll,
             headerProps: {
                 ...(optionsListProps as AnyObject)?.headerProps,
-                indeterminate: selectedDraft.length > 0,
-                checked:
-                    selectedDraft.length === flatOptions.length ||
-                    flatOptions.every(({ key }) => selectedKeys.includes(key)),
+                indeterminate: selectedDraft.length > 0 && !allSelectableSelected,
+                checked: allSelectableSelected,
                 onChange: handleToggleAll,
                 checkmarkPosition,
             },

--- a/packages/select/src/presets/useSelectWithApply/options-list-with-apply/Component.tsx
+++ b/packages/select/src/presets/useSelectWithApply/options-list-with-apply/Component.tsx
@@ -47,17 +47,27 @@ export const OptionsListWithApply = forwardRef<HTMLDivElement, OptionsListWithAp
             (option: OptionShape, index: number) => {
                 const optionProps = defaultGetOptionProps(option, index);
 
-                const selected =
-                    option.key === SELECT_ALL_KEY
-                        ? selectedDraft.length === flatOptions.length - 1
-                        : selectedDraft.some(({ key }) => key === option.key);
+                if (option.key === SELECT_ALL_KEY) {
+                    const selectable = flatOptions.filter(
+                        ({ key, disabled }) => key !== SELECT_ALL_KEY && !disabled,
+                    );
+
+                    return {
+                        ...optionProps,
+                        selected:
+                            selectable.length > 0 &&
+                            selectable.every(({ key }) =>
+                                selectedDraft.some((draft) => draft.key === key),
+                            ),
+                    };
+                }
 
                 return {
                     ...optionProps,
-                    selected,
+                    selected: selectedDraft.some(({ key }) => key === option.key),
                 };
             },
-            [defaultGetOptionProps, flatOptions.length, selectedDraft],
+            [defaultGetOptionProps, flatOptions, selectedDraft],
         );
 
         const handleApply = useCallback(() => {


### PR DESCRIPTION
Выбрать все в SelectDesktop теперь выбирает только те значения, которые не имеют disabled: true 

# Чек лист

- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [ ] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [ ] К реквесту добавлен changeset

Если есть визуальные изменения

- [ ] Прикреплено изображение было/стало
было: 
<img width="881" height="633" alt="Снимок экрана — 2026-08-07 в 16 30 56" src="https://github.com/user-attachments/assets/c73a2e3e-f939-4635-8219-9e65b664ba6e" />
стало:
<img width="1105" height="528" alt="Снимок экрана — 2026-08-07 в 16 32 14" src="https://github.com/user-attachments/assets/0affff7f-07bd-4a18-83a6-a6df8a351cfa" />

Обратите внимание на то что было при 'выбрать все' в список onChange попадали disabled значения, приходилось дополнительно фильтровать на ui + визуально с галочкой были disabled значения 