### PR TITLE
feat(side-panel): add ref to header

### DIFF
--- a/.changeset/bright-birds-ref.md
+++ b/.changeset/bright-birds-ref.md
@@ -1,5 +1,5 @@
 ---
-'@alfalab/core-components-side-panel': patch
+'@alfalab/core-components-side-panel': minor
 ---
 
 - Добавлен проброс `ref` на корневой элемент `SidePanel.Header`

--- a/.changeset/bright-birds-ref.md
+++ b/.changeset/bright-birds-ref.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-side-panel': patch
+---
+
+- Добавлен проброс `ref` на корневой элемент `SidePanel.Header`

--- a/packages/side-panel/src/Component.test.tsx
+++ b/packages/side-panel/src/Component.test.tsx
@@ -42,56 +42,46 @@ const SidePanelMobileWrapper = (props: Partial<SidePanelMobileProps>) => {
     );
 };
 
-const COMPONENT_NAME_TO_WRAPPER = {
-    SidePanelDesktop: SidePanelDesktopWrapper,
-    SidePanelMobile: SidePanelMobileWrapper,
-} as const;
+const SIDE_PANEL_TEST_CASES = [
+    ['SidePanelDesktop', SidePanelDesktopWrapper, SidePanelDesktop],
+    ['SidePanelMobile', SidePanelMobileWrapper, SidePanelMobile],
+] as const;
 
