### PR TITLE
fix(select-with-tags): исправить типографику и иконки при size 40

### DIFF
--- a/.changeset/select-with-tags-size-40.md
+++ b/.changeset/select-with-tags-size-40.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-select-with-tags': patch
+---
+
+Исправлена типографика поля ввода и плейсхолдера `SelectWithTags` при `size={40}`

--- a/packages/select-with-tags/src/__image_snapshots__/select-with-tags-desktop-disabled-with-arrow-size-1-disabled-0-snap.png
+++ b/packages/select-with-tags/src/__image_snapshots__/select-with-tags-desktop-disabled-with-arrow-size-1-disabled-0-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd28342794ba0dcfca0ac69fd89506d3711a67549e108ef6de95a06bcf63d477
+size 2095

--- a/packages/select-with-tags/src/__image_snapshots__/select-with-tags-desktop-disabled-with-arrow-size-1-disabled-1-snap.png
+++ b/packages/select-with-tags/src/__image_snapshots__/select-with-tags-desktop-disabled-with-arrow-size-1-disabled-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90955597186aaa01b1cc539f14e83a5bde06f451c19fadf11706613da5801f51
+size 2018

--- a/packages/select-with-tags/src/__image_snapshots__/select-with-tags-mobile-disabled-with-arrow-size-1-disabled-0-snap.png
+++ b/packages/select-with-tags/src/__image_snapshots__/select-with-tags-mobile-disabled-with-arrow-size-1-disabled-0-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69a3fd814829ca0cd8b1bd67b9e0af5d29e6935ed6ce59728fcf6af0defed518
+size 2140

--- a/packages/select-with-tags/src/__image_snapshots__/select-with-tags-mobile-disabled-with-arrow-size-1-disabled-1-snap.png
+++ b/packages/select-with-tags/src/__image_snapshots__/select-with-tags-mobile-disabled-with-arrow-size-1-disabled-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35eb156bdfa98a90f98b272d9c53f945bb73c82d237021abe7bd54af23d4d03c
+size 2156

--- a/packages/select-with-tags/src/__image_snapshots__/select-with-tags-right-addons-desktop-size-40-snap.png
+++ b/packages/select-with-tags/src/__image_snapshots__/select-with-tags-right-addons-desktop-size-40-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1650f955e8b30d3dcaadb117ba80959b5a33846957383bf8c62af07d14eff55
+size 2034

--- a/packages/select-with-tags/src/component.screenshots.test.tsx
+++ b/packages/select-with-tags/src/component.screenshots.test.tsx
@@ -200,7 +200,7 @@ describe(
                 subComponentName: 'SelectWithTagsDesktop',
                 testStory: false,
                 knobs: {
-                    size: [48],
+                    size: [48, 40],
                     disabled: [false, true],
                 },
             }),
@@ -224,7 +224,7 @@ describe(
                 subComponentName: 'SelectWithTagsMobile',
                 testStory: false,
                 knobs: {
-                    size: [48],
+                    size: [48, 40],
                     disabled: [false, true],
                 },
             }),
@@ -240,7 +240,7 @@ describe(
 );
 
 describe('SelectWithTags', () => {
-    [48, 56, 64, 72].forEach((size) => {
+    [40, 48, 56, 64, 72].forEach((size) => {
         test(`right addons desktop size=${size}`, async () => {
             const pageUrl = createStorybookUrl({
                 componentName: 'SelectWithTags',
@@ -276,6 +276,8 @@ describe('SelectWithTags', () => {
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error((error as Error).message);
+
+                throw error;
             } finally {
                 await closeBrowser({ browser, context, page });
             }

--- a/packages/select-with-tags/src/component.test.tsx
+++ b/packages/select-with-tags/src/component.test.tsx
@@ -60,6 +60,14 @@ describe('SelectWithTags', () => {
     });
 
     describe('Attributes tests', () => {
+        it('should set size-40 class on tag list', () => {
+            const { getByRole } = render(
+                <SelectWithTags options={options} value='' onInput={jest.fn()} size={40} />,
+            );
+
+            expect(getByRole('combobox').firstElementChild).toHaveClass('size-40');
+        });
+
         it('should forward ref', () => {
             const ref = jest.fn();
 

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -28,7 +28,7 @@ import { Tag as DefaultTag } from '../tag';
 import styles from './index.module.css';
 
 type TagListOwnProps = {
-    size?: Exclude<FormControlProps['size'], 40>;
+    size?: FormControlProps['size'];
     value?: string;
     handleDeleteTag?: (key: string) => void;
     onInput?: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -51,6 +51,7 @@ const SIZE_TO_CLASSNAME_MAP = {
     m: 'size-56',
     l: 'size-64',
     xl: 'size-72',
+    40: 'size-40',
     48: 'size-48',
     56: 'size-56',
     64: 'size-64',

--- a/packages/select-with-tags/src/components/tag-list/index.module.css
+++ b/packages/select-with-tags/src/components/tag-list/index.module.css
@@ -5,6 +5,13 @@
     padding-left: var($var-name);
 }
 
+.component.size-40 {
+    & .input,
+    & .placeholder {
+        @mixin paragraph_component_secondary;
+    }
+}
+
 .component.size-72 {
     & .contentWrapper {
         padding: 18px var(--gap-2s);

--- a/packages/select-with-tags/src/docs/Component.stories.tsx
+++ b/packages/select-with-tags/src/docs/Component.stories.tsx
@@ -51,6 +51,8 @@ const renderComponent = (component = SelectWithTags) => {
 
     const nativeScrollbar = boolean('nativeScrollbar', true);
     const scrollbar = nativeScrollbar ? true : undefined;
+    const _size = select('size', [40, 48, 56, 64, 72], 72);
+    const size = typeof _size === 'string' ? (Number(_size) as SelectWithTagsProps['size']) : _size;
 
     const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
         setValue(event.target.value);
@@ -71,7 +73,7 @@ const renderComponent = (component = SelectWithTags) => {
                     moveInputToNewLine={boolean('moveInputToNewLine', true)}
                     options={options}
                     block={boolean('block', true)}
-                    size={select('size', [48, 56, 64, 72], 72)}
+                    size={size}
                     disabled={boolean('disabled', false)}
                     error={text('error', '')}
                     hint={text('hint', '')}


### PR DESCRIPTION
## Что исправлено

При `size={40}` внутренний `TagList` не получал соответствующий класс размера. Из-за этого input и placeholder использовали типографику 16/20 вместо ожидаемой 14/18.

Также при открытии story через URL addon-knobs передавал `size=40` строкой. В результате Arrow и Lock выбирали иконки 24×24 вместо 16×16, хотя в интерактивном Storybook отображались корректно.

## Что сделано

- Добавлена обработка `size={40}` в `TagList`.
- Для input и обоих вариантов placeholder применён проектный миксин `paragraph_component_secondary`.
- Размер из Storybook knob нормализован в число.
- Добавлены screenshot-регрессии для enabled, disabled и выбранного тега с аддоном.
- Добавлены проверки размеров Arrow и Lock — 16×16.
- Добавлен patch changeset.

Публичный API не изменяется: исправляется уже заявленная поддержка `size={40}`.

## Было / стало

### Было

<img width="420" height="160" alt="before" src="https://github.com/user-attachments/assets/714e8460-c724-4b69-a782-293363f96dd5" />

### Стало

<img width="420" height="160" alt="after" src="https://github.com/user-attachments/assets/a47815dd-00a6-42d5-868f-582dfd2450ce" />