### PR TITLE
Feat/tabs scroll controls styles

### DIFF
--- a/.changeset/tabs-scroll-controls-styles.md
+++ b/.changeset/tabs-scroll-controls-styles.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/core-components-tabs': minor
+---
+
+Добавлены `scrollControlsContainerClassName` и `scrollControlsButtonClassName` для стилизации контейнера и кнопок прокрутки табов.

--- a/.changeset/tabs-scroll-controls-styles.md
+++ b/.changeset/tabs-scroll-controls-styles.md
@@ -2,4 +2,4 @@
 '@alfalab/core-components-tabs': minor
 ---
 
-Добавлены `scrollControlsContainerClassName` и `scrollControlsButtonClassName` для стилизации контейнера и кнопок прокрутки табов.
+- Добавлены `scrollControlsContainerClassName` и `scrollControlsButtonClassName` для стилизации контейнера и кнопок прокрутки табов.

--- a/packages/tabs/src/components/primary-tablist/Component.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.tsx
@@ -15,6 +15,8 @@ export const PrimaryTabList = ({
     styles = {},
     className,
     containerClassName,
+    scrollControlsClassName,
+    scrollControlsButtonClassName,
     titles = [],
     selectedId = titles.length ? titles[0].id : undefined,
     scrollable = true,
@@ -99,7 +101,11 @@ export const PrimaryTabList = ({
             containerWrapperClassName={wrapperClassName}
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
-            scrollControlsClassName={cn(textStyle && styles.scrollControls)}
+            scrollControlsClassName={cn(
+                textStyle && styles.scrollControls,
+                scrollControlsClassName,
+            )}
+            scrollControlsButtonClassName={scrollControlsButtonClassName}
             fullWidthScroll={fullWidthScroll}
             view='primary'
             size={textStyle ? undefined : size}

--- a/packages/tabs/src/components/primary-tablist/Component.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.tsx
@@ -15,7 +15,7 @@ export const PrimaryTabList = ({
     styles = {},
     className,
     containerClassName,
-    scrollControlsClassName,
+    scrollControlsContainerClassName,
     scrollControlsButtonClassName,
     titles = [],
     selectedId = titles.length ? titles[0].id : undefined,
@@ -101,9 +101,9 @@ export const PrimaryTabList = ({
             containerWrapperClassName={wrapperClassName}
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
-            scrollControlsClassName={cn(
+            scrollControlsContainerClassName={cn(
                 textStyle && styles.scrollControls,
-                scrollControlsClassName,
+                scrollControlsContainerClassName,
             )}
             scrollControlsButtonClassName={scrollControlsButtonClassName}
             fullWidthScroll={fullWidthScroll}

--- a/packages/tabs/src/components/primary-tablist/Component.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.tsx
@@ -101,7 +101,7 @@ export const PrimaryTabList = ({
             containerWrapperClassName={wrapperClassName}
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
-            scrollControlsContainerClassName={cn(
+            scrollControlsClassName={cn(
                 textStyle && styles.scrollControls,
                 scrollControlsContainerClassName,
             )}

--- a/packages/tabs/src/components/scroll-controls/Component.tsx
+++ b/packages/tabs/src/components/scroll-controls/Component.tsx
@@ -14,6 +14,7 @@ import styles from './index.module.css';
 
 type ScrollControlsProps = {
     className?: string;
+    buttonClassName?: string;
     view: Exclude<TabsProps['view'], undefined>;
     size: TabsProps['size'];
     containerRef: RefObject<HTMLDivElement>;
@@ -21,7 +22,7 @@ type ScrollControlsProps = {
 };
 
 export const ScrollControls = forwardRef<HTMLDivElement, ScrollControlsProps>(
-    ({ containerRef, view, size: sizeProp, className, showSkeleton }, ref) => {
+    ({ containerRef, view, size: sizeProp, className, buttonClassName, showSkeleton }, ref) => {
         const container = containerRef.current;
         const [disabledState, updateDisabledState] = useState(() => getDisabledState(container));
 
@@ -50,7 +51,7 @@ export const ScrollControls = forwardRef<HTMLDivElement, ScrollControlsProps>(
         const handleScrollRight = () => scrollIntoLastTab(container);
 
         const commonButtonProps = {
-            className: styles.button,
+            className: cn(styles.button, buttonClassName),
             size: getSize(),
             view: 'secondary',
         } as const;

--- a/packages/tabs/src/components/scrollable-container/Component.tsx
+++ b/packages/tabs/src/components/scrollable-container/Component.tsx
@@ -29,6 +29,11 @@ export type ScrollableContainerProps = {
     scrollControlsClassName?: string;
 
     /**
+     * Дополнительный класс для кнопок прокрутки
+     */
+    scrollControlsButtonClassName?: string;
+
+    /**
      * Дочерние компоненты
      */
     children: ReactNode;
@@ -72,6 +77,7 @@ export const ScrollableContainer = ({
     containerWrapperClassName,
     containerClassName,
     scrollControlsClassName,
+    scrollControlsButtonClassName,
     children,
     activeChild,
     fullWidthScroll,
@@ -145,6 +151,7 @@ export const ScrollableContainer = ({
             {overflown && platform === 'desktop' ? (
                 <ScrollControls
                     className={scrollControlsClassName}
+                    buttonClassName={scrollControlsButtonClassName}
                     ref={controlsRef}
                     containerRef={containerRef}
                     view={view}

--- a/packages/tabs/src/components/scrollable-container/Component.tsx
+++ b/packages/tabs/src/components/scrollable-container/Component.tsx
@@ -24,9 +24,9 @@ export type ScrollableContainerProps = {
     containerClassName?: string;
 
     /**
-     * Дополнительный класс кнопок прокрутки
+     * Дополнительный класс для контейнера кнопок прокрутки
      */
-    scrollControlsClassName?: string;
+    scrollControlsContainerClassName?: string;
 
     /**
      * Дополнительный класс для кнопок прокрутки
@@ -76,7 +76,7 @@ const isOverflown = (
 export const ScrollableContainer = ({
     containerWrapperClassName,
     containerClassName,
-    scrollControlsClassName,
+    scrollControlsContainerClassName,
     scrollControlsButtonClassName,
     children,
     activeChild,
@@ -150,7 +150,7 @@ export const ScrollableContainer = ({
             </div>
             {overflown && platform === 'desktop' ? (
                 <ScrollControls
-                    className={scrollControlsClassName}
+                    className={scrollControlsContainerClassName}
                     buttonClassName={scrollControlsButtonClassName}
                     ref={controlsRef}
                     containerRef={containerRef}

--- a/packages/tabs/src/components/scrollable-container/Component.tsx
+++ b/packages/tabs/src/components/scrollable-container/Component.tsx
@@ -26,7 +26,7 @@ export type ScrollableContainerProps = {
     /**
      * Дополнительный класс для контейнера кнопок прокрутки
      */
-    scrollControlsContainerClassName?: string;
+    scrollControlsClassName?: string;
 
     /**
      * Дополнительный класс для кнопок прокрутки
@@ -76,7 +76,7 @@ const isOverflown = (
 export const ScrollableContainer = ({
     containerWrapperClassName,
     containerClassName,
-    scrollControlsContainerClassName,
+    scrollControlsClassName,
     scrollControlsButtonClassName,
     children,
     activeChild,
@@ -150,7 +150,7 @@ export const ScrollableContainer = ({
             </div>
             {overflown && platform === 'desktop' ? (
                 <ScrollControls
-                    className={scrollControlsContainerClassName}
+                    className={scrollControlsClassName}
                     buttonClassName={scrollControlsButtonClassName}
                     ref={controlsRef}
                     containerRef={containerRef}

--- a/packages/tabs/src/components/secondary-tablist/Component.tsx
+++ b/packages/tabs/src/components/secondary-tablist/Component.tsx
@@ -26,7 +26,7 @@ export const SecondaryTabList = ({
     styles = {},
     className,
     containerClassName,
-    scrollControlsClassName,
+    scrollControlsContainerClassName,
     scrollControlsButtonClassName,
     size,
     titles = [],
@@ -117,7 +117,7 @@ export const SecondaryTabList = ({
         <ScrollableContainer
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
-            scrollControlsClassName={scrollControlsClassName}
+            scrollControlsContainerClassName={scrollControlsContainerClassName}
             scrollControlsButtonClassName={scrollControlsButtonClassName}
             fullWidthScroll={fullWidthScroll}
             view='secondary'

--- a/packages/tabs/src/components/secondary-tablist/Component.tsx
+++ b/packages/tabs/src/components/secondary-tablist/Component.tsx
@@ -26,6 +26,8 @@ export const SecondaryTabList = ({
     styles = {},
     className,
     containerClassName,
+    scrollControlsClassName,
+    scrollControlsButtonClassName,
     size,
     titles = [],
     selectedId = titles.length ? titles[0].id : undefined,
@@ -115,6 +117,8 @@ export const SecondaryTabList = ({
         <ScrollableContainer
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
+            scrollControlsClassName={scrollControlsClassName}
+            scrollControlsButtonClassName={scrollControlsButtonClassName}
             fullWidthScroll={fullWidthScroll}
             view='secondary'
             size={size}

--- a/packages/tabs/src/components/secondary-tablist/Component.tsx
+++ b/packages/tabs/src/components/secondary-tablist/Component.tsx
@@ -117,7 +117,7 @@ export const SecondaryTabList = ({
         <ScrollableContainer
             activeChild={focusedTab || selectedTab}
             containerClassName={containerClassName}
-            scrollControlsContainerClassName={scrollControlsContainerClassName}
+            scrollControlsClassName={scrollControlsContainerClassName}
             scrollControlsButtonClassName={scrollControlsButtonClassName}
             fullWidthScroll={fullWidthScroll}
             view='secondary'

--- a/packages/tabs/src/components/tabs/Component.test.tsx
+++ b/packages/tabs/src/components/tabs/Component.test.tsx
@@ -2,11 +2,12 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 
+import { Tabs } from './Component';
 import { TabsDesktop } from './Component.desktop';
 import { TabsMobile } from './Component.mobile';
 import { TabsResponsive } from './Component.responsive';
 import { Tab } from '../tab';
-import { TabsProps } from '../../typings';
+import { TabListProps, TabsProps } from '../../typings';
 import { DiamondsMIcon } from '@alfalab/icons-glyph/DiamondsMIcon';
 
 Object.defineProperty(window, 'matchMedia', {
@@ -98,6 +99,38 @@ describe('Tabs', () => {
             });
             const container = getByTestId('tabs-test').parentElement as HTMLElement;
             expect(container).toHaveClass(containerClassName);
+        });
+
+        it('should forward `scrollControlsContainerClassName` to TabList', () => {
+            const className = 'test-class';
+            const TabList = ({ scrollControlsContainerClassName }: TabListProps) => (
+                <div data-test-id='tab-list' className={scrollControlsContainerClassName} />
+            );
+
+            const { getByTestId } = render(
+                <Tabs TabList={TabList} scrollControlsContainerClassName={className}>
+                    <Tab title='Таб 1' id='tab-1' />
+                    <Tab title='Таб 2' id='tab-2' />
+                </Tabs>,
+            );
+
+            expect(getByTestId('tab-list')).toHaveClass(className);
+        });
+
+        it('should forward `scrollControlsButtonClassName` to TabList', () => {
+            const className = 'test-class';
+            const TabList = ({ scrollControlsButtonClassName }: TabListProps) => (
+                <div data-test-id='tab-list' className={scrollControlsButtonClassName} />
+            );
+
+            const { getByTestId } = render(
+                <Tabs TabList={TabList} scrollControlsButtonClassName={className}>
+                    <Tab title='Таб 1' id='tab-1' />
+                    <Tab title='Таб 2' id='tab-2' />
+                </Tabs>,
+            );
+
+            expect(getByTestId('tab-list')).toHaveClass(className);
         });
     });
 

--- a/packages/tabs/src/components/tabs/Component.tsx
+++ b/packages/tabs/src/components/tabs/Component.tsx
@@ -6,7 +6,7 @@ export const Tabs = ({
     TabList,
     className,
     containerClassName,
-    scrollControlsClassName,
+    scrollControlsContainerClassName,
     scrollControlsButtonClassName,
     size,
     children,
@@ -64,7 +64,7 @@ export const Tabs = ({
         <div className={className} {...restProps}>
             <TabList
                 containerClassName={containerClassName}
-                scrollControlsClassName={scrollControlsClassName}
+                scrollControlsContainerClassName={scrollControlsContainerClassName}
                 scrollControlsButtonClassName={scrollControlsButtonClassName}
                 size={size}
                 titles={titles}

--- a/packages/tabs/src/components/tabs/Component.tsx
+++ b/packages/tabs/src/components/tabs/Component.tsx
@@ -6,6 +6,8 @@ export const Tabs = ({
     TabList,
     className,
     containerClassName,
+    scrollControlsClassName,
+    scrollControlsButtonClassName,
     size,
     children,
     selectedId,
@@ -62,6 +64,8 @@ export const Tabs = ({
         <div className={className} {...restProps}>
             <TabList
                 containerClassName={containerClassName}
+                scrollControlsClassName={scrollControlsClassName}
+                scrollControlsButtonClassName={scrollControlsButtonClassName}
                 size={size}
                 titles={titles}
                 selectedId={selectedId}

--- a/packages/tabs/src/typings.ts
+++ b/packages/tabs/src/typings.ts
@@ -42,7 +42,7 @@ export interface TabsProps
     /**
      * Дополнительный класс для контейнера кнопок прокрутки
      */
-    scrollControlsClassName?: string;
+    scrollControlsContainerClassName?: string;
 
     /**
      * Дополнительный класс для кнопок прокрутки
@@ -264,7 +264,7 @@ export interface TabListProps
         TabsProps,
         | 'className'
         | 'containerClassName'
-        | 'scrollControlsClassName'
+        | 'scrollControlsContainerClassName'
         | 'scrollControlsButtonClassName'
         | 'size'
         | 'defaultMatchMediaValue'

--- a/packages/tabs/src/typings.ts
+++ b/packages/tabs/src/typings.ts
@@ -40,6 +40,16 @@ export interface TabsProps
     containerClassName?: string;
 
     /**
+     * Дополнительный класс для контейнера кнопок прокрутки
+     */
+    scrollControlsClassName?: string;
+
+    /**
+     * Дополнительный класс для кнопок прокрутки
+     */
+    scrollControlsButtonClassName?: string;
+
+    /**
      * Id активного таба
      */
     selectedId?: SelectedId;
@@ -254,6 +264,8 @@ export interface TabListProps
         TabsProps,
         | 'className'
         | 'containerClassName'
+        | 'scrollControlsClassName'
+        | 'scrollControlsButtonClassName'
         | 'size'
         | 'defaultMatchMediaValue'
         | 'selectedId'


### PR DESCRIPTION
  Добавлены публичные props для стилизации scroll-контролов Tabs:

  - `scrollControlsContainerClassName` - класс контейнера кнопок прокрутки;
  - `scrollControlsButtonClassName` - класс кнопок прокрутки.

# Чек лист

- [ ] Задача сформулирована и описана в JIRA
- [ ] В названии ветки есть айдишник задачи в JIRA (fix/DS-1234), ссылку прикреплять не надо
- [x] У реквеста осмысленное название feat(...) или fix(...) по conventional commits (https://www.conventionalcommits.org)
- [ ] Код покрыт тестами и протестирован в различных браузерах
- [ ] Добавленные пропсы добавлены в демки и описаны в документации
- [x] К реквесту добавлен changeset