-const COMPONENT_NAME_TO_SIDE_PANEL = {
-    SidePanelDesktop,
-    SidePanelMobile,
-} as const;
+describe.each(SIDE_PANEL_TEST_CASES)('%s', (_componentName, Component, SidePanel) => {
+    it('should forward ref to header root element', () => {
+        const headerRef = React.createRef<HTMLDivElement>();
 
-(['SidePanelDesktop', 'SidePanelMobile'] as const).forEach((componentName) => {
-    const Component = COMPONENT_NAME_TO_WRAPPER[componentName];
-    const SidePanel = COMPONENT_NAME_TO_SIDE_PANEL[componentName];
+        render(
+            <SidePanel open={true}>
+                <SidePanel.Header ref={headerRef} dataTestId='header-ref' />
+            </SidePanel>,
+        );
 
-    describe(componentName, () => {
-        it('should forward ref to header root element', () => {
-            const headerRef = React.createRef<HTMLDivElement>();
+        expect(headerRef.current).toBe(screen.getByTestId('header-ref'));
+    });
 
-            render(
-                <SidePanel open={true}>
-                    <SidePanel.Header ref={headerRef} dataTestId='header-ref' />
-                </SidePanel>,
-            );
-
-            expect(headerRef.current).toBe(screen.getByTestId('header-ref'));
+    describe('snapshots tests', () => {
+        it('should match snapshot', () => {
+            render(<Component />);
+            expect(screen.getByRole('dialog')).toMatchSnapshot();
         });
+    });
 
-        describe('snapshots tests', () => {
-            it('should match snapshot', () => {
-                render(<Component />);
-                expect(screen.getByRole('dialog')).toMatchSnapshot();
-            });
-        });
+    describe('attributes test', () => {
+        it('should have data-test-id', () => {
+            const dti = 'modal-dti';
+            const { getByTestId } = render(<Component dataTestId={dti} />);
 
-        describe('attributes test', () => {
-            it('should have data-test-id', () => {
-                const dti = 'modal-dti';
-                const { getByTestId } = render(<Component dataTestId={dti} />);
+            const testIds = getSidePanelTestIds(dti);
 
-                const testIds = getSidePanelTestIds(dti);
-
-                expect(getByTestId(testIds.modal)).toBeInTheDocument();
-                expect(getByTestId(testIds.header)).toBeInTheDocument();
-                expect(getByTestId(testIds.title)).toBeInTheDocument();
-                expect(getByTestId(testIds.content)).toBeInTheDocument();
-                expect(getByTestId(testIds.footer)).toBeInTheDocument();
-                expect(getByTestId(testIds.controls)).toBeInTheDocument();
-                expect(getByTestId(testIds.closer)).toBeInTheDocument();
-                expect(getByTestId(testIds.backButton)).toBeInTheDocument();
-            });
+            expect(getByTestId(testIds.modal)).toBeInTheDocument();
+            expect(getByTestId(testIds.header)).toBeInTheDocument();
+            expect(getByTestId(testIds.title)).toBeInTheDocument();
+            expect(getByTestId(testIds.content)).toBeInTheDocument();
+            expect(getByTestId(testIds.footer)).toBeInTheDocument();
+            expect(getByTestId(testIds.controls)).toBeInTheDocument();
+            expect(getByTestId(testIds.closer)).toBeInTheDocument();
+            expect(getByTestId(testIds.backButton)).toBeInTheDocument();
         });
     });
 });

--- a/packages/side-panel/src/Component.test.tsx
+++ b/packages/side-panel/src/Component.test.tsx
@@ -47,10 +47,28 @@ const COMPONENT_NAME_TO_WRAPPER = {
     SidePanelMobile: SidePanelMobileWrapper,
 } as const;
 
+const COMPONENT_NAME_TO_SIDE_PANEL = {
+    SidePanelDesktop,
+    SidePanelMobile,
+} as const;
+
 (['SidePanelDesktop', 'SidePanelMobile'] as const).forEach((componentName) => {
     const Component = COMPONENT_NAME_TO_WRAPPER[componentName];
+    const SidePanel = COMPONENT_NAME_TO_SIDE_PANEL[componentName];
 
     describe(componentName, () => {
+        it('should forward ref to header root element', () => {
+            const headerRef = React.createRef<HTMLDivElement>();
+
+            render(
+                <SidePanel open={true}>
+                    <SidePanel.Header ref={headerRef} dataTestId='header-ref' />
+                </SidePanel>,
+            );
+
+            expect(headerRef.current).toBe(screen.getByTestId('header-ref'));
+        });
+
         describe('snapshots tests', () => {
             it('should match snapshot', () => {
                 render(<Component />);

--- a/packages/side-panel/src/components/header/Component.tsx
+++ b/packages/side-panel/src/components/header/Component.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useContext, useEffect } from 'react';
+import React, { forwardRef, useContext, useEffect } from 'react';
 import cn from 'classnames';
 
 import {
@@ -17,49 +17,49 @@ import mobileStyles from './mobile.module.css';
 
 export type HeaderProps = Omit<NavigationBarPrivateProps, 'size' | 'view' | 'parentRef'>;
 
-export const Header: FC<HeaderProps> = ({
-    className,
-    children,
-    contentClassName,
-    title,
-    sticky,
-    hasCloser = true,
-    ...restProps
-}) => {
-    const { setHasHeader, headerHighlighted, onClose, componentRef } = useContext(ModalContext);
-    const { size = 500, view = 'desktop', dataTestId } = useContext(ResponsiveContext) || {};
+export const Header = forwardRef<HTMLDivElement, HeaderProps>(
+    (
+        { className, children, contentClassName, title, sticky, hasCloser = true, ...restProps },
+        ref,
+    ) => {
+        const { setHasHeader, headerHighlighted, onClose, componentRef } = useContext(ModalContext);
+        const { size = 500, view = 'desktop', dataTestId } = useContext(ResponsiveContext) || {};
 
-    useEffect(() => {
-        setHasHeader(true);
-    }, [setHasHeader]);
+        useEffect(() => {
+            setHasHeader(true);
+        }, [setHasHeader]);
 
-    const hasContent = Boolean(title || children);
+        const hasContent = Boolean(title || children);
 
-    return (
-        <NavigationBarPrivate
-            dataTestId={getDataTestId(dataTestId, 'header')}
-            {...restProps}
-            scrollableParentRef={componentRef}
-            view={view}
-            sticky={sticky}
-            title={title}
-            hasCloser={hasCloser}
-            onClose={onClose}
-            className={cn(styles.header, className, {
-                [styles.highlighted]: hasContent && sticky && headerHighlighted,
-                [styles.sticky]: sticky,
-                [styles.hasContent]: hasContent,
-                [desktopStyles.sticky]: view === 'desktop' && sticky,
-                [desktopStyles[SIZE_TO_CLASSNAME_MAP[size]]]: view === 'desktop',
-                [mobileStyles.sticky]: view === 'mobile' && sticky,
-                [mobileStyles.header]: view === 'mobile',
-            })}
-            contentClassName={cn(contentClassName, {
-                [desktopStyles.content]: view === 'desktop',
-                [mobileStyles.content]: view === 'mobile',
-            })}
-        >
-            {children}
-        </NavigationBarPrivate>
-    );
-};
+        return (
+            <NavigationBarPrivate
+                ref={ref}
+                dataTestId={getDataTestId(dataTestId, 'header')}
+                {...restProps}
+                scrollableParentRef={componentRef}
+                view={view}
+                sticky={sticky}
+                title={title}
+                hasCloser={hasCloser}
+                onClose={onClose}
+                className={cn(styles.header, className, {
+                    [styles.highlighted]: hasContent && sticky && headerHighlighted,
+                    [styles.sticky]: sticky,
+                    [styles.hasContent]: hasContent,
+                    [desktopStyles.sticky]: view === 'desktop' && sticky,
+                    [desktopStyles[SIZE_TO_CLASSNAME_MAP[size]]]: view === 'desktop',
+                    [mobileStyles.sticky]: view === 'mobile' && sticky,
+                    [mobileStyles.header]: view === 'mobile',
+                })}
+                contentClassName={cn(contentClassName, {
+                    [desktopStyles.content]: view === 'desktop',
+                    [mobileStyles.content]: view === 'mobile',
+                })}
+            >
+                {children}
+            </NavigationBarPrivate>
+        );
+    },
+);
+
+Header.displayName = 'Header';

--- a/packages/side-panel/src/desktop/Component.desktop.tsx
+++ b/packages/side-panel/src/desktop/Component.desktop.tsx
@@ -1,4 +1,12 @@
-import React, { cloneElement, forwardRef, isValidElement, useContext, useRef } from 'react';
+import React, {
+    cloneElement,
+    forwardRef,
+    type ForwardRefExoticComponent,
+    isValidElement,
+    type RefAttributes,
+    useContext,
+    useRef,
+} from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 
@@ -104,7 +112,9 @@ const SidePanelDesktopComponent = forwardRef<HTMLDivElement, SidePanelDesktopPro
     },
 );
 
-const HeaderDesktop = Header as React.FC<Omit<HeaderProps, 'titleSize' | 'subtitle'>>;
+const HeaderDesktop = Header as ForwardRefExoticComponent<
+    Omit<HeaderProps, 'titleSize' | 'subtitle'> & RefAttributes<HTMLDivElement>
+>;
 const ControlsDesktop = Controls as React.FC<Omit<ControlsProps, 'mobileLayout'>>;
 
 const SidePanelDesktop = Object.assign(SidePanelDesktopComponent, {


### PR DESCRIPTION
## Суть доработки

Добавлена поддержка `ref` для `SidePanel.Header`. Ref пробрасывается до корневого DOM-элемента хедера во всех вариантах SidePanel: desktop, mobile и responsive.

Доработка позволяет потребителям получать геометрию хедера без поиска элемента в DOM. Добавлены unit-тесты на desktop- и mobile-версии.



Визуальных изменений нет.