### PR TITLE
fix(popup-sheet): Учесть safe area на iOS [DS-15213]

### DIFF
--- a/.changeset/poor-banks-join.md
+++ b/.changeset/poor-banks-join.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-popup-sheet': patch
+---
+
+- Добавлен safe-area для `PopupSheet`. Контент и кнопки не перекрываются системной областью свайпа.

--- a/packages/popup-sheet/src/index.module.css
+++ b/packages/popup-sheet/src/index.module.css
@@ -1,8 +1,9 @@
 @import '@alfalab/core-components-vars/src/index.css';
+@import '@alfalab/core-components-vars/src/safe-area.css';
 
 .component.component {
     position: fixed;
-    bottom: var(--gap-0);
+    bottom: var(--sab);
     margin: auto var(--gap-8) var(--gap-8);
     width: calc(100% - 2 * var(--gap-8));
     max-width: 600px;


### PR DESCRIPTION
- Добавлен safe-area для `PopupSheet`. Контент и кнопки не перекрываются системной областью свайпа.

# Чек лист

- [x] Задача сформулирована и описана в JIRA
- [x] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [x] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

- [x] Прикреплено изображение было/стало

<img width="589" height="1280" alt="telegram-cloud-photo-size-2-5242402649204793339-y" src="https://github.com/user-attachments/assets/e3068cf1-8d99-4ec6-ba23-2d1a61d362d9" />
