### PR TITLE
fix(space): handle empty children without css gaps

### DIFF
--- a/.changeset/clean-spaces-rest.md
+++ b/.changeset/clean-spaces-rest.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-space': patch
+---
+
+Исправлены лишние отступы при `useCssGaps={false}`, если дочерние компоненты не рендерят содержимое

--- a/packages/space/src/Component.test.tsx
+++ b/packages/space/src/Component.test.tsx
@@ -31,6 +31,97 @@ describe('Space', () => {
             ).toMatchSnapshot();
         });
 
+        it('should not add trailing margin when the last child renders null', () => {
+            const Empty = () => null;
+
+            const { container } = render(
+                <Space useCssGaps={false} direction='vertical' size={[8, 20]}>
+                    <div>Visible child</div>
+                    <Empty />
+                </Space>,
+            );
+
+            const space = container.firstElementChild;
+            const visibleItem = space?.firstElementChild;
+            const emptyItem = space?.lastElementChild;
+
+            expect(space).toHaveClass('verticalMarginGaps');
+            expect(visibleItem).toHaveStyle('--space-vertical-gap: 20px');
+            expect(visibleItem).not.toHaveStyle('margin-bottom: 20px');
+            expect(emptyItem).toBeEmptyDOMElement();
+        });
+
+        it('should not add gap before the first visible child without css gaps', () => {
+            const Empty = () => null;
+
+            const { container } = render(
+                <Space useCssGaps={false} direction='vertical'>
+                    <Empty />
+                    <div>First visible child</div>
+                    <div>Second visible child</div>
+                </Space>,
+            );
+
+            const space = container.firstElementChild;
+            const emptyItem = space?.firstElementChild;
+            const firstVisibleItem = emptyItem?.nextElementSibling;
+            const secondVisibleItem = firstVisibleItem?.nextElementSibling;
+            const itemsWithGap = space?.querySelectorAll(':scope > :not(:empty) ~ :not(:empty)');
+
+            expect(emptyItem).toBeEmptyDOMElement();
+            expect(itemsWithGap).toHaveLength(1);
+            expect(itemsWithGap?.item(0)).toBe(secondVisibleItem);
+        });
+
+        it('should preserve gaps between visible children separated by empty children without css gaps', () => {
+            const Empty = () => null;
+
+            const { container } = render(
+                <Space useCssGaps={false} direction='vertical'>
+                    <div>First visible child</div>
+                    <Empty />
+                    <div>Second visible child</div>
+                    <Empty />
+                    <div>Third visible child</div>
+                </Space>,
+            );
+
+            const space = container.firstElementChild;
+            const firstVisibleItem = space?.firstElementChild;
+            const firstEmptyItem = firstVisibleItem?.nextElementSibling;
+            const secondVisibleItem = firstEmptyItem?.nextElementSibling;
+            const secondEmptyItem = secondVisibleItem?.nextElementSibling;
+            const thirdVisibleItem = secondEmptyItem?.nextElementSibling;
+            const itemsWithGap = space?.querySelectorAll(':scope > :not(:empty) ~ :not(:empty)');
+
+            expect(firstEmptyItem).toBeEmptyDOMElement();
+            expect(secondEmptyItem).toBeEmptyDOMElement();
+            expect(Array.from(itemsWithGap ?? [])).toEqual([secondVisibleItem, thirdVisibleItem]);
+        });
+
+        it('should preserve gaps between horizontal children without css gaps and wrap', () => {
+            const Empty = () => null;
+
+            const { container } = render(
+                <Space useCssGaps={false} direction='horizontal' size={[8, 20]}>
+                    <div>First child</div>
+                    <div>Second child</div>
+                    <Empty />
+                </Space>,
+            );
+
+            const space = container.firstElementChild;
+            const firstItem = space?.firstElementChild;
+            const secondItem = firstItem?.nextElementSibling;
+            const emptyItem = space?.lastElementChild;
+
+            expect(space).toHaveClass('horizontalMarginGaps');
+            expect(firstItem).toHaveStyle('--space-horizontal-gap: 8px');
+            expect(firstItem).not.toHaveStyle('margin-right: 8px');
+            expect(secondItem).not.toHaveStyle('margin-right: 8px');
+            expect(emptyItem).toBeEmptyDOMElement();
+        });
+
         it('should unmount only 1 child component when it removed', () => {
             const unmountSpy = jest.fn();
 

--- a/packages/space/src/Component.test.tsx
+++ b/packages/space/src/Component.test.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { CardImage } from '@alfalab/core-components-card-image';
 
@@ -44,10 +44,11 @@ describe('Space', () => {
             const space = container.firstElementChild;
             const visibleItem = space?.firstElementChild;
             const emptyItem = space?.lastElementChild;
+            const visibleItems = space?.querySelectorAll('.spaceItem:not(:empty)');
+            const lastVisibleItem = visibleItems?.item((visibleItems?.length ?? 0) - 1);
 
-            expect(space).toHaveClass('verticalMarginGaps');
-            expect(visibleItem).toHaveStyle('--space-vertical-gap: 20px');
-            expect(visibleItem).not.toHaveStyle('margin-bottom: 20px');
+            expect(visibleItem).toHaveStyle('margin-bottom: 20px');
+            expect(lastVisibleItem).toBe(visibleItem);
             expect(emptyItem).toBeEmptyDOMElement();
         });
 
@@ -66,11 +67,10 @@ describe('Space', () => {
             const emptyItem = space?.firstElementChild;
             const firstVisibleItem = emptyItem?.nextElementSibling;
             const secondVisibleItem = firstVisibleItem?.nextElementSibling;
-            const itemsWithGap = space?.querySelectorAll(':scope > :not(:empty) ~ :not(:empty)');
 
             expect(emptyItem).toBeEmptyDOMElement();
-            expect(itemsWithGap).toHaveLength(1);
-            expect(itemsWithGap?.item(0)).toBe(secondVisibleItem);
+            expect(firstVisibleItem).toHaveStyle('margin-bottom: 16px');
+            expect(secondVisibleItem).not.toHaveStyle('margin-bottom: 16px');
         });
 
         it('should preserve gaps between visible children separated by empty children without css gaps', () => {
@@ -92,14 +92,15 @@ describe('Space', () => {
             const secondVisibleItem = firstEmptyItem?.nextElementSibling;
             const secondEmptyItem = secondVisibleItem?.nextElementSibling;
             const thirdVisibleItem = secondEmptyItem?.nextElementSibling;
-            const itemsWithGap = space?.querySelectorAll(':scope > :not(:empty) ~ :not(:empty)');
 
             expect(firstEmptyItem).toBeEmptyDOMElement();
             expect(secondEmptyItem).toBeEmptyDOMElement();
-            expect(Array.from(itemsWithGap ?? [])).toEqual([secondVisibleItem, thirdVisibleItem]);
+            expect(firstVisibleItem).toHaveStyle('margin-bottom: 16px');
+            expect(secondVisibleItem).toHaveStyle('margin-bottom: 16px');
+            expect(thirdVisibleItem).not.toHaveStyle('margin-bottom: 16px');
         });
 
-        it('should preserve gaps between horizontal children without css gaps and wrap', () => {
+        it('should preserve gaps between horizontal children without css gaps', () => {
             const Empty = () => null;
 
             const { container } = render(
@@ -115,11 +116,48 @@ describe('Space', () => {
             const secondItem = firstItem?.nextElementSibling;
             const emptyItem = space?.lastElementChild;
 
-            expect(space).toHaveClass('horizontalMarginGaps');
-            expect(firstItem).toHaveStyle('--space-horizontal-gap: 8px');
-            expect(firstItem).not.toHaveStyle('margin-right: 8px');
-            expect(secondItem).not.toHaveStyle('margin-right: 8px');
+            const visibleItems = space?.querySelectorAll('.spaceItem:not(:empty)');
+            const lastVisibleItem = visibleItems?.item((visibleItems?.length ?? 0) - 1);
+
+            expect(firstItem).toHaveStyle('margin-right: 8px');
+            expect(secondItem).toHaveStyle('margin-right: 8px');
+            expect(lastVisibleItem).toBe(secondItem);
             expect(emptyItem).toBeEmptyDOMElement();
+        });
+
+        it('should update the last visible item when a child stops rendering content', () => {
+            const Toggle = () => {
+                const [visible, setVisible] = React.useState(true);
+
+                return visible ? (
+                    <button type='button' onClick={() => setVisible(false)}>
+                        Hide
+                    </button>
+                ) : null;
+            };
+
+            const { container, getByRole } = render(
+                <Space useCssGaps={false} direction='vertical'>
+                    <div>Visible child</div>
+                    <Toggle />
+                </Space>,
+            );
+
+            const space = container.firstElementChild;
+            const firstItem = space?.firstElementChild;
+            const secondItem = firstItem?.nextElementSibling;
+            const getLastVisibleItem = () => {
+                const visibleItems = space?.querySelectorAll('.spaceItem:not(:empty)');
+
+                return visibleItems?.item((visibleItems?.length ?? 0) - 1);
+            };
+
+            expect(getLastVisibleItem()).toBe(secondItem);
+
+            fireEvent.click(getByRole('button'));
+
+            expect(secondItem).toBeEmptyDOMElement();
+            expect(getLastVisibleItem()).toBe(firstItem);
         });
 
         it('should unmount only 1 child component when it removed', () => {

--- a/packages/space/src/Component.tsx
+++ b/packages/space/src/Component.tsx
@@ -100,7 +100,11 @@ export const Space = forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
         [size],
     );
 
-    const childNodes = Children.toArray(children);
+    /*
+     * Children.toArray сохраняет пустую строку как отдельного ребёнка,
+     * хотя она не создаёт видимого содержимого в DOM.
+     */
+    const childNodes = Children.toArray(children).filter((child) => child !== '');
 
     if (childNodes.length === 0) {
         return null;
@@ -109,12 +113,18 @@ export const Space = forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
     const directionClassName = styles[direction];
     const alignClassName = styles[align];
 
+    /*
+     * При useCssGaps=false расстояние между видимыми элементами рассчитывается
+     * CSS-селекторами, так как React не может определить, вернёт ли ребёнок null.
+     */
     const containerClassName = cn(
         styles.spaceContainer,
         directionClassName,
         {
             [alignClassName]: align,
             [styles.spaceContainerFullWidth]: fullWidth,
+            [styles.verticalMarginGaps]: !useCssGaps && direction === 'vertical',
+            [styles.horizontalMarginGaps]: !useCssGaps && direction === 'horizontal' && !wrap,
         },
         className,
     );

--- a/packages/space/src/Component.tsx
+++ b/packages/space/src/Component.tsx
@@ -113,18 +113,12 @@ export const Space = forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
     const directionClassName = styles[direction];
     const alignClassName = styles[align];
 
-    /*
-     * При useCssGaps=false расстояние между видимыми элементами рассчитывается
-     * CSS-селекторами, так как React не может определить, вернёт ли ребёнок null.
-     */
     const containerClassName = cn(
         styles.spaceContainer,
         directionClassName,
         {
             [alignClassName]: align,
             [styles.spaceContainerFullWidth]: fullWidth,
-            [styles.verticalMarginGaps]: !useCssGaps && direction === 'vertical',
-            [styles.horizontalMarginGaps]: !useCssGaps && direction === 'horizontal' && !wrap,
         },
         className,
     );

--- a/packages/space/src/Item.tsx
+++ b/packages/space/src/Item.tsx
@@ -16,11 +16,6 @@ export interface ItemProps {
     useCssGaps: boolean;
 }
 
-type ItemStyle = React.CSSProperties & {
-    '--space-vertical-gap'?: string;
-    '--space-horizontal-gap'?: string;
-};
-
 const Item = (props: ItemProps) => {
     const {
         className,
@@ -36,33 +31,19 @@ const Item = (props: ItemProps) => {
         useCssGaps,
     } = props;
 
-    let style: ItemStyle | undefined;
+    let style: React.CSSProperties | undefined;
 
     if (!useCssGaps) {
         if (direction === 'vertical') {
-            /*
-             * Передаём размер в CSS вместо установки marginBottom по React-индексу.
-             * CSS сможет определить реально непустые элементы уже после рендера.
-             */
-            style = {
-                '--space-vertical-gap': `${verticalSize / (divider ? 2 : 1)}px`,
-            };
-        } else if (wrap) {
-            /*
-             * Для wrap сохраняется прежний алгоритм, поскольку CSS-селекторы
-             * не позволяют определить начало новой flex-строки.
-             */
+            if (index < length - 1) {
+                style = { marginBottom: verticalSize / (divider ? 2 : 1) };
+            }
+        } else {
             style = {
                 ...(index < length - 1 && { marginRight: horizontalSize / (divider ? 2 : 1) }),
-                paddingBottom: verticalSize,
-            };
-        } else {
-            /*
-             * Для горизонтального Space без переноса используется тот же подход:
-             * отступ получает следующий непустой DOM-элемент.
-             */
-            style = {
-                '--space-horizontal-gap': `${horizontalSize / (divider ? 2 : 1)}px`,
+                ...(wrap && {
+                    paddingBottom: verticalSize,
+                }),
             };
         }
     }

--- a/packages/space/src/Item.tsx
+++ b/packages/space/src/Item.tsx
@@ -16,6 +16,11 @@ export interface ItemProps {
     useCssGaps: boolean;
 }
 
+type ItemStyle = React.CSSProperties & {
+    '--space-vertical-gap'?: string;
+    '--space-horizontal-gap'?: string;
+};
+
 const Item = (props: ItemProps) => {
     const {
         className,
@@ -31,17 +36,33 @@ const Item = (props: ItemProps) => {
         useCssGaps,
     } = props;
 
-    let style: React.CSSProperties | undefined;
+    let style: ItemStyle | undefined;
 
     if (!useCssGaps) {
         if (direction === 'vertical') {
-            if (index < length - 1) {
-                style = { marginBottom: horizontalSize / (divider ? 2 : 1) };
-            }
-        } else {
+            /*
+             * Передаём размер в CSS вместо установки marginBottom по React-индексу.
+             * CSS сможет определить реально непустые элементы уже после рендера.
+             */
+            style = {
+                '--space-vertical-gap': `${verticalSize / (divider ? 2 : 1)}px`,
+            };
+        } else if (wrap) {
+            /*
+             * Для wrap сохраняется прежний алгоритм, поскольку CSS-селекторы
+             * не позволяют определить начало новой flex-строки.
+             */
             style = {
                 ...(index < length - 1 && { marginRight: horizontalSize / (divider ? 2 : 1) }),
-                ...(wrap && { paddingBottom: verticalSize }),
+                paddingBottom: verticalSize,
+            };
+        } else {
+            /*
+             * Для горизонтального Space без переноса используется тот же подход:
+             * отступ получает следующий непустой DOM-элемент.
+             */
+            style = {
+                '--space-horizontal-gap': `${horizontalSize / (divider ? 2 : 1)}px`,
             };
         }
     }

--- a/packages/space/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/space/src/__snapshots__/Component.test.tsx.snap
@@ -6,11 +6,10 @@ exports[`Space Display tests should display radio group with one child correctly
   "baseElement": <body>
     <div>
       <div
-        class="spaceContainer vertical start verticalMarginGaps"
+        class="spaceContainer vertical start"
       >
         <div
           class="spaceItem"
-          style="--space-vertical-gap: 16px;"
         >
           <div
             class="cardImage rounded"
@@ -31,11 +30,10 @@ exports[`Space Display tests should display radio group with one child correctly
   </body>,
   "container": <div>
     <div
-      class="spaceContainer vertical start verticalMarginGaps"
+      class="spaceContainer vertical start"
     >
       <div
         class="spaceItem"
-        style="--space-vertical-gap: 16px;"
       >
         <div
           class="cardImage rounded"
@@ -113,11 +111,10 @@ exports[`Space Display tests should display with children like boolean or string
   "baseElement": <body>
     <div>
       <div
-        class="spaceContainer vertical start verticalMarginGaps"
+        class="spaceContainer vertical start"
       >
         <div
           class="spaceItem"
-          style="--space-vertical-gap: 16px;"
         >
           0
         </div>
@@ -126,11 +123,10 @@ exports[`Space Display tests should display with children like boolean or string
   </body>,
   "container": <div>
     <div
-      class="spaceContainer vertical start verticalMarginGaps"
+      class="spaceContainer vertical start"
     >
       <div
         class="spaceItem"
-        style="--space-vertical-gap: 16px;"
       >
         0
       </div>

--- a/packages/space/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/space/src/__snapshots__/Component.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`Space Display tests should display radio group with one child correctly
   "baseElement": <body>
     <div>
       <div
-        class="spaceContainer vertical start"
+        class="spaceContainer vertical start verticalMarginGaps"
       >
         <div
           class="spaceItem"
+          style="--space-vertical-gap: 16px;"
         >
           <div
             class="cardImage rounded"
@@ -30,10 +31,11 @@ exports[`Space Display tests should display radio group with one child correctly
   </body>,
   "container": <div>
     <div
-      class="spaceContainer vertical start"
+      class="spaceContainer vertical start verticalMarginGaps"
     >
       <div
         class="spaceItem"
+        style="--space-vertical-gap: 16px;"
       >
         <div
           class="cardImage rounded"
@@ -111,33 +113,27 @@ exports[`Space Display tests should display with children like boolean or string
   "baseElement": <body>
     <div>
       <div
-        class="spaceContainer vertical start"
+        class="spaceContainer vertical start verticalMarginGaps"
       >
         <div
           class="spaceItem"
-          style="margin-bottom: 16px;"
+          style="--space-vertical-gap: 16px;"
         >
           0
         </div>
-        <div
-          class="spaceItem"
-        />
       </div>
     </div>
   </body>,
   "container": <div>
     <div
-      class="spaceContainer vertical start"
+      class="spaceContainer vertical start verticalMarginGaps"
     >
       <div
         class="spaceItem"
-        style="margin-bottom: 16px;"
+        style="--space-vertical-gap: 16px;"
       >
         0
       </div>
-      <div
-        class="spaceItem"
-      />
     </div>
   </div>,
   "debug": [Function],

--- a/packages/space/src/index.module.css
+++ b/packages/space/src/index.module.css
@@ -32,6 +32,18 @@
     display: none;
 }
 
+/*
+ * Отступ получает каждый непустой элемент, перед которым существует
+ * другой непустой элемент. Пустые DOM-обёртки не влияют на результат.
+ */
+.verticalMarginGaps > :not(:empty) ~ :not(:empty) {
+    margin-top: var(--space-vertical-gap);
+}
+
+.horizontalMarginGaps > :not(:empty) ~ :not(:empty) {
+    margin-inline-start: var(--space-horizontal-gap);
+}
+
 .wrap {
     flex-wrap: wrap;
 }

--- a/packages/space/src/index.module.css
+++ b/packages/space/src/index.module.css
@@ -33,15 +33,16 @@
 }
 
 /*
- * Отступ получает каждый непустой элемент, перед которым существует
- * другой непустой элемент. Пустые DOM-обёртки не влияют на результат.
+ * React-индекс не учитывает компоненты, которые возвращают null. Поэтому находим последний
+ * непустой item по фактическому DOM и убираем у него отступ. !important необходим, чтобы
+ * переопределить inline-margin, заданный в Item для режима без CSS gaps.
  */
-.verticalMarginGaps > :not(:empty) ~ :not(:empty) {
-    margin-top: var(--space-vertical-gap);
+.vertical > .spaceItem:not(:empty):not(:has(~ .spaceItem:not(:empty))) {
+    margin-bottom: 0 !important;
 }
 
-.horizontalMarginGaps > :not(:empty) ~ :not(:empty) {
-    margin-inline-start: var(--space-horizontal-gap);
+.horizontal > .spaceItem:not(:empty):not(:has(~ .spaceItem:not(:empty))) {
+    margin-right: 0 !important;
 }
 
 .wrap {


### PR DESCRIPTION
Исправлены лишние отступы в `Space` при `useCssGaps={false}`, когда дочерний компонент возвращает `null`

Ранее отступы задавались по индексам React-детей, поэтому последний непустой элемент мог получить `margin-bottom` или `margin-right`, если после него оставалась пустая DOM-обёртка

Теперь CSS-селектор с `:has()` определяет последний непустой `.spaceItem` по фактическому DOM и обнуляет его хвостовой отступ. Промежуточные отступы по-прежнему задаются inline-стилями в `Item`

Добавлены тесты для пустых детей в начале, между видимыми элементами и в конце, в вертикальном и горизонтальном направлениях. Также добавлен тест динамического исчезновения последнего ребёнка

# Чек лист

- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [x] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset

Если есть визуальные изменения

<img width="2559" height="1390" alt="изображение" src="https://github.com/user-attachments/assets/1e1c7c9b-761a-4be7-9828-383327849a10" />