### PR TITLE
Fix/scrollbar private recalculate

### DIFF
--- a/.changeset/calm-lists-grow.md
+++ b/.changeset/calm-lists-grow.md
@@ -1,0 +1,13 @@
+---
+'@alfalab/core-components-select': patch
+'@alfalab/core-components-scrollbar': patch
+'@alfalab/core-components': patch
+---
+
+##### Select
+
+- Исправлена высота `OptionsList` при изменении размера содержимого
+
+##### Scrollbar
+
+- Исправлено обновление overflow при изменении размера содержимого

--- a/.changeset/lucky-doors-listen.md
+++ b/.changeset/lucky-doors-listen.md
@@ -1,0 +1,8 @@
+---
+'@alfalab/core-components-scrollbar-private': patch
+'@alfalab/core-components': patch
+---
+
+##### ScrollbarPrivate
+
+- Исправлена обрезка содержимого: SimpleBar пересчитывается при изменении размера детей узла с контентом

--- a/packages/scrollbar-private/src/component.test.tsx
+++ b/packages/scrollbar-private/src/component.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import SimpleBarCore from 'simplebar-core';
+
+import { ScrollbarPrivate } from './component';
+
+type Observer = { callback: ResizeObserverCallback; targets: Element[] };
+
+const observers: Observer[] = [];
+
+beforeAll(() => {
+    window.ResizeObserver = class MockResizeObserver {
+        private readonly entry: Observer;
+
+        constructor(callback: ResizeObserverCallback) {
+            this.entry = { callback, targets: [] };
+            observers.push(this.entry);
+        }
+
+        observe(target: Element) {
+            this.entry.targets.push(target);
+        }
+
+        unobserve() {}
+
+        disconnect() {
+            this.entry.targets.length = 0;
+        }
+    } as unknown as typeof ResizeObserver;
+});
+
+beforeEach(() => {
+    observers.length = 0;
+});
+
+const flushFrame = () =>
+    act(async () => {
+        await new Promise((resolve) => {
+            requestAnimationFrame(resolve);
+        });
+    });
+
+describe('ScrollbarPrivate', () => {
+    it('should render children', () => {
+        const { getByTestId } = render(
+            <ScrollbarPrivate style={{ maxHeight: 100 }}>
+                <div data-test-id='content-child'>контент</div>
+            </ScrollbarPrivate>,
+        );
+
+        expect(getByTestId('content-child')).toBeInTheDocument();
+    });
+
+    it('should unmount without errors', () => {
+        const { unmount } = render(
+            <ScrollbarPrivate style={{ maxHeight: 100 }}>
+                <div />
+            </ScrollbarPrivate>,
+        );
+
+        expect(unmount).not.toThrow();
+    });
+
+    /*
+     * Встроенный в SimpleBar ResizeObserver следит только за корнем и узлом с контентом,
+     * чей бокс ограничен высотой корня. Поэтому рост содержимого он не замечает.
+     */
+    it('should observe children of the content node', () => {
+        const { getByTestId } = render(
+            <ScrollbarPrivate style={{ maxHeight: 100 }}>
+                <div data-test-id='content-child' style={{ height: 50 }} />
+            </ScrollbarPrivate>,
+        );
+
+        const child = getByTestId('content-child');
+
+        expect(observers.some(({ targets }) => targets.includes(child))).toBe(true);
+    });
+
+    it('should recalculate when content child size changes', async () => {
+        const recalculateSpy = jest.spyOn(SimpleBarCore.prototype, 'recalculate');
+
+        const { getByTestId } = render(
+            <ScrollbarPrivate style={{ maxHeight: 100 }}>
+                <div data-test-id='content-child' style={{ height: 50 }} />
+            </ScrollbarPrivate>,
+        );
+
+        const child = getByTestId('content-child');
+        const childObservers = observers.filter(({ targets }) => targets.includes(child));
+
+        expect(childObservers).not.toHaveLength(0);
+
+        recalculateSpy.mockClear();
+
+        act(() => {
+            childObservers.forEach(({ callback }) => callback([], {} as ResizeObserver));
+        });
+
+        await flushFrame();
+
+        expect(recalculateSpy).toHaveBeenCalled();
+
+        recalculateSpy.mockRestore();
+    });
+
+    it('should not observe anything in native mode', () => {
+        render(
+            <ScrollbarPrivate native={true} style={{ maxHeight: 100 }}>
+                <div />
+            </ScrollbarPrivate>,
+        );
+
+        expect(observers).toHaveLength(0);
+    });
+});

--- a/packages/scrollbar-private/src/component.tsx
+++ b/packages/scrollbar-private/src/component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Fragment } from 'react';
+import React, { forwardRef, Fragment, useEffect, useRef } from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 import SimpleBar, { type Props as SimpleBarProps } from 'simplebar-react';
@@ -51,6 +51,56 @@ export const ScrollbarPrivate = forwardRef<ScrollbarPrivateRef, ScrollbarPrivate
         },
         ref,
     ) => {
+        const instanceRef = useRef<ScrollbarPrivateRef>(null);
+        const contentNodeRef = useRef<HTMLElement>(null);
+
+        useEffect(() => {
+            const contentNode = contentNodeRef.current;
+            const instance = instanceRef.current;
+            const win = contentNode?.ownerDocument.defaultView;
+
+            if (!contentNode || !instance || !win?.ResizeObserver) {
+                return undefined;
+            }
+
+            let frameId = 0;
+
+            const scheduleRecalculate = () => {
+                win.cancelAnimationFrame(frameId);
+                frameId = win.requestAnimationFrame(() => instance.recalculate());
+            };
+
+            /*
+             * Высота узла с контентом ограничена высотой корня SimpleBar, а та задаётся
+             * плейсхолдером по итогам предыдущего замера. Поэтому при росте содержимого
+             * бокс самого узла не меняется, и встроенный в SimpleBar ResizeObserver не
+             * срабатывает. Разрываем цикл, наблюдая за потомками узла.
+             */
+            const resizeObserver = new win.ResizeObserver(scheduleRecalculate);
+
+            const observeChildren = () => {
+                resizeObserver.disconnect();
+                Array.from(contentNode.children).forEach((child) => {
+                    resizeObserver.observe(child);
+                });
+            };
+
+            observeChildren();
+
+            const mutationObserver = new win.MutationObserver(() => {
+                observeChildren();
+                scheduleRecalculate();
+            });
+
+            mutationObserver.observe(contentNode, { childList: true });
+
+            return () => {
+                win.cancelAnimationFrame(frameId);
+                resizeObserver.disconnect();
+                mutationObserver.disconnect();
+            };
+        }, []);
+
         const render = ({
             scrollableNodeProps,
             contentNodeProps,
@@ -76,6 +126,7 @@ export const ScrollbarPrivate = forwardRef<ScrollbarPrivateRef, ScrollbarPrivate
                     ref={mergeRefs([
                         contentNodeProps?.ref ?? null,
                         contentNodePropsFromProps?.ref ?? null,
+                        contentNodeRef,
                     ])}
                     className={cn(
                         contentNodeProps?.className,
@@ -99,7 +150,7 @@ export const ScrollbarPrivate = forwardRef<ScrollbarPrivateRef, ScrollbarPrivate
         ) : (
             <SimpleBar
                 {...restProps}
-                ref={ref}
+                ref={mergeRefs([ref, instanceRef])}
                 style={style}
                 className={cn(styles.component, colorStyles[colors].component, className)}
                 tabIndex={tabIndex}

--- a/packages/scrollbar/src/Component.test.tsx
+++ b/packages/scrollbar/src/Component.test.tsx
@@ -1,10 +1,41 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 
 import { Scrollbar, ScrollbarProps } from './index';
+import SimpleBar from './simplebar/simplebar';
 
 const scrollableDataTestId = 'scrollable-node';
 const scrollableNodeProps = { 'data-test-id': scrollableDataTestId };
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+jest.mock('@juggle/resize-observer', () => ({
+    ResizeObserver: class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+            resizeObserverCallbacks.push(callback);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+    },
+}));
+
+beforeAll(() => {
+    global.ResizeObserver = class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+            resizeObserverCallbacks.push(callback);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
 
 const renderScrollbar = (props?: ScrollbarProps) => (
     <Scrollbar
@@ -51,6 +82,34 @@ describe('Scrollbar', () => {
             const { unmount } = render(renderScrollbar());
 
             expect(unmount).not.toThrow();
+        });
+    });
+
+    describe('Recalculate tests', () => {
+        it('should recalculate when content child size changes', () => {
+            const recalculateSpy = jest.spyOn(SimpleBar.prototype, 'recalculate');
+
+            jest.useFakeTimers();
+
+            render(
+                <Scrollbar style={{ maxHeight: 100 }} scrollableNodeProps={scrollableNodeProps}>
+                    <div data-test-id='content-child' style={{ height: 50 }} />
+                </Scrollbar>,
+            );
+
+            recalculateSpy.mockClear();
+
+            act(() => {
+                resizeObserverCallbacks.forEach((callback) => {
+                    callback([], {} as ResizeObserver);
+                });
+                jest.advanceTimersByTime(100);
+            });
+
+            expect(recalculateSpy).toHaveBeenCalled();
+
+            recalculateSpy.mockRestore();
+            jest.useRealTimers();
         });
     });
 });

--- a/packages/scrollbar/src/Component.test.tsx
+++ b/packages/scrollbar/src/Component.test.tsx
@@ -23,20 +23,6 @@ jest.mock('@juggle/resize-observer', () => ({
     },
 }));
 
-beforeAll(() => {
-    global.ResizeObserver = class MockResizeObserver {
-        constructor(callback: ResizeObserverCallback) {
-            resizeObserverCallbacks.push(callback);
-        }
-
-        observe() {}
-
-        unobserve() {}
-
-        disconnect() {}
-    } as typeof ResizeObserver;
-});
-
 const renderScrollbar = (props?: ScrollbarProps) => (
     <Scrollbar
         {...props}

--- a/packages/scrollbar/src/Component.tsx
+++ b/packages/scrollbar/src/Component.tsx
@@ -1,7 +1,6 @@
 import React, { type HTMLAttributes, useEffect, useRef, useState } from 'react';
 import mergeRefs from 'react-merge-refs';
 import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
-import canUseDOM from 'can-use-dom';
 import cn from 'classnames';
 // eslint-disable-next-line no-restricted-imports
 import throttle from 'lodash.throttle';
@@ -212,13 +211,11 @@ export const Scrollbar = React.forwardRef<HTMLDivElement, ScrollbarProps>(
             const contentNode = contentNodeRef.current;
             const instance = instanceRef.current;
 
-            if (!canUseDOM || !contentNode || !instance) {
+            if (!contentNode || !instance) {
                 return undefined;
             }
 
-            const Observer =
-                typeof ResizeObserver === 'undefined' ? ResizeObserverPolyfill : ResizeObserver;
-            const resizeObserver = new Observer(() => {
+            const resizeObserver = new ResizeObserverPolyfill(() => {
                 instance.recalculate();
             });
 

--- a/packages/scrollbar/src/Component.tsx
+++ b/packages/scrollbar/src/Component.tsx
@@ -1,5 +1,7 @@
 import React, { type HTMLAttributes, useEffect, useRef, useState } from 'react';
 import mergeRefs from 'react-merge-refs';
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
+import canUseDOM from 'can-use-dom';
 import cn from 'classnames';
 // eslint-disable-next-line no-restricted-imports
 import throttle from 'lodash.throttle';
@@ -166,12 +168,13 @@ export const Scrollbar = React.forwardRef<HTMLDivElement, ScrollbarProps>(
         const scrollableNodeRef = useRef<HTMLDivElement>(null);
         const contentNodeRef = useRef<HTMLDivElement>(null);
         const maskNodeRef = useRef<HTMLDivElement>(null);
+        const instanceRef = useRef<SimpleBar | null>(null);
         const [width, setWidth] = useState<number>();
 
         const colorStyles = colorStylesMap[colors];
 
         useEffect(() => {
-            let instance: SimpleBar | null;
+            let instance: SimpleBar | null = null;
 
             if (elRef.current) {
                 instance = new SimpleBar(elRef.current, {
@@ -185,6 +188,7 @@ export const Scrollbar = React.forwardRef<HTMLDivElement, ScrollbarProps>(
                     scrollableNode: scrollableNodeRef.current,
                     contentNode: contentNodeRef.current,
                 });
+                instanceRef.current = instance;
 
                 if (onContentScroll) {
                     instance.getScrollElement().addEventListener('scroll', onContentScroll);
@@ -198,9 +202,47 @@ export const Scrollbar = React.forwardRef<HTMLDivElement, ScrollbarProps>(
                     }
                     instance.unMount();
                     instance = null;
+                    instanceRef.current = null;
                 }
             };
             // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
+
+        useEffect(() => {
+            const contentNode = contentNodeRef.current;
+            const instance = instanceRef.current;
+
+            if (!canUseDOM || !contentNode || !instance) {
+                return undefined;
+            }
+
+            const Observer =
+                typeof ResizeObserver === 'undefined' ? ResizeObserverPolyfill : ResizeObserver;
+            const resizeObserver = new Observer(() => {
+                instance.recalculate();
+            });
+
+            const observeTargets = () => {
+                resizeObserver.disconnect();
+                resizeObserver.observe(contentNode);
+                Array.from(contentNode.children).forEach((child) => {
+                    resizeObserver.observe(child);
+                });
+            };
+
+            observeTargets();
+
+            const mutationObserver = new MutationObserver(() => {
+                observeTargets();
+                instance.recalculate();
+            });
+
+            mutationObserver.observe(contentNode, { childList: true });
+
+            return () => {
+                resizeObserver.disconnect();
+                mutationObserver.disconnect();
+            };
         }, []);
 
         useEffect(() => {

--- a/packages/scrollbar/src/can-use-dom.d.ts
+++ b/packages/scrollbar/src/can-use-dom.d.ts
@@ -1,0 +1,4 @@
+declare module 'can-use-dom' {
+    const canUseDOM: boolean;
+    export default canUseDOM;
+}

--- a/packages/scrollbar/src/can-use-dom.d.ts
+++ b/packages/scrollbar/src/can-use-dom.d.ts
@@ -1,4 +1,0 @@
-declare module 'can-use-dom' {
-    const canUseDOM: boolean;
-    export default canUseDOM;
-}

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -1,5 +1,12 @@
 import React, { ForwardRefRenderFunction } from 'react';
-import { fireEvent, render, screen, waitFor, queryByText } from '@testing-library/react';
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    queryByText,
+    act as rtlAct,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import * as popoverModule from '@alfalab/core-components-popover';
@@ -11,6 +18,7 @@ import {
     FieldProps as BaseFieldProps,
     OptionsListProps,
     OptionProps,
+    OptgroupProps,
     useSelectWithApply,
     Arrow,
     SelectProps,
@@ -20,6 +28,36 @@ import { SelectMobile, SelectModalMobile } from './mobile';
 import { BaseOption } from './components';
 import { getSelectTestIds } from './utils';
 import { Environment } from 'downshift';
+
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+jest.mock('@juggle/resize-observer', () => ({
+    ResizeObserver: class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+            resizeObserverCallbacks.push(callback);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+    },
+}));
+
+beforeAll(() => {
+    global.ResizeObserver = class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+            resizeObserverCallbacks.push(callback);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
 
 function SelectWithApplyComponent({ testId }: { testId: string }) {
     const selectProps = useSelectWithApply({
@@ -1131,6 +1169,90 @@ describe('Select', () => {
             await waitFor(() => {
                 expect(screen.getByRole('listbox')).toBeInTheDocument();
             });
+        });
+    });
+
+    describe('OptionsList height', () => {
+        const COLLAPSED_GROUP_HEIGHT = 48;
+        const EXPANDED_GROUP_HEIGHT = 144;
+        const OPTION_HEIGHT = 48;
+
+        const groupedOptions = [
+            {
+                label: 'Группа 1',
+                options: [
+                    { key: 'g1', content: 'Рублёвый счёт' },
+                    { key: 'g2', content: 'Ипотечный счёт' },
+                ],
+            },
+            { key: '3', content: 'Сберегательный счёт' },
+        ];
+
+        const CollapsibleOptgroup = ({ children, label }: OptgroupProps) => {
+            const [expanded, setExpanded] = React.useState(false);
+
+            return (
+                <div
+                    data-test-id='collapsible-optgroup'
+                    data-client-height={expanded ? EXPANDED_GROUP_HEIGHT : COLLAPSED_GROUP_HEIGHT}
+                >
+                    <button
+                        type='button'
+                        data-test-id='optgroup-toggle'
+                        onClick={() => setExpanded((value) => !value)}
+                    >
+                        {label}
+                    </button>
+                    <div style={{ display: expanded ? 'block' : 'none' }}>{children}</div>
+                </div>
+            );
+        };
+
+        let clientHeightSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            resizeObserverCallbacks.length = 0;
+
+            clientHeightSpy = jest
+                .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+                .mockImplementation(function getClientHeight(this: HTMLElement) {
+                    const height = this.getAttribute('data-client-height');
+
+                    return height ? Number(height) : OPTION_HEIGHT;
+                });
+        });
+
+        afterEach(() => {
+            clientHeightSpy.mockRestore();
+        });
+
+        it('should recalculate list height when custom Optgroup expands', () => {
+            const { getByTestId } = render(
+                <Select
+                    {...baseProps}
+                    options={groupedOptions}
+                    Optgroup={CollapsibleOptgroup}
+                    visibleOptions={8}
+                    defaultOpen={true}
+                    optionsListProps={{ nativeScrollbar: true }}
+                    dataTestId='select'
+                />,
+            );
+
+            const optionsList = getByTestId('select-options-list');
+            const scrollable = optionsList.querySelector('.scrollable') as HTMLElement;
+
+            expect(scrollable.style.maxHeight).toBe(`${COLLAPSED_GROUP_HEIGHT + OPTION_HEIGHT}px`);
+
+            fireEvent.click(getByTestId('optgroup-toggle'));
+
+            rtlAct(() => {
+                resizeObserverCallbacks.forEach((callback) => {
+                    callback([], {} as ResizeObserver);
+                });
+            });
+
+            expect(scrollable.style.maxHeight).toBe(`${EXPANDED_GROUP_HEIGHT + OPTION_HEIGHT}px`);
         });
     });
 

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -31,22 +31,8 @@ import { Environment } from 'downshift';
 
 const resizeObserverCallbacks: ResizeObserverCallback[] = [];
 
-jest.mock('@juggle/resize-observer', () => ({
-    ResizeObserver: class MockResizeObserver {
-        constructor(callback: ResizeObserverCallback) {
-            resizeObserverCallbacks.push(callback);
-        }
-
-        observe() {}
-
-        unobserve() {}
-
-        disconnect() {}
-    },
-}));
-
 beforeAll(() => {
-    global.ResizeObserver = class MockResizeObserver {
+    window.ResizeObserver = class MockResizeObserver {
         constructor(callback: ResizeObserverCallback) {
             resizeObserverCallbacks.push(callback);
         }
@@ -56,7 +42,7 @@ beforeAll(() => {
         unobserve() {}
 
         disconnect() {}
-    } as typeof ResizeObserver;
+    } as unknown as typeof ResizeObserver;
 });
 
 function SelectWithApplyComponent({ testId }: { testId: string }) {
@@ -1226,7 +1212,7 @@ describe('Select', () => {
             clientHeightSpy.mockRestore();
         });
 
-        it('should recalculate list height when custom Optgroup expands', () => {
+        it('should recalculate list height when custom Optgroup expands', async () => {
             const { getByTestId } = render(
                 <Select
                     {...baseProps}
@@ -1246,9 +1232,13 @@ describe('Select', () => {
 
             fireEvent.click(getByTestId('optgroup-toggle'));
 
-            rtlAct(() => {
+            await rtlAct(async () => {
                 resizeObserverCallbacks.forEach((callback) => {
                     callback([], {} as ResizeObserver);
+                });
+
+                await new Promise((resolve) => {
+                    requestAnimationFrame(resolve);
                 });
             });
 

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -7,13 +7,11 @@ import {
     useRef,
     useState,
 } from 'react';
-import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 
 import {
     fnUtils,
     getDataTestId,
     getElementWindow,
-    isClient,
     useIsMounted,
 } from '@alfalab/core-components-shared';
 import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
@@ -212,49 +210,49 @@ function measureVisibleOptionsHeight({
 
     const win = getElementWindow(list);
 
-    // jsdom logs (and does not throw) on getComputedStyle with pseudo-elements
-    if (!/jsdom/i.test(win.navigator.userAgent)) {
-        try {
-            height += ['::before', '::after']
-                .map((pseudo) => parseFloat(win.getComputedStyle(list, pseudo).paddingTop) || 0)
-                .reduce((a, b) => a + b);
-        } catch {
-            // Some browsers throw on getComputedStyle with pseudo-elements
-        }
-    }
+    height += ['::before', '::after']
+        .map((pseudo) => parseFloat(win.getComputedStyle(list, pseudo).paddingTop) || 0)
+        .reduce((a, b) => a + b);
 
     return height;
 }
 
-function observeElementSize(element: HTMLElement, onResize: () => void) {
-    if (!isClient()) {
-        return fnUtils.noop;
-    }
+function observeOptionsSize(list: HTMLElement, onResize: () => void) {
+    const win = getElementWindow(list);
+    let frameId = 0;
 
-    const Observer =
-        typeof ResizeObserver === 'undefined' ? ResizeObserverPolyfill : ResizeObserver;
-    const resizeObserver = new Observer(onResize);
+    /*
+     * Пересчитываем в следующем кадре: замер прямо в колбэке ResizeObserver
+     * вклинивается в позиционирование поповера, и список остаётся скрытым.
+     */
+    const scheduleResize = () => {
+        win.cancelAnimationFrame(frameId);
+        frameId = win.requestAnimationFrame(onResize);
+    };
 
-    const observeTargets = () => {
+    const resizeObserver = win.ResizeObserver ? new win.ResizeObserver(scheduleResize) : null;
+
+    const observeOptions = () => {
+        if (!resizeObserver) return;
+
         resizeObserver.disconnect();
-        resizeObserver.observe(element);
-        Array.from(element.children).forEach((child) => {
-            resizeObserver.observe(child);
+        Array.from(list.children).forEach((option) => {
+            resizeObserver.observe(option);
         });
     };
 
-    observeTargets();
-    onResize();
+    observeOptions();
 
-    const mutationObserver = new MutationObserver(() => {
-        observeTargets();
-        onResize();
+    const mutationObserver = new win.MutationObserver(() => {
+        observeOptions();
+        scheduleResize();
     });
 
-    mutationObserver.observe(element, { childList: true });
+    mutationObserver.observe(list, { childList: true });
 
     return () => {
-        resizeObserver.disconnect();
+        win.cancelAnimationFrame(frameId);
+        resizeObserver?.disconnect();
         mutationObserver.disconnect();
     };
 }
@@ -276,18 +274,20 @@ export function useVirtualVisibleOptions({
 
         if (open && list && visibleOptions > 0) {
             const applyHeight = () => {
-                const nextHeight = measureVisibleOptionsHeight({
-                    list,
-                    visibleOptions,
-                    options,
-                    size,
-                    actualOptionsCount,
-                });
-
-                setHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+                setHeight(
+                    measureVisibleOptionsHeight({
+                        list,
+                        visibleOptions,
+                        options,
+                        size,
+                        actualOptionsCount,
+                    }),
+                );
             };
 
-            return observeElementSize(list, applyHeight);
+            applyHeight();
+
+            return observeOptionsSize(list, applyHeight);
         }
 
         return fnUtils.noop;
@@ -313,19 +313,21 @@ export function useVisibleOptions({
 
         if (open && list && visibleOptions > 0) {
             const applyHeight = () => {
-                const nextHeight = measureVisibleOptionsHeight({
-                    list,
-                    visibleOptions,
-                    options,
-                    size,
-                    actualOptionsCount,
-                });
-
-                setHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+                setHeight(
+                    measureVisibleOptionsHeight({
+                        list,
+                        visibleOptions,
+                        options,
+                        size,
+                        actualOptionsCount,
+                    }),
+                );
                 setMeasured(true);
             };
 
-            const disconnect = observeElementSize(list, applyHeight);
+            applyHeight();
+
+            const disconnect = observeOptionsSize(list, applyHeight);
 
             return () => {
                 disconnect();

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -7,11 +7,13 @@ import {
     useRef,
     useState,
 } from 'react';
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 
 import {
     fnUtils,
     getDataTestId,
     getElementWindow,
+    isClient,
     useIsMounted,
 } from '@alfalab/core-components-shared';
 import { useLayoutEffect_SAFE_FOR_SSR } from '@alfalab/hooks';
@@ -161,6 +163,102 @@ type useVisibleOptionsArgs = {
     actualOptionsCount?: boolean;
 };
 
+function measureVisibleOptionsHeight({
+    list,
+    visibleOptions,
+    options,
+    size,
+    actualOptionsCount,
+}: {
+    list: HTMLElement;
+    visibleOptions: number;
+    options?: Array<OptionShape | GroupShape>;
+    size?: Extract<OptionsListProps['size'], number>;
+    actualOptionsCount?: boolean;
+}) {
+    const measureOptionHeight = (element: HTMLElement) =>
+        typeof size === 'number' ? Math.min(element.clientHeight, size) : element.clientHeight;
+
+    const childCount = list.children.length;
+    const optionsNodes = ([] as HTMLElement[]).slice.call(list.children, 0, visibleOptions + 1);
+
+    let height = optionsNodes
+        .slice(0, visibleOptions)
+        .reduce((acc, child) => acc + measureOptionHeight(child), 0);
+
+    if (visibleOptions < childCount) {
+        const lastVisibleOptionHeight = measureOptionHeight(optionsNodes[optionsNodes.length - 1]);
+
+        // Если кол-во опций больше visibleOptions на 1, то показываем все опции, иначе добавляем половинку
+        height += Math.round(
+            childCount - visibleOptions === 1
+                ? lastVisibleOptionHeight
+                : lastVisibleOptionHeight / 2,
+        );
+    } else if (visibleOptions > childCount && actualOptionsCount && typeof size === 'number') {
+        const actualCount = (options ?? []).reduce(
+            (sum, option) => sum + 1 + (isGroup(option) ? option.options.length : 0),
+            0,
+        );
+
+        height =
+            Math.min(actualCount === 0 ? /** empty placeholder */ 1 : actualCount, visibleOptions) *
+            size;
+
+        if (visibleOptions < actualCount) {
+            height += size / 2;
+        }
+    }
+
+    const win = getElementWindow(list);
+
+    // jsdom logs (and does not throw) on getComputedStyle with pseudo-elements
+    if (!/jsdom/i.test(win.navigator.userAgent)) {
+        try {
+            height += ['::before', '::after']
+                .map((pseudo) => parseFloat(win.getComputedStyle(list, pseudo).paddingTop) || 0)
+                .reduce((a, b) => a + b);
+        } catch {
+            // Some browsers throw on getComputedStyle with pseudo-elements
+        }
+    }
+
+    return height;
+}
+
+function observeElementSize(element: HTMLElement, onResize: () => void) {
+    if (!isClient()) {
+        return fnUtils.noop;
+    }
+
+    const Observer =
+        typeof ResizeObserver === 'undefined' ? ResizeObserverPolyfill : ResizeObserver;
+    const resizeObserver = new Observer(onResize);
+
+    const observeTargets = () => {
+        resizeObserver.disconnect();
+        resizeObserver.observe(element);
+        Array.from(element.children).forEach((child) => {
+            resizeObserver.observe(child);
+        });
+    };
+
+    observeTargets();
+    onResize();
+
+    const mutationObserver = new MutationObserver(() => {
+        observeTargets();
+        onResize();
+    });
+
+    mutationObserver.observe(element, { childList: true });
+
+    return () => {
+        resizeObserver.disconnect();
+        mutationObserver.disconnect();
+    };
+}
+
 // copy-paste of original `useVisibleOptions` before https://github.com/core-ds/core-components/pull/1368
 export function useVirtualVisibleOptions({
     visibleOptions,
@@ -174,63 +272,25 @@ export function useVirtualVisibleOptions({
     const [height, setHeight] = useState<number>();
 
     useLayoutEffect_SAFE_FOR_SSR(() => {
-        const measureOptionHeight = (element: HTMLElement) =>
-            typeof size === 'number' ? Math.min(element.clientHeight, size) : element.clientHeight;
-
         const list = listRef.current;
 
         if (open && list && visibleOptions > 0) {
-            const childCount = list.children.length;
-            const optionsNodes = ([] as HTMLElement[]).slice.call(
-                list.children,
-                0,
-                visibleOptions + 1,
-            );
+            const applyHeight = () => {
+                const nextHeight = measureVisibleOptionsHeight({
+                    list,
+                    visibleOptions,
+                    options,
+                    size,
+                    actualOptionsCount,
+                });
 
-            let nextHeight = optionsNodes
-                .slice(0, visibleOptions)
-                .reduce((acc, child) => acc + measureOptionHeight(child), 0);
+                setHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+            };
 
-            if (visibleOptions < childCount) {
-                const lastVisibleOptionHeight = measureOptionHeight(
-                    optionsNodes[optionsNodes.length - 1],
-                );
-
-                // Если кол-во опций больше visibleOptions на 1, то показываем все опции, иначе добавляем половинку
-                nextHeight += Math.round(
-                    childCount - visibleOptions === 1
-                        ? lastVisibleOptionHeight
-                        : lastVisibleOptionHeight / 2,
-                );
-            } else if (
-                visibleOptions > childCount &&
-                actualOptionsCount &&
-                typeof size === 'number'
-            ) {
-                const actualCount = (options ?? []).reduce(
-                    (sum, option) => sum + 1 + (isGroup(option) ? option.options.length : 0),
-                    0,
-                );
-
-                nextHeight =
-                    Math.min(
-                        actualCount === 0 ? /** empty placeholder */ 1 : actualCount,
-                        visibleOptions,
-                    ) * size;
-
-                if (visibleOptions < actualCount) {
-                    nextHeight += size / 2;
-                }
-            }
-
-            const win = getElementWindow(list);
-
-            nextHeight += ['::before', '::after']
-                .map((pseudo) => parseFloat(win.getComputedStyle(list, pseudo).paddingTop) || 0)
-                .reduce((a, b) => a + b);
-
-            setHeight(nextHeight);
+            return observeElementSize(list, applyHeight);
         }
+
+        return fnUtils.noop;
     }, [actualOptionsCount, listRef, open, options, size, visibleOptions, invalidate]);
 
     return height;
@@ -249,66 +309,26 @@ export function useVisibleOptions({
     const [height, setHeight] = useState<number | undefined>();
 
     useLayoutEffect_SAFE_FOR_SSR(() => {
-        const measureOptionHeight = (element: HTMLElement) =>
-            typeof size === 'number' ? Math.min(element.clientHeight, size) : element.clientHeight;
-
         const list = listRef.current;
 
         if (open && list && visibleOptions > 0) {
-            const childCount = list.children.length;
-            const optionsNodes = ([] as HTMLElement[]).slice.call(
-                list.children,
-                0,
-                visibleOptions + 1,
-            );
+            const applyHeight = () => {
+                const nextHeight = measureVisibleOptionsHeight({
+                    list,
+                    visibleOptions,
+                    options,
+                    size,
+                    actualOptionsCount,
+                });
 
-            let measuredHeight = optionsNodes
-                .slice(0, visibleOptions)
-                .reduce((acc, child) => acc + measureOptionHeight(child), 0);
+                setHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+                setMeasured(true);
+            };
 
-            if (visibleOptions < childCount) {
-                const lastVisibleOptionHeight = measureOptionHeight(
-                    optionsNodes[optionsNodes.length - 1],
-                );
-
-                // Если кол-во опций больше visibleOptions на 1, то показываем все опции, иначе добавляем половинку
-                measuredHeight += Math.round(
-                    childCount - visibleOptions === 1
-                        ? lastVisibleOptionHeight
-                        : lastVisibleOptionHeight / 2,
-                );
-            } else if (
-                visibleOptions > childCount &&
-                actualOptionsCount &&
-                typeof size === 'number'
-            ) {
-                const actualCount = (options ?? []).reduce(
-                    (sum, option) => sum + 1 + (isGroup(option) ? option.options.length : 0),
-                    0,
-                );
-
-                measuredHeight =
-                    Math.min(
-                        actualCount === 0 ? /** empty placeholder */ 1 : actualCount,
-                        visibleOptions,
-                    ) * size;
-
-                if (visibleOptions < actualCount) {
-                    measuredHeight += size / 2;
-                }
-            }
-
-            const win = getElementWindow(list);
-
-            measuredHeight += ['::before', '::after']
-                .map((pseudo) => parseFloat(win.getComputedStyle(list, pseudo).paddingTop) || 0)
-                .reduce((a, b) => a + b);
-
-            setHeight(measuredHeight);
-
-            setMeasured(true);
+            const disconnect = observeElementSize(list, applyHeight);
 
             return () => {
+                disconnect();
                 runIfMounted(() => setMeasured(false));
             };
         }


### PR DESCRIPTION
## Проблема

`Select` не пересчитывает высоту при изменении контента. Например, при раскрытии группы опций список остаётся старой высоты, из-за чего контент обрезается и не появляется скролл.

Та же проблема есть в `ScrollbarPrivate` и `Scrollbar`.

## Решение

Добавил отслеживание изменений дочерних элементов через `ResizeObserver` и `MutationObserver`.

При изменении размера или состава элементов пересчитывается высота `Select` и вызывается `recalculate()` у scrollbar.

<img width="977" height="395" alt="Снимок экрана — 2026-08-21 в 11 14 16" src="https://github.com/user-attachments/assets/81f712d6-26fa-4863-a9a0-76c5b0149a35" />
<img width="572" height="168" alt="Снимок экрана — 2026-08-21 в 11 15 40" src="https://github.com/user-attachments/assets/7dbf37ee-ec6a-4632-9b9b-a5fd9c5bc0fc" />